### PR TITLE
Latest updates to the TE Types

### DIFF
--- a/drafts/te-types-update/draft-ietf-teas-rfc8776-update.md
+++ b/drafts/te-types-update/draft-ietf-teas-rfc8776-update.md
@@ -48,7 +48,7 @@ author:
 
 --- abstract
 
-   This document defines few additional common data types and groupings
+   This document defines few additional common data types, identities, and groupings
    in YANG data modeling language to be imported by modules that model Traffic
    Engineering (TE) configuration and state capabilities.
 
@@ -61,13 +61,13 @@ Editors' note: Copy the text from {{!RFC8776}} and merge it with the content of 
 
 # Introduction
 
-After the publication of {{!RFC8776}}, a new typedef and a new grouping to ietf-te-types have been defined. Given their broad applicability this document defines them as part of the ietf-te-types YANG model.
+After the publication of {{!RFC8776}}, few additional common data types, identities, and groupings have been defined. Given their broad applicability this document defines them as part of the revised ietf-te-types YANG model.
 
 Editors' note: Copy the text from {{!RFC8776}} and merge it with the content of this section before WG LC if the RFC8876-bis approach is confirmed.
 
-NOTE: These definitions have been developed in {{?I-D.ietf-teas-yang-te}} and {{?I-D.ietf-teas-yang-l3-te-topo}} and are quite mature: {{?I-D.ietf-teas-yang-te}} in particular is ready from WG Last Call.
+CHANGE NOTE: These definitions have been developed in {{?I-D.ietf-teas-yang-te}}, {{?I-D.ietf-teas-yang-path-computation}} and {{?I-D.ietf-teas-yang-l3-te-topo}} and are quite mature: {{?I-D.ietf-teas-yang-te}} and {{?I-D.ietf-teas-yang-path-computation}} in particular are in WG Last Call and some definitions have been moved to this document as part of WG LC comments resolution.
 
-RFC Editor: remove the note above and this note
+RFC Editor: remove the CHANGE NOTE above and this note
 
 ## Requirements Notation
 
@@ -106,15 +106,61 @@ Editors' note: Copy the text from {{!RFC8776}} before WG LC if the RFC8876-bis a
 
 Editors' note: Copy the text from {{!RFC8776}} and merge it with the content of this section before WG LC if the RFC8876-bis approach is confirmed.
 
-   The module ietf-te-types has been updated to add the following
-   YANG identies, types and groupings which can be reused by TE YANG models:
+The module ietf-te-types updates the following YANG identities defined in {{!RFC8776}}:
 
-bandwidth-scientific-notation
-: This types represents the bandwidth in
-bit-per-second, using the scientific notation (e.g., 10e3).
+association-type:
 
-encoding-and-switching-type
-: This is a common grouping to define the LSP encoding and switching types.
+> A base YANG identity for supported LSP association types as defined in {{!RFC6780}}, {{!RFC4872}}, {{!RFC4873}} and {{!RFC8800}}
+
+objective-function-type:
+
+> A base YANG identity for supported path objective functions, as defined in {{!RFC5541}}.
+
+CHANGE NOTE: The association-type-diversity identity, defined in {{!RFC8800}} has been added to the association-type base identity. The of-minimize-agg-bandwidth-consumption, of-minimize-load-most-loaded-link and of-minimize-cost-path-set, defined in {{!RFC5541}}, have been obsoleted because not applicable to paths but to Synchronization VECtor (SVEC) objects.
+
+RFC Editor: remove the CHANGE NOTE above and this note
+
+The module ietf-te-types has been updated to add the following YANG identities, types and groupings which can be reused by TE YANG models:
+
+bandwidth-scientific-notation:
+
+> This data type represents the bandwidth in bit-per-second, using the scientific notation (e.g., 10e3).
+
+lsp-provisioning-error-reason:
+
+> A base YANG identity for reporting LSP provisioning error reasons. No standard LPS provisioning error reasons are defined in this document.
+
+identity path-computation-error-reason:
+
+> A base YANG identity for reporting path computation error reasons, as defined in {{!RFC5440}}, {{!RFC5441}}, {{!RFC5520}}, {{!RFC5557}}, {{!RFC8306}} and {{!RFC8685}}.
+
+Editors' Note: how to describe the path computation error reasons defined in this document?
+
+tunnel-actions-type:
+
+> A base YANG identity for tunnel actions.
+
+Editors' Note: check whether standard tunnel actions should be defined in this document or not.
+
+protocol-origin-type:
+
+>  A base YANG identity for the type of protocol origin, as defined in {{!RFC5440}} and {{!RFC5512}}.
+
+Editors' Note: how to describe the protocol origin types defined in this document?
+
+svec-objective-function-type:
+
+> A base YANG identity for supported SVEC objective functions, as defined in {{!RFC5541}} and {{!RFC8685}}.
+
+svec-metric-type:
+
+> A base YANG identity for supported SVEC objective functions, as defined in {{!RFC5541}}.
+
+encoding-and-switching-type:
+
+> This is a common grouping to define the LSP encoding and switching types.
+
+Editors' Note: how to describe the tunnel-admin-auto, which is defined in this document as derived from tunnel-admin-status-type base identity?
 
 ## Packet TE Types Module Contents
 
@@ -129,17 +175,15 @@ Editors' note: Copy the text from {{!RFC8776}} and merge it with the content of 
 This section provides the updated revision of the "ietf-te-types"
 YANG module.
 
-NOTE: Only the typedef bandwidth-scientific-notation and 
-the grouping encoding-and-switching-type have been added
-in this module revision. Please focus your review on this part. See also {{yang-diff}}.
+CHANGE NOTE: Please focus your review only on the updates to the YANG model: see also {{yang-diff}}.
 
-RFC Editor: remove the note above and this note
+RFC Editor: remove the CHANGE NOTE above and this note
 
 ~~~~ yang
 {::include ../../ietf-te-types.yang}
 ~~~~
 {: #fig-pc-yang title="TE Types YANG module"
-sourcecode-markers="true" sourcecode-name="ietf-te-types@2022-10-15.yang"}
+sourcecode-markers="true" sourcecode-name="ietf-te-types@2022-10-21.yang"}
 
 # Packet TE Types YANG Module
 
@@ -198,13 +242,13 @@ To be added in a future revision of this draft.
 
 ## TE Types YANG Diffs
 
+RFC Editor Note: please remove this appendix before publication.
+
 This section provides the diff between the YANG module in section 3.1 of {{!RFC8776}} and the YANG model revision in {{yang-code}}.
 
 The intention of this appendix is to facilitate focusing the review of the YANG model in {{yang-code}} to the changes compared with the YANG model in {{!RFC8776}}.
 
-Editors note, please remove this appendix before publication.
-
-Note - This diff has been generated using the following UNIX commands to compare the YANG module revisions in section 3.1 of {{!RFC8776}} and in {{yang-code}}:
+This diff has been generated using the following UNIX commands to compare the YANG module revisions in section 3.1 of {{!RFC8776}} and in {{yang-code}}:
 
 ~~~~~
 diff ietf-te-types@2020-06-10.yang ietf-te-types.yang > model-diff.txt
@@ -219,6 +263,8 @@ The output (model-updates.txt) is reported here:
 {: #options}
 
 # Option Considered for updating RFC8776
+
+RFC Editor Note: please remove this appendix before publication.
 
 The concern is how to be able to update the ietf-te-types YANG module published in {{!RFC8776}} without delaying too much the progress of the mature WG documents.
 
@@ -247,8 +293,6 @@ https://datatracker.ietf.org/meeting/114/materials/slides-114-netmod-ad-topic-ma
 Future updates of this document could align with the proposed approach.
 
 Therefore, in order to avoid useless editorial work, this version of the document has been structured to become an RFC8776-bis but not all the existing text in {{!RFC8776}} has been copied: some editors' notes has been inserted instead. These editors' note will be removed and replaced by actual text copied from {{!RFC8776}} before WG LC if the RFC8776-bis approach is confirmed.
-
-Editors note, please remove this appendix before publication.
 
 {: numbered="false"}
 

--- a/drafts/te-types-update/draft-ietf-teas-rfc8776-update.txt
+++ b/drafts/te-types-update/draft-ietf-teas-rfc8776-update.txt
@@ -6,7 +6,7 @@ TEAS Working Group                                               I. Busi
 Internet-Draft                                                    Huawei
 Obsoletes: 8776 (if approved)                                     A. Guo
 Intended status: Standards Track                  Futurewei Technologies
-Expires: 24 April 2023                                            X. Liu
+Expires: 27 April 2023                                            X. Liu
                                                          IBM Corporation
                                                                  T. Saad
                                                         Juniper Networks
@@ -16,7 +16,7 @@ Expires: 24 April 2023                                            X. Liu
                                                         Juniper Networks
                                                               I. Bryskin
                                                               Individual
-                                                         21 October 2022
+                                                         24 October 2022
 
 
          Updated Common YANG Data Types for Traffic Engineering
@@ -53,12 +53,12 @@ Status of This Memo
 
 
 
-Busi, et al.              Expires 24 April 2023                 [Page 1]
+Busi, et al.              Expires 27 April 2023                 [Page 1]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
 
-   This Internet-Draft will expire on 24 April 2023.
+   This Internet-Draft will expire on 27 April 2023.
 
 Copyright Notice
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Busi, et al.              Expires 24 April 2023                 [Page 2]
+Busi, et al.              Expires 27 April 2023                 [Page 2]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -165,7 +165,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                 [Page 3]
+Busi, et al.              Expires 27 April 2023                 [Page 3]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -221,7 +221,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                 [Page 4]
+Busi, et al.              Expires 27 April 2023                 [Page 4]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -277,7 +277,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                 [Page 5]
+Busi, et al.              Expires 27 April 2023                 [Page 5]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -333,7 +333,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                 [Page 6]
+Busi, et al.              Expires 27 April 2023                 [Page 6]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -389,7 +389,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                 [Page 7]
+Busi, et al.              Expires 27 April 2023                 [Page 7]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -445,7 +445,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                 [Page 8]
+Busi, et al.              Expires 27 April 2023                 [Page 8]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -501,7 +501,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                 [Page 9]
+Busi, et al.              Expires 27 April 2023                 [Page 9]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -557,7 +557,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 10]
+Busi, et al.              Expires 27 April 2023                [Page 10]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -613,7 +613,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 11]
+Busi, et al.              Expires 27 April 2023                [Page 11]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -669,7 +669,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 12]
+Busi, et al.              Expires 27 April 2023                [Page 12]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -725,7 +725,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 13]
+Busi, et al.              Expires 27 April 2023                [Page 13]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -781,7 +781,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 14]
+Busi, et al.              Expires 27 April 2023                [Page 14]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -837,7 +837,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 15]
+Busi, et al.              Expires 27 April 2023                [Page 15]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -893,7 +893,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 16]
+Busi, et al.              Expires 27 April 2023                [Page 16]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -949,7 +949,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 17]
+Busi, et al.              Expires 27 April 2023                [Page 17]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1005,7 +1005,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 18]
+Busi, et al.              Expires 27 April 2023                [Page 18]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1061,7 +1061,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 19]
+Busi, et al.              Expires 27 April 2023                [Page 19]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1117,7 +1117,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 20]
+Busi, et al.              Expires 27 April 2023                [Page 20]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1173,7 +1173,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 21]
+Busi, et al.              Expires 27 April 2023                [Page 21]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1229,7 +1229,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 22]
+Busi, et al.              Expires 27 April 2023                [Page 22]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1285,7 +1285,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 23]
+Busi, et al.              Expires 27 April 2023                [Page 23]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1341,7 +1341,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 24]
+Busi, et al.              Expires 27 April 2023                [Page 24]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1397,7 +1397,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 25]
+Busi, et al.              Expires 27 April 2023                [Page 25]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1453,7 +1453,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 26]
+Busi, et al.              Expires 27 April 2023                [Page 26]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1509,7 +1509,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 27]
+Busi, et al.              Expires 27 April 2023                [Page 27]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1565,7 +1565,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 28]
+Busi, et al.              Expires 27 April 2023                [Page 28]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1621,7 +1621,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 29]
+Busi, et al.              Expires 27 April 2023                [Page 29]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1677,7 +1677,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 30]
+Busi, et al.              Expires 27 April 2023                [Page 30]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1733,7 +1733,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 31]
+Busi, et al.              Expires 27 April 2023                [Page 31]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1789,7 +1789,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 32]
+Busi, et al.              Expires 27 April 2023                [Page 32]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1845,7 +1845,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 33]
+Busi, et al.              Expires 27 April 2023                [Page 33]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1901,7 +1901,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 34]
+Busi, et al.              Expires 27 April 2023                [Page 34]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -1957,7 +1957,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 35]
+Busi, et al.              Expires 27 April 2023                [Page 35]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2013,7 +2013,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 36]
+Busi, et al.              Expires 27 April 2023                [Page 36]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2069,7 +2069,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 37]
+Busi, et al.              Expires 27 April 2023                [Page 37]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2125,7 +2125,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 38]
+Busi, et al.              Expires 27 April 2023                [Page 38]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2181,7 +2181,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 39]
+Busi, et al.              Expires 27 April 2023                [Page 39]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2237,7 +2237,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 40]
+Busi, et al.              Expires 27 April 2023                [Page 40]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2293,7 +2293,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 41]
+Busi, et al.              Expires 27 April 2023                [Page 41]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2349,7 +2349,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 42]
+Busi, et al.              Expires 27 April 2023                [Page 42]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2405,7 +2405,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 43]
+Busi, et al.              Expires 27 April 2023                [Page 43]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2461,7 +2461,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 44]
+Busi, et al.              Expires 27 April 2023                [Page 44]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2517,7 +2517,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 45]
+Busi, et al.              Expires 27 April 2023                [Page 45]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2573,7 +2573,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 46]
+Busi, et al.              Expires 27 April 2023                [Page 46]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2629,7 +2629,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 47]
+Busi, et al.              Expires 27 April 2023                [Page 47]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2685,7 +2685,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 48]
+Busi, et al.              Expires 27 April 2023                [Page 48]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2741,7 +2741,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 49]
+Busi, et al.              Expires 27 April 2023                [Page 49]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2797,7 +2797,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 50]
+Busi, et al.              Expires 27 April 2023                [Page 50]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2853,7 +2853,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 51]
+Busi, et al.              Expires 27 April 2023                [Page 51]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2909,7 +2909,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 52]
+Busi, et al.              Expires 27 April 2023                [Page 52]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -2965,7 +2965,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 53]
+Busi, et al.              Expires 27 April 2023                [Page 53]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3021,7 +3021,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 54]
+Busi, et al.              Expires 27 April 2023                [Page 54]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3077,7 +3077,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 55]
+Busi, et al.              Expires 27 April 2023                [Page 55]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3133,7 +3133,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 56]
+Busi, et al.              Expires 27 April 2023                [Page 56]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3189,7 +3189,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 57]
+Busi, et al.              Expires 27 April 2023                [Page 57]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3245,7 +3245,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 58]
+Busi, et al.              Expires 27 April 2023                [Page 58]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3301,7 +3301,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 59]
+Busi, et al.              Expires 27 April 2023                [Page 59]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3357,7 +3357,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 60]
+Busi, et al.              Expires 27 April 2023                [Page 60]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3413,7 +3413,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 61]
+Busi, et al.              Expires 27 April 2023                [Page 61]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3469,7 +3469,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 62]
+Busi, et al.              Expires 27 April 2023                [Page 62]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3525,7 +3525,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 63]
+Busi, et al.              Expires 27 April 2023                [Page 63]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3581,7 +3581,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 64]
+Busi, et al.              Expires 27 April 2023                [Page 64]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3637,7 +3637,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 65]
+Busi, et al.              Expires 27 April 2023                [Page 65]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3693,7 +3693,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 66]
+Busi, et al.              Expires 27 April 2023                [Page 66]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3749,7 +3749,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 67]
+Busi, et al.              Expires 27 April 2023                [Page 67]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3805,7 +3805,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 68]
+Busi, et al.              Expires 27 April 2023                [Page 68]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3861,7 +3861,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 69]
+Busi, et al.              Expires 27 April 2023                [Page 69]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3917,7 +3917,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 70]
+Busi, et al.              Expires 27 April 2023                [Page 70]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -3973,7 +3973,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 71]
+Busi, et al.              Expires 27 April 2023                [Page 71]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4029,7 +4029,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 72]
+Busi, et al.              Expires 27 April 2023                [Page 72]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4085,7 +4085,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 73]
+Busi, et al.              Expires 27 April 2023                [Page 73]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4141,7 +4141,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 74]
+Busi, et al.              Expires 27 April 2023                [Page 74]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4197,7 +4197,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 75]
+Busi, et al.              Expires 27 April 2023                [Page 75]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4253,7 +4253,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 76]
+Busi, et al.              Expires 27 April 2023                [Page 76]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4309,7 +4309,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 77]
+Busi, et al.              Expires 27 April 2023                [Page 77]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4365,7 +4365,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 78]
+Busi, et al.              Expires 27 April 2023                [Page 78]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4421,7 +4421,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 79]
+Busi, et al.              Expires 27 April 2023                [Page 79]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4477,7 +4477,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 80]
+Busi, et al.              Expires 27 April 2023                [Page 80]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4533,7 +4533,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 81]
+Busi, et al.              Expires 27 April 2023                [Page 81]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4589,7 +4589,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 82]
+Busi, et al.              Expires 27 April 2023                [Page 82]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4645,7 +4645,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 83]
+Busi, et al.              Expires 27 April 2023                [Page 83]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4701,7 +4701,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 84]
+Busi, et al.              Expires 27 April 2023                [Page 84]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4757,7 +4757,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 85]
+Busi, et al.              Expires 27 April 2023                [Page 85]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4813,7 +4813,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 86]
+Busi, et al.              Expires 27 April 2023                [Page 86]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4869,7 +4869,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 87]
+Busi, et al.              Expires 27 April 2023                [Page 87]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4925,7 +4925,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 88]
+Busi, et al.              Expires 27 April 2023                [Page 88]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -4981,7 +4981,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 89]
+Busi, et al.              Expires 27 April 2023                [Page 89]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5015,8 +5015,8 @@ Internet-Draft          Yang updates for TE Types           October 2022
               and O. G. de Dios, "A YANG Data Model for Traffic
               Engineering Tunnels, Label Switched Paths and Interfaces",
               Work in Progress, Internet-Draft, draft-ietf-teas-yang-te-
-              30, 11 July 2022, <https://www.ietf.org/archive/id/draft-
-              ietf-teas-yang-te-30.txt>.
+              31, 24 October 2022, <https://www.ietf.org/archive/id/
+              draft-ietf-teas-yang-te-31.txt>.
 
    [RFC3688]  Mealling, M., "The IETF XML Registry", BCP 81, RFC 3688,
               DOI 10.17487/RFC3688, January 2004,
@@ -5037,7 +5037,7 @@ Appendix A.  Changes from RFC 8776
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 90]
+Busi, et al.              Expires 27 April 2023                [Page 90]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5093,7 +5093,7 @@ A.1.  TE Types YANG Diffs
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 91]
+Busi, et al.              Expires 27 April 2023                [Page 91]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5149,7 +5149,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 92]
+Busi, et al.              Expires 27 April 2023                [Page 92]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5205,7 +5205,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 93]
+Busi, et al.              Expires 27 April 2023                [Page 93]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5261,7 +5261,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 94]
+Busi, et al.              Expires 27 April 2023                [Page 94]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5317,7 +5317,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 95]
+Busi, et al.              Expires 27 April 2023                [Page 95]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5373,7 +5373,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 96]
+Busi, et al.              Expires 27 April 2023                [Page 96]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5429,7 +5429,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 97]
+Busi, et al.              Expires 27 April 2023                [Page 97]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5485,7 +5485,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 98]
+Busi, et al.              Expires 27 April 2023                [Page 98]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5541,7 +5541,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 99]
+Busi, et al.              Expires 27 April 2023                [Page 99]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5597,7 +5597,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023               [Page 100]
+Busi, et al.              Expires 27 April 2023               [Page 100]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5653,7 +5653,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023               [Page 101]
+Busi, et al.              Expires 27 April 2023               [Page 101]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5709,7 +5709,7 @@ Appendix B.  Option Considered for updating RFC8776
 
 
 
-Busi, et al.              Expires 24 April 2023               [Page 102]
+Busi, et al.              Expires 27 April 2023               [Page 102]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5765,7 +5765,7 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-Busi, et al.              Expires 24 April 2023               [Page 103]
+Busi, et al.              Expires 27 April 2023               [Page 103]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
@@ -5821,4 +5821,4 @@ Authors' Addresses
 
 
 
-Busi, et al.              Expires 24 April 2023               [Page 104]
+Busi, et al.              Expires 27 April 2023               [Page 104]

--- a/drafts/te-types-update/draft-ietf-teas-rfc8776-update.txt
+++ b/drafts/te-types-update/draft-ietf-teas-rfc8776-update.txt
@@ -24,9 +24,10 @@ Expires: 24 April 2023                                            X. Liu
 
 Abstract
 
-   This document defines few additional common data types and groupings
-   in YANG data modeling language to be imported by modules that model
-   Traffic Engineering (TE) configuration and state capabilities.
+   This document defines few additional common data types, identities,
+   and groupings in YANG data modeling language to be imported by
+   modules that model Traffic Engineering (TE) configuration and state
+   capabilities.
 
    Editors' note: Copy the text from [RFC8776] and merge it with the
    content of this section before WG LC if the RFC8876-bis approach is
@@ -49,7 +50,6 @@ Status of This Memo
    and may be updated, replaced, or obsoleted by other documents at any
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
-
 
 
 
@@ -83,29 +83,29 @@ Table of Contents
    2.  Acronyms and Abbreviations  . . . . . . . . . . . . . . . . .   4
    3.  Overview  . . . . . . . . . . . . . . . . . . . . . . . . . .   4
      3.1.  TE Types Module Contents  . . . . . . . . . . . . . . . .   4
-     3.2.  Packet TE Types Module Contents . . . . . . . . . . . . .   4
-   4.  TE Types YANG Module  . . . . . . . . . . . . . . . . . . . .   4
-   5.  Packet TE Types YANG Module . . . . . . . . . . . . . . . . .  81
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  81
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  82
-   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  82
-     8.1.  Normative References  . . . . . . . . . . . . . . . . . .  82
-     8.2.  Informative References  . . . . . . . . . . . . . . . . .  83
-   Appendix A.  Changes from RFC 8776  . . . . . . . . . . . . . . .  83
-     A.1.  TE Types YANG Diffs . . . . . . . . . . . . . . . . . . .  83
-   Appendix B.  Option Considered for updating RFC8776 . . . . . . .  91
-   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . .  92
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  92
+     3.2.  Packet TE Types Module Contents . . . . . . . . . . . . .   6
+   4.  TE Types YANG Module  . . . . . . . . . . . . . . . . . . . .   6
+   5.  Packet TE Types YANG Module . . . . . . . . . . . . . . . . .  87
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  87
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  87
+   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  87
+     8.1.  Normative References  . . . . . . . . . . . . . . . . . .  88
+     8.2.  Informative References  . . . . . . . . . . . . . . . . .  90
+   Appendix A.  Changes from RFC 8776  . . . . . . . . . . . . . . .  90
+     A.1.  TE Types YANG Diffs . . . . . . . . . . . . . . . . . . .  91
+   Appendix B.  Option Considered for updating RFC8776 . . . . . . . 102
+   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . . 104
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . . 104
 
 1.  Introduction
 
-   After the publication of [RFC8776], a new typedef and a new grouping
-   to ietf-te-types have been defined.  Given their broad applicability
-   this document defines them as part of the ietf-te-types YANG model.
+   After the publication of [RFC8776], few additional common data types,
+   identities, and groupings have been defined.  Given their broad
+   applicability this document defines them as part of the revised ietf-
+   te-types YANG model.
 
-   Editors' note: Copy the text from [RFC8776] and merge it with the
-   content of this section before WG LC if the RFC8876-bis approach is
-   confirmed.
+
+
 
 
 
@@ -114,12 +114,18 @@ Busi, et al.              Expires 24 April 2023                 [Page 2]
 Internet-Draft          Yang updates for TE Types           October 2022
 
 
-   NOTE: These definitions have been developed in
-   [I-D.ietf-teas-yang-te] and [I-D.ietf-teas-yang-l3-te-topo] and are
-   quite mature: [I-D.ietf-teas-yang-te] in particular is ready from WG
-   Last Call.
+   Editors' note: Copy the text from [RFC8776] and merge it with the
+   content of this section before WG LC if the RFC8876-bis approach is
+   confirmed.
 
-   RFC Editor: remove the note above and this note
+   CHANGE NOTE: These definitions have been developed in
+   [I-D.ietf-teas-yang-te], [I-D.ietf-teas-yang-path-computation] and
+   [I-D.ietf-teas-yang-l3-te-topo] and are quite mature:
+   [I-D.ietf-teas-yang-te] and [I-D.ietf-teas-yang-path-computation] in
+   particular are in WG Last Call and some definitions have been moved
+   to this document as part of WG LC comments resolution.
+
+   RFC Editor: remove the CHANGE NOTE above and this note
 
 1.1.  Requirements Notation
 
@@ -156,12 +162,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
              Table 1: Prefixes and corresponding YANG modules
 
-   RFC Editor Note: Please replace XXXX with the RFC number assigned to
-   this document.
-
-
-
-
 
 
 
@@ -169,6 +169,9 @@ Busi, et al.              Expires 24 April 2023                 [Page 3]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
+
+   RFC Editor Note: Please replace XXXX with the RFC number assigned to
+   this document.
 
 2.  Acronyms and Abbreviations
 
@@ -183,14 +186,101 @@ Internet-Draft          Yang updates for TE Types           October 2022
    content of this section before WG LC if the RFC8876-bis approach is
    confirmed.
 
+   The module ietf-te-types updates the following YANG identities
+   defined in [RFC8776]:
+
+   association-type:
+
+      A base YANG identity for supported LSP association types as
+      defined in [RFC6780], [RFC4872], [RFC4873] and [RFC8800]
+
+   objective-function-type:
+
+      A base YANG identity for supported path objective functions, as
+      defined in [RFC5541].
+
+   CHANGE NOTE: The association-type-diversity identity, defined in
+   [RFC8800] has been added to the association-type base identity.  The
+   of-minimize-agg-bandwidth-consumption, of-minimize-load-most-loaded-
+   link and of-minimize-cost-path-set, defined in [RFC5541], have been
+   obsoleted because not applicable to paths but to Synchronization
+   VECtor (SVEC) objects.
+
+   RFC Editor: remove the CHANGE NOTE above and this note
+
    The module ietf-te-types has been updated to add the following YANG
-   identies, types and groupings which can be reused by TE YANG models:
+   identities, types and groupings which can be reused by TE YANG
+   models:
 
-   bandwidth-scientific-notation  This types represents the bandwidth in
-      bit-per-second, using the scientific notation (e.g., 10e3).
+   bandwidth-scientific-notation:
 
-   encoding-and-switching-type  This is a common grouping to define the
-      LSP encoding and switching types.
+      This data type represents the bandwidth in bit-per-second, using
+      the scientific notation (e.g., 10e3).
+
+   lsp-provisioning-error-reason:
+
+
+
+Busi, et al.              Expires 24 April 2023                 [Page 4]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
+      A base YANG identity for reporting LSP provisioning error reasons.
+      No standard LPS provisioning error reasons are defined in this
+      document.
+
+   identity path-computation-error-reason:
+
+      A base YANG identity for reporting path computation error reasons,
+      as defined in [RFC5440], [RFC5441], [RFC5520], [RFC5557],
+      [RFC8306] and [RFC8685].
+
+   Editors' Note: how to describe the path computation error reasons
+   defined in this document?
+
+   tunnel-actions-type:
+
+      A base YANG identity for tunnel actions.
+
+   Editors' Note: check whether standard tunnel actions should be
+   defined in this document or not.
+
+   protocol-origin-type:
+
+      A base YANG identity for the type of protocol origin, as defined
+      in [RFC5440] and [RFC5512].
+
+   Editors' Note: how to describe the protocol origin types defined in
+   this document?
+
+   svec-objective-function-type:
+
+      A base YANG identity for supported SVEC objective functions, as
+      defined in [RFC5541] and [RFC8685].
+
+   svec-metric-type:
+
+      A base YANG identity for supported SVEC objective functions, as
+      defined in [RFC5541].
+
+   encoding-and-switching-type:
+
+      This is a common grouping to define the LSP encoding and switching
+      types.
+
+   Editors' Note: how to describe the tunnel-admin-auto, which is
+   defined in this document as derived from tunnel-admin-status-type
+   base identity?
+
+
+
+
+
+Busi, et al.              Expires 24 April 2023                 [Page 5]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
 
 3.2.  Packet TE Types Module Contents
 
@@ -206,25 +296,16 @@ Internet-Draft          Yang updates for TE Types           October 2022
    This section provides the updated revision of the "ietf-te-types"
    YANG module.
 
-   NOTE: Only the typedef bandwidth-scientific-notation and the grouping
-   encoding-and-switching-type have been added in this module revision.
-   Please focus your review on this part.  See also Appendix A.1.
+   CHANGE NOTE: Please focus your review only on the updates to the YANG
+   model: see also Appendix A.1.
 
-   RFC Editor: remove the note above and this note
+   RFC Editor: remove the CHANGE NOTE above and this note
 
-   <CODE BEGINS> file "ietf-te-types@2022-10-15.yang"
+   <CODE BEGINS> file "ietf-te-types@2022-10-21.yang"
    module ietf-te-types {
      yang-version 1.1;
      namespace "urn:ietf:params:xml:ns:yang:ietf-te-types";
      prefix te-types;
-
-
-
-
-Busi, et al.              Expires 24 April 2023                 [Page 4]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
 
      import ietf-inet-types {
        prefix inet;
@@ -248,6 +329,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
      contact
        "WG Web:   <https://datatracker.ietf.org/wg/teas/>
         WG List:  <mailto:teas@ietf.org>
+
+
+
+
+Busi, et al.              Expires 24 April 2023                 [Page 6]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
 
         Editor:   Tarek Saad
                   <mailto:tsaad.net@gmail.com>
@@ -275,13 +364,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
         described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
         they appear in all capitals, as shown here.
 
-
-
-Busi, et al.              Expires 24 April 2023                 [Page 5]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
         Copyright (c) 2022 IETF Trust and the persons identified as
         authors of the code.  All rights reserved.
 
@@ -296,17 +378,39 @@ Internet-Draft          Yang updates for TE Types           October 2022
         (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
         for full legal notices.";
 
-     revision 2022-10-15 {
+     revision 2022-10-21 {
        description
          "Added:
          - typedef bandwidth-scientific-notation;
+         - base identity lsp-provisioning-error-reason;
          - identity association-type-diversity;
          - identity tunnel-admin-auto;
          - base identity path-computation-error-reason and
+
+
+
+Busi, et al.              Expires 24 April 2023                 [Page 7]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
            its derived identities;
+         - base identity tunnel-actions-type and its derived
+           identities;
          - base identity protocol-origin-type and
            its derived identities;
-         - grouping encoding-and-switching-type.";
+         - base identity svec-objective-function-type and its derived
+           identities;
+         - base identity svec-metric-type and its derived identities;
+         - grouping encoding-and-switching-type.
+
+         Updated:
+         - description of the base identity objective-function-type.
+
+         Obsoleted:
+         - identity of-minimize-agg-bandwidth-consumption
+         - identity of-minimize-load-most-loaded-link
+         - identity of-minimize-cost-path-set";
        reference
          "RFC XXXX: Updated Common YANG Data Types for Traffic
          Engineering";
@@ -330,14 +434,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
          /* 01:02:03:04 */
          length "1..11";
        }
-
-
-
-Busi, et al.              Expires 24 April 2023                 [Page 6]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        description
          "Administrative group / resource class / color representation
           in 'hex-string' type.
@@ -346,6 +442,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
           configured value may be omitted for brevity.";
        reference
          "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+
+
+
+Busi, et al.              Expires 24 April 2023                 [Page 8]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
           Version 2
           RFC 5305: IS-IS Extensions for Traffic Engineering
           RFC 7308: Extended Administrative Groups in MPLS Traffic
@@ -387,13 +491,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
          "Path attributes flags type.";
      }
 
-
-
-Busi, et al.              Expires 24 April 2023                 [Page 7]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
      typedef performance-metrics-normality {
        type enumeration {
          enum unknown {
@@ -401,6 +498,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
            description
              "Unknown.";
          }
+
+
+
+Busi, et al.              Expires 24 April 2023                 [Page 9]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          enum normal {
            value 1;
            description
@@ -442,14 +547,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
          }
          enum down {
            description
-
-
-
-Busi, et al.              Expires 24 April 2023                 [Page 8]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
              "Disabled.";
          }
          enum testing {
@@ -457,6 +554,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
              "In some test mode.";
          }
          enum preparing-maintenance {
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 10]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
            description
              "The resource is disabled in the control plane to prepare
               for a graceful shutdown for maintenance purposes.";
@@ -498,14 +603,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
           (dec | hex | float)[*(','(dec | hex | float))]
 
-
-
-
-Busi, et al.              Expires 24 April 2023                 [Page 9]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
           For the packet-switching type, the string encoding follows
           the type 'bandwidth-ieee-float32' as defined in RFC 8294
           (e.g., 0x1p10), where the units are in bytes per second.
@@ -513,6 +610,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
           For the Optical Transport Network (OTN) switching type,
           a list of integers can be used, such as '0,2,3,1', indicating
           two ODU0s and one ODU3.  ('ODU' stands for 'Optical Data
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 11]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
           Unit'.)  For Dense Wavelength Division Multiplexing (DWDM),
           a list of pairs of slot numbers and widths can be used,
           such as '0,2,3,3', indicating a frequency slot 0 with
@@ -554,14 +659,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
        type enumeration {
          enum loose {
            description
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 10]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
              "A loose hop in an explicit path.";
          }
          enum strict {
@@ -569,6 +666,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
              "A strict hop in an explicit path.";
          }
        }
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 12]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        description
          "Enumerated type for specifying loose or strict paths.";
        reference
@@ -610,14 +715,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
           label.";
      }
 
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 11]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
      typedef te-link-direction {
        type enumeration {
          enum incoming {
@@ -625,6 +722,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
              "The explicit route represents an incoming link on
               a node.";
          }
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 13]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          enum outgoing {
            description
              "The explicit route represents an outgoing link on
@@ -666,14 +771,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
           Section 4.3
           RFC 6119: IPv6 Traffic Engineering in IS-IS, Section 3.2.1
           RFC 6827: Automatically Switched Optical Network (ASON)
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 12]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
           Routing for OSPFv2 Protocols, Section 3";
      }
 
@@ -681,6 +778,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
        type te-common-status;
        description
          "Defines a type representing the operational status of
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 14]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
           a TE resource.";
      }
 
@@ -722,14 +827,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
            description
              "Both the recovery span and the working span are fully
               allocated and active, data traffic is being
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 13]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
               transported over (or selected from) the working
               span, and no trigger events are reported.";
          }
@@ -737,6 +834,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
            description
              "The recovery action has been started but not completed.";
          }
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 15]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          enum recovery-succeeded {
            description
              "The recovery action has succeeded.  The working span has
@@ -778,20 +883,20 @@ Internet-Draft          Yang updates for TE Types           October 2022
          }
        }
        description
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 14]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
          "Defines the status of a recovery action.";
        reference
          "RFC 4427: Recovery (Protection and Restoration) Terminology
           for Generalized Multi-Protocol Label Switching (GMPLS)
           RFC 6378: MPLS Transport Profile (MPLS-TP) Linear Protection";
      }
+
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 16]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
 
      typedef te-template-name {
        type string {
@@ -834,14 +939,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
            pattern '([a-zA-Z0-9\-_.]+:)*'
                  + '/?([a-zA-Z0-9\-_.]+)(/[a-zA-Z0-9\-_.]+)*';
          }
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 15]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        }
        description
          "An identifier for a topology.
@@ -849,6 +946,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
           separated by colons.  The prefixes can be 'network-types' as
           defined in the 'ietf-network' module in RFC 8345, to help the
           user better understand the topology before further inquiry
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 17]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
           is made.";
        reference
          "RFC 8345: A YANG Data Model for Network Topologies";
@@ -890,14 +995,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
          (-1)**(S) * 10**(Exponent) * (Significant),
          where Significant uses 7 digits.
          An implementation for this representation may use decimal32
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 16]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
          or binary32. The range of the Exponent is from -95 to +96
          for decimal32, and from -38 to +38 for binary32.
          As a bandwidth value, the format is restricted to be
@@ -905,6 +1002,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
          n.dddddde{+}dd, N.DDDDDDE{+}DD, 0e0 or 0E0,
          where 'd' and 'D' are decimal digits; 'n' and 'N' are
          non-zeror decimal digits; 'e' and 'E' indicate a power of ten.
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 18]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          Some examples are 0e0, 1e10, and 9.953e9.";
        reference
          "IEEE Std 754-2008: IEEE Standard for Floating-Point
@@ -946,14 +1051,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
      }
 
      feature named-extended-admin-groups {
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 17]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        description
          "Indicates support for named extended administrative groups.";
      }
@@ -961,6 +1058,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
      feature named-srlg-groups {
        description
          "Indicates support for named SRLG groups.";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 19]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
      }
 
      feature named-path-constraints {
@@ -982,6 +1087,9 @@ Internet-Draft          Yang updates for TE Types           October 2022
       * Identities
       */
 
+     // NOTE: The base identity lsp-provisioning-error-reason has been
+     // added in this module revision
+     // RFC Editor: remove the note above and this note
      identity lsp-provisioning-error-reason {
        description
          "Base identity for LSP provisioning errors.";
@@ -1002,18 +1110,18 @@ Internet-Draft          Yang updates for TE Types           October 2022
      }
 
      identity se-style-desired {
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 18]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        base session-attributes-flags;
        description
          "Shared explicit style, to allow the LSP to be established
           and share resources with the old LSP.";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 20]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        reference
          "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
      }
@@ -1058,18 +1166,18 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
      identity soft-preemption-desired {
        base session-attributes-flags;
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 19]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        description
          "Soft preemption of LSP resources is desired.";
        reference
          "RFC 5712: MPLS Traffic Engineering Soft Preemption";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 21]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
      }
 
      identity lsp-attributes-flags {
@@ -1115,16 +1223,17 @@ Internet-Draft          Yang updates for TE Types           October 2022
           Route Object (ERO)";
      }
 
+     identity segment-based-rerouting-desired {
+       base lsp-attributes-flags;
+       description
 
 
-Busi, et al.              Expires 24 April 2023                [Page 20]
+
+Busi, et al.              Expires 24 April 2023                [Page 22]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
 
-     identity segment-based-rerouting-desired {
-       base lsp-attributes-flags;
-       description
          "Indicates segment-based rerouting behavior for an LSP
           undergoing establishment.  This MAY also be used to specify
           segment-based LSP recovery for established LSPs.";
@@ -1170,16 +1279,16 @@ Internet-Draft          Yang updates for TE Types           October 2022
          "RFC 5150: Label Switched Path Stitching with Generalized
           Multiprotocol Label Switching Traffic Engineering (GMPLS TE)
           RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+          Route Object (ERO)";
+     }
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 21]
+
+Busi, et al.              Expires 24 April 2023                [Page 23]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
-
-          Route Object (ERO)";
-     }
 
      identity pre-planned-lsp-flag {
        base lsp-attributes-flags;
@@ -1227,15 +1336,16 @@ Internet-Draft          Yang updates for TE Types           October 2022
           Route Object (ERO)";
      }
 
+     identity oam-mep-entity-desired {
+       base lsp-attributes-flags;
 
 
-Busi, et al.              Expires 24 April 2023                [Page 22]
+
+Busi, et al.              Expires 24 April 2023                [Page 24]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
 
-     identity oam-mep-entity-desired {
-       base lsp-attributes-flags;
        description
          "OAM Maintenance Entity Group End Point (MEP) entities
           desired.";
@@ -1282,16 +1392,16 @@ Internet-Draft          Yang updates for TE Types           October 2022
          "P2MP-TE tree re-evaluation request.";
        reference
          "RFC 8149: RSVP Extensions for Reoptimization of Loosely Routed
+          Point-to-Multipoint Traffic Engineering Label Switched Paths
+          (LSPs)";
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 23]
+Busi, et al.              Expires 24 April 2023                [Page 25]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
 
-          Point-to-Multipoint Traffic Engineering Label Switched Paths
-          (LSPs)";
      }
 
      identity rtm-set-desired {
@@ -1338,16 +1448,16 @@ Internet-Draft          Yang updates for TE Types           October 2022
        base link-protection-type;
        description
          "One-for-one (1:1) protected link type.";
+       reference
+         "RFC 4872: RSVP-TE Extensions in Support of End-to-End
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 24]
+Busi, et al.              Expires 24 April 2023                [Page 26]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
 
-       reference
-         "RFC 4872: RSVP-TE Extensions in Support of End-to-End
           Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
      }
 
@@ -1394,16 +1504,16 @@ Internet-Draft          Yang updates for TE Types           October 2022
      }
 
      identity association-type-double-sided-bidir {
+       base association-type;
+       description
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 25]
+Busi, et al.              Expires 24 April 2023                [Page 27]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
 
-       base association-type;
-       description
          "Association type for double-sided bidirectional LSPs,
           used to associate two LSPs of two tunnels that are
           independently configured on either endpoint.";
@@ -1431,32 +1541,39 @@ Internet-Draft          Yang updates for TE Types           October 2022
      identity association-type-diversity {
        base association-type;
        description
-         "Association Type diversity used to associate LSPs whose paths
-          are to be diverse from each other.";
+         "Association Type diversity used to associate LSPs whose
+         paths are to be diverse from each other.";
        reference
-         "RFC8800";
+         "RFC8800: Path Computation Element Communication Protocol
+         (PCEP) Extension for Label Switched Path (LSP) Diversity
+         Constraint Signaling";
      }
 
+     // NOTE: The description of the base identity
+     // objective-function-type has been updated
+     // in this module revision
+     // RFC Editor: remove the note above and this note
      identity objective-function-type {
        description
-         "Base objective function type.";
+         "Base identity for path objective function type.";
      }
 
      identity of-minimize-cost-path {
        base objective-function-type;
        description
          "Objective function for minimizing path cost.";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 28]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        reference
          "RFC 5541: Encoding of Objective Functions in the Path
           Computation Element Communication Protocol (PCEP)";
      }
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 26]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
 
      identity of-minimize-load-path {
        base objective-function-type;
@@ -1477,42 +1594,54 @@ Internet-Draft          Yang updates for TE Types           October 2022
           Computation Element Communication Protocol (PCEP)";
      }
 
+     // NOTE: The identity of-minimize-agg-bandwidth-consumption
+     // below has been obsoleted in this module revision
+     // RFC Editor: remove the note above and this note
      identity of-minimize-agg-bandwidth-consumption {
        base objective-function-type;
+       status obsolete;
        description
          "Objective function for minimizing aggregate bandwidth
-          consumption.";
+         consumption.";
        reference
          "RFC 5541: Encoding of Objective Functions in the Path
-          Computation Element Communication Protocol (PCEP)";
+         Computation Element Communication Protocol (PCEP)";
      }
 
+     // NOTE: The identity of-minimize-load-most-loaded-link
+     // below has been obsoleted in this module revision
+     // RFC Editor: remove the note above and this note
      identity of-minimize-load-most-loaded-link {
        base objective-function-type;
+       status obsolete;
        description
          "Objective function for minimizing the load on the link that
-          is carrying the highest load.";
+         is carrying the highest load.";
        reference
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 29]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          "RFC 5541: Encoding of Objective Functions in the Path
-          Computation Element Communication Protocol (PCEP)";
+         Computation Element Communication Protocol (PCEP)";
      }
 
+     // NOTE: The identity of-minimize-cost-path-set
+     // below has been obsoleted in this module revision
+     // RFC Editor: remove the note above and this note
      identity of-minimize-cost-path-set {
        base objective-function-type;
+       status obsolete;
        description
          "Objective function for minimizing the cost on a path set.";
        reference
          "RFC 5541: Encoding of Objective Functions in the Path
           Computation Element Communication Protocol (PCEP)";
      }
-
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 27]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
 
      identity path-computation-method {
        description
@@ -1546,6 +1675,13 @@ Internet-Draft          Yang updates for TE Types           October 2022
           Protocol Generic Requirements";
      }
 
+
+
+Busi, et al.              Expires 24 April 2023                [Page 30]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
      identity path-explicitly-defined {
        base path-computation-method;
        description
@@ -1562,13 +1698,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
        description
          "Base identity for the LSP metric specification types.";
      }
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 28]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
 
      identity lsp-metric-relative {
        base lsp-metric-type;
@@ -1602,6 +1731,13 @@ Internet-Draft          Yang updates for TE Types           October 2022
           Protocol Generic Requirements";
      }
 
+
+
+Busi, et al.              Expires 24 April 2023                [Page 31]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
      identity te-tunnel-type {
        description
          "Base identity from which specific tunnel types are derived.";
@@ -1618,14 +1754,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
      identity te-tunnel-p2mp {
        base te-tunnel-type;
        description
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 29]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
          "TE P2MP tunnel type.";
        reference
          "RFC 4875: Extensions to Resource Reservation Protocol -
@@ -1658,6 +1786,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
        description
          "TE tunnel action that switches the tunnel's LSP to use the
           specified path.";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 32]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
      }
 
      identity te-action-result {
@@ -1674,14 +1810,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
      identity te-action-fail {
        base te-action-result;
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 30]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        description
          "TE action failed.";
      }
@@ -1714,11 +1842,19 @@ Internet-Draft          Yang updates for TE Types           October 2022
      // RFC Editor: remove the note above and this note
      identity tunnel-admin-auto {
        base tunnel-admin-state-type;
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 33]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        description
          "Tunnel administrative auto state. The administrative status
-          in state datastore transitions to 'tunnel-admin-up' when the
-          tunnel used by the client layer, and to 'tunnel-admin-down'
-          when it is not used by the client layer.";
+         in state datastore transitions to 'tunnel-admin-up' when the
+         tunnel used by the client layer, and to 'tunnel-admin-down'
+         when it is not used by the client layer.";
      }
 
      identity tunnel-state-type {
@@ -1730,14 +1866,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
        base tunnel-state-type;
        description
          "Tunnel's state is up.";
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 31]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
      }
 
      identity tunnel-state-down {
@@ -1770,6 +1898,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
      }
 
      identity lsp-state-setting-up {
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 34]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        base lsp-state-type;
        description
          "State is being set up.";
@@ -1786,13 +1922,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
        description
          "State setup failed.";
      }
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 32]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
 
      identity lsp-state-up {
        base lsp-state-type;
@@ -1825,6 +1954,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
        reference
          "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
           Section 2.5";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 35]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
      }
 
      identity path-invalidation-action-teardown {
@@ -1842,14 +1979,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
      }
 
      identity lsp-restoration-restore-any {
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 33]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        base lsp-restoration-type;
        description
          "Any LSP affected by a failure is restored.";
@@ -1881,6 +2010,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
        description
          "Restoration LSP is precomputed prior to the failure.";
        reference
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 36]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          "RFC 4427: Recovery (Protection and Restoration) Terminology
           for Generalized Multi-Protocol Label Switching (GMPLS)";
      }
@@ -1898,14 +2035,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
        description
          "Base identity from which LSP protection types are derived.";
        reference
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 34]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
          "RFC 4872: RSVP-TE Extensions in Support of End-to-End
           Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
      }
@@ -1937,6 +2066,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
           Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
      }
 
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 37]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
      identity lsp-protection-1-for-n {
        base lsp-protection-type;
        description
@@ -1954,13 +2091,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
          "RFC 4872: RSVP-TE Extensions in Support of End-to-End
           Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
      }
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 35]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
 
      identity lsp-protection-unidir-1-plus-1 {
        base lsp-protection-type;
@@ -1992,6 +2122,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
      identity lsp-protection-state {
        description
          "Base identity of protection states for reporting purposes.";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 38]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
      }
 
      identity normal {
@@ -2010,13 +2148,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
          "RFC 4427: Recovery (Protection and Restoration) Terminology
           for Generalized Multi-Protocol Label Switching (GMPLS)";
      }
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 36]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
 
      identity lockout-of-protection {
        base lsp-protection-state;
@@ -2047,6 +2178,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
      }
 
      identity signal-degrade {
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 39]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        base lsp-protection-state;
        description
          "There is a signal degrade condition on either the working
@@ -2066,14 +2205,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
      }
 
      identity wait-to-restore {
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 37]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        base lsp-protection-state;
        description
          "A WTR timer is running.";
@@ -2103,6 +2234,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
      }
 
      identity protection-external-commands {
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 40]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        description
          "Base identity from which protection-related external commands
           used for troubleshooting purposes are derived.";
@@ -2122,14 +2261,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
      identity clear-freeze {
        base protection-external-commands;
        description
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 38]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
          "An action that clears the active freeze state.";
        reference
          "RFC 4427: Recovery (Protection and Restoration) Terminology
@@ -2159,6 +2290,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
      identity action-lockout-of-protection {
        base protection-external-commands;
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 41]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        description
          "A temporary configuration action initiated by an operator
           command to ensure that the protection transport entity is
@@ -2178,14 +2317,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
           switchover command of equal or higher priority is in effect.";
        reference
          "RFC 4427: Recovery (Protection and Restoration) Terminology
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 39]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
           for Generalized Multi-Protocol Label Switching (GMPLS)";
      }
 
@@ -2215,6 +2346,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
      identity clear {
        base protection-external-commands;
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 42]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        description
          "An action that clears the active near-end lockout of a
           protection, forced switchover, manual switchover, WTR state,
@@ -2234,14 +2373,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
      identity switching-psc1 {
        base switching-capabilities;
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 40]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        description
          "Packet-Switch Capable-1 (PSC-1).";
        reference
@@ -2271,6 +2402,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
        base switching-capabilities;
        description
          "Time-Division-Multiplex Capable (TDM).";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 43]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        reference
          "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
           Signaling Functional Description";
@@ -2290,14 +2429,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
        description
          "Data Channel Switching Capable (DCSC).";
        reference
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 41]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
          "RFC 6002: Generalized MPLS (GMPLS) Data Channel
           Switching Capable (DCSC) and Channel Set Label Extensions";
      }
@@ -2328,6 +2459,13 @@ Internet-Draft          Yang updates for TE Types           October 2022
           Signaling Functional Description";
      }
 
+
+
+Busi, et al.              Expires 24 April 2023                [Page 44]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
      identity lsp-encoding-packet {
        base lsp-encoding-types;
        description
@@ -2345,14 +2483,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
          "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
           Signaling Functional Description";
      }
-
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 42]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
 
      identity lsp-encoding-pdh {
        base lsp-encoding-types;
@@ -2384,6 +2514,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
      identity lsp-encoding-lambda {
        base lsp-encoding-types;
        description
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 45]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          "Lambda (photonic) LSP encoding.";
        reference
          "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
@@ -2402,14 +2540,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
      identity lsp-encoding-fiber-channel {
        base lsp-encoding-types;
        description
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 43]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
          "FiberChannel LSP encoding.";
        reference
          "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
@@ -2440,6 +2570,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
        base lsp-encoding-types;
        description
          "Line (e.g., 8B/10B) LSP encoding.";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 46]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        reference
          "RFC 6004: Generalized MPLS (GMPLS) Support for Metro
           Ethernet Forum and G.8011 Ethernet Service Switching";
@@ -2458,14 +2596,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
      }
 
      identity path-setup-rsvp {
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 44]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        base path-signaling-type;
        description
          "RSVP-TE signaling path setup.";
@@ -2496,6 +2626,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
      identity path-scope-end-to-end {
        base path-scope-type;
        description
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 47]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          "Path scope end to end.";
        reference
          "RFC 4873: GMPLS Segment Recovery";
@@ -2514,14 +2652,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
      identity route-exclude-object {
        base route-usage-type;
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 45]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        description
          "'Exclude route' object.";
        reference
@@ -2552,6 +2682,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
           second MPLS Traffic Engineering (TE) Metric";
      }
 
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 48]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
      identity path-metric-igp {
        base path-metric-type;
        description
@@ -2570,14 +2708,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
      identity path-metric-delay-average {
        base path-metric-type;
        description
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 46]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
          "Average unidirectional link delay.";
        reference
          "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
@@ -2608,6 +2738,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
        description
          "A metric that optimizes the number of included resources
           specified in a set.";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 49]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
      }
 
      identity path-metric-optimize-excludes {
@@ -2626,14 +2764,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
        base path-tiebreaker-type;
        description
          "Min-Fill LSP path placement.";
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 47]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
      }
 
      identity path-tiebreaker-maxfill {
@@ -2664,6 +2794,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
        reference
          "RFC 2702: Requirements for Traffic Engineering Over MPLS
           RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 50]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
      }
 
      identity resource-aff-include-any {
@@ -2682,14 +2820,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
        description
          "The set of attribute filters associated with a
           tunnel, any of which renders a link unacceptable.";
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 48]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        reference
          "RFC 2702: Requirements for Traffic Engineering Over MPLS
           RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
@@ -2720,6 +2850,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
      identity delay {
        base te-optimization-criterion;
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 51]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        description
          "Optimized on delay.";
        reference
@@ -2737,14 +2875,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
        description
          "Ignores SRLGs in the path computation.";
      }
-
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 49]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
 
      identity srlg-strict {
        base path-computation-srlg-type;
@@ -2773,139 +2903,9 @@ Internet-Draft          Yang updates for TE Types           October 2022
          "Base identity for path computation error reasons.";
      }
 
-     identity path-computation-error-no-topology {
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because there is no topology
-          with the provided topology-identifier.";
-     }
-
-     identity path-computation-error-no-dependent-server {
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because one or more dependent
-          path computation servers are unavailable.
-          The dependent path computation server could be
-          a Backward-Recursive Path Computation (BRPC) downstream
-          PCE or a child PCE.";
-       reference
-         "RFC5441, RFC8685";
-     }
-
-     identity path-computation-error-pce-unavailable {
-       base path-computation-error-reason;
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 50]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
-       description
-         "Path computation has failed because PCE is not available.";
-       reference
-         "RFC5440";
-     }
-
-     identity path-computation-error-no-inclusion-hop {
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because there is no
-          node or link provided by one or more inclusion hops.";
-       reference
-         "RFC8685";
-     }
-
-     identity path-computation-error-destination-unknown-in-domain {
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because the destination node is
-          unknown in indicated destination domain.";
-       reference
-         "RFC8685";
-     }
-
-     identity path-computation-error-no-resource {
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because there is no
-          available resource in one or more domains.";
-       reference
-         "RFC8685";
-     }
-
-     identity path-computation-error-child-pce-unresponsive {
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because child PCE is not
-          responsive.";
-       reference
-         "RFC8685";
-     }
-
-     identity path-computation-error-destination-domain-unknown {
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because the destination domain
-          was unknown.";
-       reference
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 51]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
-         "RFC8685";
-     }
-
-     identity path-computation-error-p2mp {
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because of P2MP reachability
-          problem.";
-       reference
-         "RFC8306";
-     }
-
-     identity path-computation-error-no-gco-migration {
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because of no Global Concurrent
-          Optimization (GCO) migration path found.";
-       reference
-         "RFC5557";
-     }
-
-     identity path-computation-error-no-gco-solution {
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because of no GCO solution
-          found.";
-       reference
-         "RFC5557";
-     }
-
-     identity path-computation-error-path-not-found {
-       base path-computation-error-reason;
-       description
-         "Path computation no path found error reason.";
-       reference
-         "RFC5440";
-     }
-
-     identity path-computation-error-pks-expansion {
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because of Path-Key Subobject
-          (PKS)  expansion failure.";
-       reference
-         "RFC5520";
-     }
-
-     identity path-computation-error-brpc-chain-unavailable {
+       identity path-computation-error-no-topology {
+         base path-computation-error-reason;
+         description
 
 
 
@@ -2914,39 +2914,178 @@ Busi, et al.              Expires 24 April 2023                [Page 52]
 Internet-Draft          Yang updates for TE Types           October 2022
 
 
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because PCE BRPC chain
-          unavailable.";
-       reference
-         "RFC5441";
-     }
+           "Path computation has failed because there is no topology
+           with the provided topology-identifier.";
+       }
 
-     identity path-computation-error-source-unknown {
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because source node is unknown.";
-       reference
-         "RFC5440";
-     }
+       identity path-computation-error-no-dependent-server {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because one or more dependent
+           path computation servers are unavailable.
+           The dependent path computation server could be
+           a Backward-Recursive Path Computation (BRPC) downstream
+           PCE or a child PCE.";
+         reference
+           "RFC5441, RFC8685";
+       }
 
-     identity path-computation-error-destination-unknown {
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because destination node is
-          unknown.";
-       reference
-         "RFC5440";
-     }
+       identity path-computation-error-pce-unavailable {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because PCE is not available.";
+         reference
+           "RFC5440";
+       }
 
-     identity path-computation-error-no-server {
-       base path-computation-error-reason;
-       description
-         "Path computation has failed because path computation
-          server is unavailable.";
-       reference
-         "RFC5440";
-     }
+       identity path-computation-error-no-inclusion-hop {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because there is no
+           node or link provided by one or more inclusion hops.";
+         reference
+           "RFC8685";
+       }
+
+       identity path-computation-error-destination-unknown-in-domain {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because the destination node is
+           unknown in indicated destination domain.";
+         reference
+           "RFC8685";
+       }
+
+       identity path-computation-error-no-resource {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because there is no
+           available resource in one or more domains.";
+         reference
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 53]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
+           "RFC8685";
+       }
+
+       identity path-computation-error-child-pce-unresponsive {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because child PCE is not
+           responsive.";
+         reference
+           "RFC8685";
+       }
+
+       identity path-computation-error-destination-domain-unknown {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because the destination domain
+           was unknown.";
+         reference
+           "RFC8685";
+       }
+
+       identity path-computation-error-p2mp {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because of P2MP reachability
+           problem.";
+         reference
+           "RFC8306";
+       }
+
+       identity path-computation-error-no-gco-migration {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because of no Global Concurrent
+           Optimization (GCO) migration path found.";
+         reference
+           "RFC5557";
+       }
+
+       identity path-computation-error-no-gco-solution {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because of no GCO solution
+           found.";
+         reference
+           "RFC5557";
+       }
+
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 54]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
+       identity path-computation-error-path-not-found {
+         base path-computation-error-reason;
+         description
+           "Path computation no path found error reason.";
+         reference
+           "RFC5440";
+       }
+
+       identity path-computation-error-pks-expansion {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because of Path-Key Subobject
+           (PKS)  expansion failure.";
+         reference
+           "RFC5520";
+       }
+
+       identity path-computation-error-brpc-chain-unavailable {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because PCE BRPC chain
+           unavailable.";
+         reference
+           "RFC5441";
+       }
+
+       identity path-computation-error-source-unknown {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because source node is
+           unknown.";
+         reference
+           "RFC5440";
+       }
+
+       identity path-computation-error-destination-unknown {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because destination node is
+           unknown.";
+         reference
+           "RFC5440";
+       }
+
+       identity path-computation-error-no-server {
+         base path-computation-error-reason;
+         description
+           "Path computation has failed because path computation
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 55]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
+           server is unavailable.";
+         reference
+           "RFC5440";
+       }
 
      // NOTE: The base identity tunnel-actions-type and
      // its derived identities below have been
@@ -2962,42 +3101,210 @@ Internet-Draft          Yang updates for TE Types           October 2022
      // added in this module revision
      // RFC Editor: remove the note above and this note
      identity protocol-origin-type {
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 53]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        description
          "Base identity for protocol origin type.";
      }
 
-     identity protocol-origin-api {
-       base protocol-origin-type;
+       identity protocol-origin-api {
+         base protocol-origin-type;
+         description
+           "Protocol origin is via Application Programmable Interface
+           (API).";
+       }
+
+       identity protocol-origin-pcep {
+         base protocol-origin-type;
+         description
+           "Protocol origin is Path Computation Engine Protocol
+           (PCEP).";
+         reference "RFC5440";
+       }
+
+       identity protocol-origin-bgp {
+         base protocol-origin-type;
+         description
+           "Protocol origin is Border Gateway Protocol (BGP).";
+         reference "RFC5512";
+       }
+
+     // NOTE: The base identity svec-objective-function-type and
+     // its derived identities below have been
+     // added in this module revision
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 56]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
+     // RFC Editor: remove the note above and this note
+     identity svec-objective-function-type {
        description
-         "Protocol origin is via Application Programmable Interface
-          (API).";
+         "Base identity for SVEC objective function type.";
+       reference
+         "RFC5541: Encoding of Objective Functions in the Path
+          Computation Element Communication Protocol (PCEP).";
      }
 
-     identity protocol-origin-pcep {
-       base protocol-origin-type;
+       identity svec-of-minimize-agg-bandwidth-consumption {
+         base svec-objective-function-type;
+         description
+           "Objective function for minimizing aggregate bandwidth
+           consumption (MBC).";
+         reference
+           "RFC5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP).";
+       }
+
+       identity svec-of-minimize-load-most-loaded-link {
+         base svec-objective-function-type;
+         description
+           "Objective function for minimizing the load on the link that
+           is carrying the highest load (MLL).";
+         reference
+           "RFC5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP).";
+       }
+
+       identity svec-of-minimize-cost-path-set {
+         base svec-objective-function-type;
+         description
+           "Objective function for minimizing the cost on a path set
+           (MCC).";
+         reference
+           "RFC5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP).";
+       }
+
+       identity svec-of-minimize-common-transit-domain {
+         base svec-objective-function-type;
+         description
+           "Objective function for minimizing the number of common
+           transit domains (MCTD).";
+         reference
+           "RFC8685: Path Computation Element Communication Protocol
+           (PCEP) Extensions for the Hierarchical Path Computation
+           Element (H-PCE) Architecture.";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 57]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
+       }
+
+       identity svec-of-minimize-shared-link {
+         base svec-objective-function-type;
+         description
+           "Objective function for minimizing the number of shared
+           links (MSL).";
+         reference
+           "RFC8685: Path Computation Element Communication Protocol
+           (PCEP) Extensions for the Hierarchical Path Computation
+           Element (H-PCE) Architecture.";
+       }
+
+       identity svec-of-minimize-shared-srlg {
+         base svec-objective-function-type;
+         description
+           "Objective function for minimizing the number of shared
+           Shared Risk Link Groups (SRLG) (MSS).";
+         reference
+           "RFC8685: Path Computation Element Communication Protocol
+           (PCEP) Extensions for the Hierarchical Path Computation
+           Element (H-PCE) Architecture.";
+       }
+
+       identity svec-of-minimize-shared-nodes {
+         base svec-objective-function-type;
+         description
+           "Objective function for minimizing the number of shared
+           nodes (MSN).";
+         reference
+           "RFC8685: Path Computation Element Communication Protocol
+           (PCEP) Extensions for the Hierarchical Path Computation
+           Element (H-PCE) Architecture.";
+       }
+
+     // NOTE: The base identity svec-metric-type and
+     // its derived identities below have been
+     // added in this module revision
+     // RFC Editor: remove the note above and this note
+     identity svec-metric-type {
        description
-         "Protocol origin is Path Computation Engine Protocol (PCEP).";
-       reference "RFC5440";
+         "Base identity for SVEC metric type.";
+       reference
+         "RFC5541: Encoding of Objective Functions in the Path
+          Computation Element Communication Protocol (PCEP).";
      }
 
-     identity protocol-origin-bgp {
-       base protocol-origin-type;
-       description
-         "Protocol origin is Border Gateway Protocol (BGP).";
-       reference "RFC5512";
-     }
+       identity svec-metric-cumul-te {
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 58]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
+         base svec-metric-type;
+         description
+           "Cumulative TE cost.";
+         reference
+           "RFC5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP).";
+       }
+
+       identity svec-metric-cumul-igp {
+         base svec-metric-type;
+         description
+           "Cumulative IGP cost.";
+         reference
+           "RFC5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP).";
+       }
+
+       identity svec-metric-cumul-hop {
+         base svec-metric-type;
+         description
+           "Cumulative Hop path metric.";
+         reference
+           "RFC5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP).";
+       }
+
+       identity svec-metric-aggregate-bandwidth-consumption {
+         base svec-metric-type;
+         description
+           "Aggregate bandwidth consumption.";
+         reference
+           "RFC5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP).";
+       }
+
+       identity svec-metric-load-of-the-most-loaded-link {
+         base svec-metric-type;
+         description
+           "Load of the most loaded link.";
+         reference
+           "RFC5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP).";
+       }
 
      /**
       * TE bandwidth groupings
       **/
+
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 59]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
 
      grouping te-bandwidth {
        description
@@ -3018,14 +3325,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
            case generic {
              leaf generic {
                type te-bandwidth;
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 54]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
                description
                  "Bandwidth specified in a generic format.";
              }
@@ -3055,6 +3354,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
            case generic {
              leaf generic {
                type rt-types:generalized-label;
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 60]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
                description
                  "TE label specified in a generic format.";
              }
@@ -3074,14 +3381,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
          "Augmentation for a TE topology.";
        container te-topology-identifier {
          description
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 55]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
            "TE topology identifier container.";
          leaf provider-id {
            type te-global-id;
@@ -3111,6 +3410,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
      }
 
      /**
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 61]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
       * TE performance metrics groupings
       **/
 
@@ -3130,14 +3437,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
          type uint32 {
            range "0..16777215";
          }
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 56]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
          description
            "One-way delay or latency in microseconds.";
        }
@@ -3167,6 +3466,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
            "Two-way delay or latency in microseconds.";
        }
        leaf two-way-delay-normality {
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 62]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          type te-types:performance-metrics-normality;
          description
            "Two-way delay normality.";
@@ -3186,14 +3493,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
           RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
        leaf one-way-residual-bandwidth {
          type rt-types:bandwidth-ieee-float32;
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 57]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
          units "bytes per second";
          default "0x0p0";
          description
@@ -3223,6 +3522,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
        }
        leaf one-way-available-bandwidth-normality {
          type te-types:performance-metrics-normality;
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 63]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          default "normal";
          description
            "Available bandwidth normality.";
@@ -3242,14 +3549,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
          default "normal";
          description
            "Bandwidth utilization normality.";
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 58]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        }
      }
 
@@ -3279,6 +3578,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
        leaf one-way-available-bandwidth {
          type rt-types:bandwidth-ieee-float32;
          units "bytes per second";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 64]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          default "0x0p0";
          description
            "Available bandwidth that is defined to be residual
@@ -3298,13 +3605,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
             be the sum of the component link bandwidth utilizations.";
        }
      }
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 59]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
 
      grouping two-way-performance-metrics {
        description
@@ -3334,6 +3634,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
          description
            "One-way link performance information in real time.";
          reference
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 65]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
            "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions
             RFC 7823: Performance-Based Path Selection for Explicitly
             Routed Label Switched Paths (LSPs) Using TE Metric
@@ -3354,14 +3662,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
      grouping performance-metrics-throttle-container {
        description
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 60]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
          "Controls PM throttling.";
        container throttle {
          must 'suppression-interval >= measure-interval' {
@@ -3390,6 +3690,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
          leaf measure-interval {
            type uint32;
            default "30";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 66]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
            description
              "Interval, in seconds, to measure the extended metric
               values.";
@@ -3410,14 +3718,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
              "Interval, in seconds, to suppress advertisement of the
               extended metric values.";
            reference
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 61]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
              "RFC 8570: IS-IS Traffic Engineering (TE) Metric
               Extensions, Section 6";
          }
@@ -3446,6 +3746,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
               'anomalous' announcement (anomalous bit set) will be
               triggered.";
            uses performance-metrics-thresholds;
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 67]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          }
        }
      }
@@ -3466,14 +3774,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
                type te-node-id;
                mandatory true;
                description
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 62]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
                  "The identifier of a node in the TE topology.";
              }
              leaf hop-type {
@@ -3502,6 +3802,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
              leaf hop-type {
                type te-hop-type;
                default "strict";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 68]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
                description
                  "Strict or loose hop.";
              }
@@ -3522,14 +3830,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
          }
          case unnumbered-link-hop {
            container unnumbered-link-hop {
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 63]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
              leaf link-tp-id {
                type te-tp-id;
                mandatory true;
@@ -3558,6 +3858,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
              }
              description
                "Unnumbered link explicit route hop.";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 69]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
              reference
                "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
                 Section 4.3, EXPLICIT_ROUTE in RSVP-TE
@@ -3578,14 +3886,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
                default "strict";
                description
                  "Strict or loose hop.";
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 64]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
              }
              description
                "AS explicit route hop.";
@@ -3614,6 +3914,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
             is defined by the user without relying on key values.";
        }
        choice type {
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 70]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          description
            "The Record Route entry type.";
          case numbered-node-hop {
@@ -3634,14 +3942,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
                  "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels
                   RFC 4090: Fast Reroute Extensions to RSVP-TE for LSP
                   Tunnels
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 65]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
                   RFC 4561: Definition of a Record Route Object (RRO)
                   Node-Id Sub-Object";
              }
@@ -3670,6 +3970,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
                   RFC 4561: Definition of a Record Route Object (RRO)
                   Node-Id Sub-Object";
              }
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 71]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
            }
            description
              "Numbered link route hop.";
@@ -3690,14 +3998,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
                  "The identifier of a node in the TE topology.";
              }
              leaf-list flags {
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 66]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
                type path-attribute-flags;
                description
                  "Path attributes flags.";
@@ -3726,6 +4026,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
                type path-attribute-flags;
                description
                  "Path attributes flags.";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 72]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
                reference
                  "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels
                   RFC 4090: Fast Reroute Extensions to RSVP-TE for LSP
@@ -3746,14 +4054,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
        leaf restriction {
          type enumeration {
            enum inclusive {
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 67]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
              description
                "The label or label range is inclusive.";
            }
@@ -3782,6 +4082,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
             + " or "
             + "(not(../label-end/te-label/direction) and"
             + " (te-label/direction = 'forward'))" {
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 73]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
            error-message "'label-start' and 'label-end' must have the "
                        + "same direction.";
          }
@@ -3802,14 +4110,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
             + " or "
             + "(not(../label-start/te-label/direction) and"
             + " (te-label/direction = 'forward'))" {
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 68]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
            error-message "'label-start' and 'label-end' must have the "
                        + "same direction.";
          }
@@ -3838,6 +4138,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
              }
            }
          }
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 74]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        }
        leaf range-bitmap {
          type yang:hex-string;
@@ -3858,14 +4166,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
             - bit position (0) is set, and the corresponding mapped
               label from the range is 16000 + (0 * 'label-step') or
               16000 for default 'label-step' = 1.
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 69]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
             - bit position (24) is set, and the corresponding mapped
               label from the range is 16000 + (24 * 'label-step') or
               16024 for default 'label-step' = 1.";
@@ -3894,6 +4194,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
      }
 
      grouping optimization-metric-entry {
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 75]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        description
          "Optimization metrics configuration grouping.";
        leaf metric-type {
@@ -3914,14 +4222,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
          when "../metric-type = "
             + "'te-types:path-metric-optimize-excludes'";
          description
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 70]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
            "Container for the 'exclude route' object list.";
          uses path-route-exclude-objects;
        }
@@ -3950,6 +4250,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
          description
            "Link protection type required for the links included
             in the computed path.";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 76]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          reference
            "RFC 4202: Routing Extensions in Support of
             Generalized Multi-Protocol Label Switching (GMPLS)";
@@ -3970,14 +4278,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
          }
          default "7";
          description
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 71]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
            "TE LSP requested hold priority.";
          reference
            "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
@@ -4006,6 +4306,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
           performing the path computation.";
        container explicit-route-objects-always {
          description
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 77]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
            "Container for the 'exclude route' object list.";
          list route-object-exclude-always {
            key "index";
@@ -4026,14 +4334,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
            key "index";
            ordered-by user;
            description
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 72]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
              "List of route objects to include or exclude in the path
               computation.";
            leaf explicit-route-usage {
@@ -4062,6 +4362,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
                      type uint32;
                      description
                        "SRLG value.";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 78]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
                    }
                  }
                  description
@@ -4082,14 +4390,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
           the path computation.";
        list route-object-include-object {
          key "index";
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 73]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
          ordered-by user;
          description
            "List of Explicit Route Objects to be included in the
@@ -4118,6 +4418,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
          leaf index {
            type uint32;
            description
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 79]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
              "Route object entry index.  The index is used to
               identify an entry in the list.  The order of entries
               is defined by the user without relying on key values.";
@@ -4138,14 +4446,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
                  "An SRLG value to be included or excluded.";
              }
              description
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 74]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
                "Augmentation for a generic explicit route for SRLG
                 exclusion.";
            }
@@ -4174,6 +4474,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
            leaf upper-bound {
              type uint64;
              default "0";
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 80]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
              description
                "Upper bound on the end-to-end TE path metric.  A zero
                 indicates an unbounded upper limit for the specific
@@ -4194,14 +4502,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
            description
              "Optimizations algorithm.";
            case metric {
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 75]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
              if-feature "path-optimization-metric";
              /* Optimize by metric */
              list optimization-metric {
@@ -4230,6 +4530,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
                }
              }
            }
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 81]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
            case objective-function {
              if-feature "path-optimization-objective-function";
              /* Objective functions */
@@ -4250,13 +4558,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
          }
        }
      }
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 76]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
 
      grouping generic-path-affinities {
        description
@@ -4285,6 +4586,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
          }
        }
        container path-affinity-names {
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 82]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
          description
            "Path affinities represented as names.";
          list path-affinity-name {
@@ -4306,14 +4615,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
                description
                  "Identifies a named affinity entry.";
              }
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 77]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
              description
                "List of named affinities.";
            }
@@ -4341,6 +4642,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
            }
            leaf-list values {
              type srlg;
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 83]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
              description
                "List of SRLG values.";
            }
@@ -4362,14 +4671,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
                 include or exclude.";
            }
            leaf-list names {
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 78]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
              type string;
              description
                "List of named SRLGs.";
@@ -4397,6 +4698,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
          "Common path constraints configuration grouping.";
        uses common-constraints;
        uses generic-path-metric-bounds;
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 84]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
        uses generic-path-affinities;
        uses generic-path-srlgs;
      }
@@ -4418,14 +4727,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
        container path-properties {
          config false;
          description
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 79]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
            "The TE path properties.";
          list path-metric {
            key "metric-type";
@@ -4453,6 +4754,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
            list path-route-object {
              key "index";
              ordered-by user;
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 85]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
              description
                "List of route objects either returned by the computation
                 engine or actually used by an LSP.";
@@ -4474,14 +4783,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
      // added in this module revision
      // RFC Editor: remove the note above and this note
      grouping encoding-and-switching-type {
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 80]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
        description
          "Common grouping to define the LSP encoding and
          switching types";
@@ -4509,6 +4810,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
                        Figure 1: TE Types YANG module
 
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 86]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
 5.  Packet TE Types YANG Module
 
    Editors' note: Copy the text from [RFC8776] before WG LC if the
@@ -4529,14 +4838,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
    This document also adds updated YANG modules to the "YANG Module
    Names" registry [RFC7950]:
-
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 81]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
 
          name:      ietf-te-types
          namespace: urn:ietf:params:xml:ns:yang:ietf-te-types
@@ -4565,12 +4866,80 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 8.  References
 
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 87]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
 8.1.  Normative References
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC4872]  Lang, J.P., Ed., Rekhter, Y., Ed., and D. Papadimitriou,
+              Ed., "RSVP-TE Extensions in Support of End-to-End
+              Generalized Multi-Protocol Label Switching (GMPLS)
+              Recovery", RFC 4872, DOI 10.17487/RFC4872, May 2007,
+              <https://www.rfc-editor.org/info/rfc4872>.
+
+   [RFC4873]  Berger, L., Bryskin, I., Papadimitriou, D., and A. Farrel,
+              "GMPLS Segment Recovery", RFC 4873, DOI 10.17487/RFC4873,
+              May 2007, <https://www.rfc-editor.org/info/rfc4873>.
+
+   [RFC5440]  Vasseur, JP., Ed. and JL. Le Roux, Ed., "Path Computation
+              Element (PCE) Communication Protocol (PCEP)", RFC 5440,
+              DOI 10.17487/RFC5440, March 2009,
+              <https://www.rfc-editor.org/info/rfc5440>.
+
+   [RFC5441]  Vasseur, JP., Ed., Zhang, R., Bitar, N., and JL. Le Roux,
+              "A Backward-Recursive PCE-Based Computation (BRPC)
+              Procedure to Compute Shortest Constrained Inter-Domain
+              Traffic Engineering Label Switched Paths", RFC 5441,
+              DOI 10.17487/RFC5441, April 2009,
+              <https://www.rfc-editor.org/info/rfc5441>.
+
+   [RFC5512]  Mohapatra, P. and E. Rosen, "The BGP Encapsulation
+              Subsequent Address Family Identifier (SAFI) and the BGP
+              Tunnel Encapsulation Attribute", RFC 5512,
+              DOI 10.17487/RFC5512, April 2009,
+              <https://www.rfc-editor.org/info/rfc5512>.
+
+   [RFC5520]  Bradford, R., Ed., Vasseur, JP., and A. Farrel,
+              "Preserving Topology Confidentiality in Inter-Domain Path
+              Computation Using a Path-Key-Based Mechanism", RFC 5520,
+              DOI 10.17487/RFC5520, April 2009,
+              <https://www.rfc-editor.org/info/rfc5520>.
+
+   [RFC5541]  Le Roux, JL., Vasseur, JP., and Y. Lee, "Encoding of
+              Objective Functions in the Path Computation Element
+              Communication Protocol (PCEP)", RFC 5541,
+              DOI 10.17487/RFC5541, June 2009,
+              <https://www.rfc-editor.org/info/rfc5541>.
+
+
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 88]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
+   [RFC5557]  Lee, Y., Le Roux, JL., King, D., and E. Oki, "Path
+              Computation Element Communication Protocol (PCEP)
+              Requirements and Protocol Extensions in Support of Global
+              Concurrent Optimization", RFC 5557, DOI 10.17487/RFC5557,
+              July 2009, <https://www.rfc-editor.org/info/rfc5557>.
+
+   [RFC6780]  Berger, L., Le Faucheur, F., and A. Narayanan, "RSVP
+              ASSOCIATION Object Extensions", RFC 6780,
+              DOI 10.17487/RFC6780, October 2012,
+              <https://www.rfc-editor.org/info/rfc6780>.
 
    [RFC6991]  Schoenwaelder, J., Ed., "Common YANG Data Types",
               RFC 6991, DOI 10.17487/RFC6991, July 2013,
@@ -4584,25 +4953,44 @@ Internet-Draft          Yang updates for TE Types           October 2022
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
-
-
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 82]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
    [RFC8294]  Liu, X., Qu, Y., Lindem, A., Hopps, C., and L. Berger,
               "Common YANG Data Types for the Routing Area", RFC 8294,
               DOI 10.17487/RFC8294, December 2017,
               <https://www.rfc-editor.org/info/rfc8294>.
 
+   [RFC8306]  Zhao, Q., Dhody, D., Ed., Palleti, R., and D. King,
+              "Extensions to the Path Computation Element Communication
+              Protocol (PCEP) for Point-to-Multipoint Traffic
+              Engineering Label Switched Paths", RFC 8306,
+              DOI 10.17487/RFC8306, November 2017,
+              <https://www.rfc-editor.org/info/rfc8306>.
+
+   [RFC8685]  Zhang, F., Zhao, Q., Gonzalez de Dios, O., Casellas, R.,
+              and D. King, "Path Computation Element Communication
+              Protocol (PCEP) Extensions for the Hierarchical Path
+              Computation Element (H-PCE) Architecture", RFC 8685,
+              DOI 10.17487/RFC8685, December 2019,
+              <https://www.rfc-editor.org/info/rfc8685>.
+
    [RFC8776]  Saad, T., Gandhi, R., Liu, X., Beeram, V., and I. Bryskin,
               "Common YANG Data Types for Traffic Engineering",
               RFC 8776, DOI 10.17487/RFC8776, June 2020,
               <https://www.rfc-editor.org/info/rfc8776>.
+
+
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 89]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
+   [RFC8800]  Litkowski, S., Sivabalan, S., Barth, C., and M. Negi,
+              "Path Computation Element Communication Protocol (PCEP)
+              Extension for Label Switched Path (LSP) Diversity
+              Constraint Signaling", RFC 8800, DOI 10.17487/RFC8800,
+              July 2020, <https://www.rfc-editor.org/info/rfc8800>.
 
 8.2.  Informative References
 
@@ -4613,6 +5001,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
               teas-yang-l3-te-topo-13, 10 July 2022,
               <https://www.ietf.org/archive/id/draft-ietf-teas-yang-l3-
               te-topo-13.txt>.
+
+   [I-D.ietf-teas-yang-path-computation]
+              Busi, I., Belotti, S., de Dios, O. G., Sharma, A., and D.
+              Ceccarelli, "A YANG Data Model for requesting path
+              computation", Work in Progress, Internet-Draft, draft-
+              ietf-teas-yang-path-computation-18, 22 March 2022,
+              <https://www.ietf.org/archive/id/draft-ietf-teas-yang-
+              path-computation-18.txt>.
 
    [I-D.ietf-teas-yang-te]
               Saad, T., Gandhi, R., Liu, X., Beeram, V. P., Bryskin, I.,
@@ -4636,29 +5032,30 @@ Appendix A.  Changes from RFC 8776
 
    To be added in a future revision of this draft.
 
-A.1.  TE Types YANG Diffs
-
-   This section provides the diff between the YANG module in section 3.1
-   of [RFC8776] and the YANG model revision in Section 4.
 
 
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 83]
+Busi, et al.              Expires 24 April 2023                [Page 90]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
+
+A.1.  TE Types YANG Diffs
+
+   RFC Editor Note: please remove this appendix before publication.
+
+   This section provides the diff between the YANG module in section 3.1
+   of [RFC8776] and the YANG model revision in Section 4.
 
    The intention of this appendix is to facilitate focusing the review
    of the YANG model in Section 4 to the changes compared with the YANG
    model in [RFC8776].
 
-   Editors note, please remove this appendix before publication.
-
-   Note - This diff has been generated using the following UNIX commands
-   to compare the YANG module revisions in section 3.1 of [RFC8776] and
-   in Section 4:
+   This diff has been generated using the following UNIX commands to
+   compare the YANG module revisions in section 3.1 of [RFC8776] and in
+   Section 4:
 
   diff ietf-te-types@2020-06-10.yang ietf-te-types.yang > model-diff.txt
   sed 's/^/    /' model-diff.txt > model-diff-spaces.txt
@@ -4666,46 +5063,70 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
    The output (model-updates.txt) is reported here:
 
+  30c30
+  <                <mailto:tsaad@juniper.net>
+  ---
+  >                <mailto:tsaad.net@gmail.com>
   55c55
   <      Copyright (c) 2020 IETF Trust and the persons identified as
   ---
   >      Copyright (c) 2022 IETF Trust and the persons identified as
-  65c65
-  <      This version of this YANG module is part of RFC 8776; see the
+  60c60
+  <      the license terms contained in, the Simplified BSD License set
   ---
-  >      This version of this YANG module is part of RFC XXXX; see the
-  67a68,85
-  >   revision 2022-09-09 {
+  >      the license terms contained in, the Revised BSD License set
+  65,66c65,99
+  <      This version of this YANG module is part of RFC 8776; see the
+  <      RFC itself for full legal notices.";
+  ---
+  >      This version of this YANG module is part of RFC XXXX
+  >      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+  >      for full legal notices.";
+  >
+  >   revision 2022-10-21 {
   >     description
   >       "Added:
   >       - typedef bandwidth-scientific-notation;
+  >       - base identity lsp-provisioning-error-reason;
   >       - identity association-type-diversity;
   >       - identity tunnel-admin-auto;
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 91]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
   >       - base identity path-computation-error-reason and
   >         its derived identities;
+  >       - base identity tunnel-actions-type and its derived
+  >         identities;
   >       - base identity protocol-origin-type and
   >         its derived identities;
-  >       - grouping encoding-and-switching-type.";
+  >       - base identity svec-objective-function-type and its derived
+  >         identities;
+  >       - base identity svec-metric-type and its derived identities;
+  >       - grouping encoding-and-switching-type.
+  >
+  >       Updated:
+  >       - description of the base identity objective-function-type.
+  >
+  >       Obsoleted:
+  >       - identity of-minimize-agg-bandwidth-consumption
+  >       - identity of-minimize-load-most-loaded-link
+  >       - identity of-minimize-cost-path-set";
   >     reference
   >       "RFC XXXX: Updated Common YANG Data Types for Traffic
   >       Engineering";
   >   }
   >   // RFC Editor: replace XXXX with actual RFC number, update date
   >   // information and remove this note
-  >
-  545a564,597
+  545a579,612
   >   // NOTE: The typedef bandwidth-scientific-notation below has been
   >   // added in this module revision
   >   // RFC Editor: remove the note above and this note
   >   typedef bandwidth-scientific-notation {
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 84]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
   >     type string {
   >       pattern
   >         '0(\.0?)?([eE](\+)?0?)?|'
@@ -4725,6 +5146,14 @@ Internet-Draft          Yang updates for TE Types           October 2022
   >       for decimal32, and from -38 to +38 for binary32.
   >       As a bandwidth value, the format is restricted to be
   >       normalized, non-negative, and non-fraction:
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 92]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
   >       n.dddddde{+}dd, N.DDDDDDE{+}DD, 0e0 or 0E0,
   >       where 'd' and 'D' are decimal digits; 'n' and 'N' are
   >       non-zeror decimal digits; 'e' and 'E' indicate a power of ten.
@@ -4736,41 +5165,92 @@ Internet-Draft          Yang updates for TE Types           October 2022
   >       Languages - C.";
   >   }
   >
-  982a1035,1046
+  606a674,681
+  >   // NOTE: The base identity lsp-provisioning-error-reason has been
+  >   // added in this module revision
+  >   // RFC Editor: remove the note above and this note
+  >   identity lsp-provisioning-error-reason {
+  >     description
+  >       "Base identity for LSP provisioning errors.";
+  >   }
+  >
+  982a1058,1073
   >   // NOTE: The identity association-type-diversity below has been
   >   // added in this module revision
   >   // RFC Editor: remove the note above and this note
   >   identity association-type-diversity {
   >     base association-type;
   >     description
-  >       "Association Type diversity used to associate LSPs whose paths
-  >        are to be diverse from each other.";
+  >       "Association Type diversity used to associate LSPs whose
+  >       paths are to be diverse from each other.";
   >     reference
   >       "RFC8800";
   >   }
   >
-  1216a1281,1292
-  >   // NOTE: The identity tunnel-admin-auto below has been
-  >   // added in this module revision
+  >   // NOTE: The description of the base identity
+  >   // objective-function-type has been updated
+  >   // in this module revision
   >   // RFC Editor: remove the note above and this note
-  >   identity tunnel-admin-auto {
+  985c1076
+  <       "Base objective function type.";
+  ---
+  >       "Base identity for path objective function type.";
+  1015a1107,1109
+  >   // NOTE: The identity of-minimize-agg-bandwidth-consumption
+  >   // below has been obsoleted in this module revision
+  >   // RFC Editor: remove the note above and this note
+  1017a1112
+  >     status obsolete;
+  1020c1115
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 85]
+Busi, et al.              Expires 24 April 2023                [Page 93]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
 
+  <        consumption.";
+  ---
+  >       consumption.";
+  1023c1118
+  <        Computation Element Communication Protocol (PCEP)";
+  ---
+  >       Computation Element Communication Protocol (PCEP)";
+  1025a1121,1123
+  >   // NOTE: The identity of-minimize-load-most-loaded-link
+  >   // below has been obsoleted in this module revision
+  >   // RFC Editor: remove the note above and this note
+  1027a1126
+  >     status obsolete;
+  1030c1129
+  <        is carrying the highest load.";
+  ---
+  >       is carrying the highest load.";
+  1033c1132
+  <        Computation Element Communication Protocol (PCEP)";
+  ---
+  >       Computation Element Communication Protocol (PCEP)";
+  1035a1135,1137
+  >   // NOTE: The identity of-minimize-cost-path-set
+  >   // below has been obsoleted in this module revision
+  >   // RFC Editor: remove the note above and this note
+  1037a1140
+  >     status obsolete;
+  1216a1320,1331
+  >   // NOTE: The identity tunnel-admin-auto below has been
+  >   // added in this module revision
+  >   // RFC Editor: remove the note above and this note
+  >   identity tunnel-admin-auto {
   >     base tunnel-admin-state-type;
   >     description
   >       "Tunnel administrative auto state. The administrative status
-  >        in state datastore transitions to 'tunnel-admin-up' when the
-  >        tunnel used by the client layer, and to 'tunnel-admin-down'
-  >        when it is not used by the client layer.";
+  >       in state datastore transitions to 'tunnel-admin-up' when the
+  >       tunnel used by the client layer, and to 'tunnel-admin-down'
+  >       when it is not used by the client layer.";
   >   }
   >
-  2110a2187,2391
+  2110a2226,2569
   >   // NOTE: The base identity path-computation-error-reason and
   >   // its derived identities below have been
   >   // added in this module revision
@@ -4778,182 +5258,191 @@ Internet-Draft          Yang updates for TE Types           October 2022
   >   identity path-computation-error-reason {
   >     description
   >       "Base identity for path computation error reasons.";
-  >   }
-  >
-  >   identity path-computation-error-no-topology {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because there is no topology
-  >        with the provided topology-identifier.";
-  >   }
-  >
-  >   identity path-computation-error-no-dependent-server {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because one or more dependent
-  >        path computation servers are unavailable.
-  >        The dependent path computation server could be
-  >        a Backward-Recursive Path Computation (BRPC) downstream
-  >        PCE or a child PCE.";
-  >     reference
-  >       "RFC5441, RFC8685";
-  >   }
-  >
-  >   identity path-computation-error-pce-unavailable {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because PCE is not available.";
-  >     reference
-  >       "RFC5440";
-  >   }
-  >
-  >   identity path-computation-error-no-inclusion-hop {
-  >     base path-computation-error-reason;
-  >     description
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 86]
+Busi, et al.              Expires 24 April 2023                [Page 94]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
 
-  >       "Path computation has failed because there is no
-  >        node or link provided by one or more inclusion hops.";
-  >     reference
-  >       "RFC8685";
   >   }
   >
-  >   identity path-computation-error-destination-unknown-in-domain {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because the destination node is
-  >        unknown in indicated destination domain.";
-  >     reference
-  >       "RFC8685";
-  >   }
+  >     identity path-computation-error-no-topology {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because there is no topology
+  >         with the provided topology-identifier.";
+  >     }
   >
-  >   identity path-computation-error-no-resource {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because there is no
-  >        available resource in one or more domains.";
-  >     reference
-  >       "RFC8685";
-  >   }
+  >     identity path-computation-error-no-dependent-server {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because one or more dependent
+  >         path computation servers are unavailable.
+  >         The dependent path computation server could be
+  >         a Backward-Recursive Path Computation (BRPC) downstream
+  >         PCE or a child PCE.";
+  >       reference
+  >         "RFC5441, RFC8685";
+  >     }
   >
-  >   identity path-computation-error-child-pce-unresponsive {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because child PCE is not
-  >        responsive.";
-  >     reference
-  >       "RFC8685";
-  >   }
+  >     identity path-computation-error-pce-unavailable {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because PCE is not available.";
+  >       reference
+  >         "RFC5440";
+  >     }
   >
-  >   identity path-computation-error-destination-domain-unknown {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because the destination domain
-  >        was unknown.";
-  >     reference
-  >       "RFC8685";
-  >   }
+  >     identity path-computation-error-no-inclusion-hop {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because there is no
+  >         node or link provided by one or more inclusion hops.";
+  >       reference
+  >         "RFC8685";
+  >     }
   >
-  >   identity path-computation-error-p2mp {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because of P2MP reachability
-  >        problem.";
-  >     reference
+  >     identity path-computation-error-destination-unknown-in-domain {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because the destination node is
+  >         unknown in indicated destination domain.";
+  >       reference
+  >         "RFC8685";
+  >     }
+  >
+  >     identity path-computation-error-no-resource {
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 87]
+Busi, et al.              Expires 24 April 2023                [Page 95]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
 
-  >       "RFC8306";
-  >   }
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because there is no
+  >         available resource in one or more domains.";
+  >       reference
+  >         "RFC8685";
+  >     }
   >
-  >   identity path-computation-error-no-gco-migration {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because of no Global Concurrent
-  >        Optimization (GCO) migration path found.";
-  >     reference
-  >       "RFC5557";
-  >   }
+  >     identity path-computation-error-child-pce-unresponsive {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because child PCE is not
+  >         responsive.";
+  >       reference
+  >         "RFC8685";
+  >     }
   >
-  >   identity path-computation-error-no-gco-solution {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because of no GCO solution
-  >        found.";
-  >     reference
-  >       "RFC5557";
-  >   }
+  >     identity path-computation-error-destination-domain-unknown {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because the destination domain
+  >         was unknown.";
+  >       reference
+  >         "RFC8685";
+  >     }
   >
-  >   identity path-computation-error-path-not-found {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation no path found error reason.";
-  >     reference
-  >       "RFC5440";
-  >   }
+  >     identity path-computation-error-p2mp {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because of P2MP reachability
+  >         problem.";
+  >       reference
+  >         "RFC8306";
+  >     }
   >
-  >   identity path-computation-error-pks-expansion {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because of Path-Key Subobject
-  >        (PKS)  expansion failure.";
-  >     reference
-  >       "RFC5520";
-  >   }
+  >     identity path-computation-error-no-gco-migration {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because of no Global Concurrent
+  >         Optimization (GCO) migration path found.";
+  >       reference
+  >         "RFC5557";
+  >     }
   >
-  >   identity path-computation-error-brpc-chain-unavailable {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because PCE BRPC chain
-  >        unavailable.";
-  >     reference
-  >       "RFC5441";
-  >   }
-  >
-  >   identity path-computation-error-source-unknown {
+  >     identity path-computation-error-no-gco-solution {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because of no GCO solution
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 88]
+Busi, et al.              Expires 24 April 2023                [Page 96]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
 
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because source node is unknown.";
-  >     reference
-  >       "RFC5440";
-  >   }
+  >         found.";
+  >       reference
+  >         "RFC5557";
+  >     }
   >
-  >   identity path-computation-error-destination-unknown {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because destination node is
-  >        unknown.";
-  >     reference
-  >       "RFC5440";
-  >   }
+  >     identity path-computation-error-path-not-found {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation no path found error reason.";
+  >       reference
+  >         "RFC5440";
+  >     }
   >
-  >   identity path-computation-error-no-server {
-  >     base path-computation-error-reason;
-  >     description
-  >       "Path computation has failed because path computation
-  >        server is unavailable.";
-  >     reference
-  >       "RFC5440";
-  >   }
+  >     identity path-computation-error-pks-expansion {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because of Path-Key Subobject
+  >         (PKS)  expansion failure.";
+  >       reference
+  >         "RFC5520";
+  >     }
+  >
+  >     identity path-computation-error-brpc-chain-unavailable {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because PCE BRPC chain
+  >         unavailable.";
+  >       reference
+  >         "RFC5441";
+  >     }
+  >
+  >     identity path-computation-error-source-unknown {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because source node is
+  >         unknown.";
+  >       reference
+  >         "RFC5440";
+  >     }
+  >
+  >     identity path-computation-error-destination-unknown {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because destination node is
+  >         unknown.";
+  >       reference
+  >         "RFC5440";
+  >     }
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 97]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
+  >
+  >     identity path-computation-error-no-server {
+  >       base path-computation-error-reason;
+  >       description
+  >         "Path computation has failed because path computation
+  >         server is unavailable.";
+  >       reference
+  >         "RFC5440";
+  >     }
   >
   >   // NOTE: The base identity tunnel-actions-type and
   >   // its derived identities below have been
@@ -4964,12 +5453,6 @@ Internet-Draft          Yang updates for TE Types           October 2022
   >       "TE tunnel actions type.";
   >   }
   >
-  >   identity tunnel-action-reoptimize {
-  >     base tunnel-actions-type;
-  >     description
-  >       "Reoptimize tunnel action type.";
-  >   }
-  >
   >   // NOTE: The base identity protocol-origin-type and
   >   // its derived identities below have been
   >   // added in this module revision
@@ -4978,39 +5461,208 @@ Internet-Draft          Yang updates for TE Types           October 2022
   >     description
   >       "Base identity for protocol origin type.";
   >   }
+  >
+  >     identity protocol-origin-api {
+  >       base protocol-origin-type;
+  >       description
+  >         "Protocol origin is via Application Programmable Interface
+  >         (API).";
+  >     }
+  >
+  >     identity protocol-origin-pcep {
+  >       base protocol-origin-type;
+  >       description
+  >         "Protocol origin is Path Computation Engine Protocol
+  >         (PCEP).";
+  >       reference "RFC5440";
+  >     }
+  >
+  >     identity protocol-origin-bgp {
+  >       base protocol-origin-type;
+  >       description
+  >         "Protocol origin is Border Gateway Protocol (BGP).";
+  >       reference "RFC5512";
 
 
 
-Busi, et al.              Expires 24 April 2023                [Page 89]
+Busi, et al.              Expires 24 April 2023                [Page 98]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
+  >     }
+  >
+  >   // NOTE: The base identity svec-objective-function-type and
+  >   // its derived identities below have been
+  >   // added in this module revision
+  >   // RFC Editor: remove the note above and this note
+  >   identity svec-objective-function-type {
+  >     description
+  >       "Base identity for SVEC objective function type.";
+  >     reference
+  >       "RFC5541: Encoding of Objective Functions in the Path
+  >        Computation Element Communication Protocol (PCEP).";
+  >   }
+  >
+  >     identity svec-of-minimize-agg-bandwidth-consumption {
+  >       base svec-objective-function-type;
+  >       description
+  >         "Objective function for minimizing aggregate bandwidth
+  >         consumption (MBC).";
+  >       reference
+  >         "RFC5541: Encoding of Objective Functions in the Path
+  >         Computation Element Communication Protocol (PCEP).";
+  >     }
+  >
+  >     identity svec-of-minimize-load-most-loaded-link {
+  >       base svec-objective-function-type;
+  >       description
+  >         "Objective function for minimizing the load on the link that
+  >         is carrying the highest load (MLL).";
+  >       reference
+  >         "RFC5541: Encoding of Objective Functions in the Path
+  >         Computation Element Communication Protocol (PCEP).";
+  >     }
+  >
+  >     identity svec-of-minimize-cost-path-set {
+  >       base svec-objective-function-type;
+  >       description
+  >         "Objective function for minimizing the cost on a path set
+  >         (MCC).";
+  >       reference
+  >         "RFC5541: Encoding of Objective Functions in the Path
+  >         Computation Element Communication Protocol (PCEP).";
+  >     }
+  >
+  >     identity svec-of-minimize-common-transit-domain {
+  >       base svec-objective-function-type;
+  >       description
+  >         "Objective function for minimizing the number of common
+
+
+
+Busi, et al.              Expires 24 April 2023                [Page 99]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
+  >         transit domains (MCTD).";
+  >       reference
+  >         "RFC8685: Path Computation Element Communication Protocol
+  >         (PCEP) Extensions for the Hierarchical Path Computation
+  >         Element (H-PCE) Architecture.";
+  >     }
+  >
+  >     identity svec-of-minimize-shared-link {
+  >       base svec-objective-function-type;
+  >       description
+  >         "Objective function for minimizing the number of shared
+  >         links (MSL).";
+  >       reference
+  >         "RFC8685: Path Computation Element Communication Protocol
+  >         (PCEP) Extensions for the Hierarchical Path Computation
+  >         Element (H-PCE) Architecture.";
+  >     }
+  >
+  >     identity svec-of-minimize-shared-srlg {
+  >       base svec-objective-function-type;
+  >       description
+  >         "Objective function for minimizing the number of shared
+  >         Shared Risk Link Groups (SRLG) (MSS).";
+  >       reference
+  >         "RFC8685: Path Computation Element Communication Protocol
+  >         (PCEP) Extensions for the Hierarchical Path Computation
+  >         Element (H-PCE) Architecture.";
+  >     }
+  >
+  >     identity svec-of-minimize-shared-nodes {
+  >       base svec-objective-function-type;
+  >       description
+  >         "Objective function for minimizing the number of shared
+  >         nodes (MSN).";
+  >       reference
+  >         "RFC8685: Path Computation Element Communication Protocol
+  >         (PCEP) Extensions for the Hierarchical Path Computation
+  >         Element (H-PCE) Architecture.";
+  >     }
+  >
+  >   // NOTE: The base identity svec-metric-type and
+  >   // its derived identities below have been
+  >   // added in this module revision
+  >   // RFC Editor: remove the note above and this note
+  >   identity svec-metric-type {
+  >     description
+  >       "Base identity for SVEC metric type.";
+  >     reference
+
+
+
+Busi, et al.              Expires 24 April 2023               [Page 100]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
+  >       "RFC5541: Encoding of Objective Functions in the Path
+  >        Computation Element Communication Protocol (PCEP).";
+  >   }
+  >
+  >     identity svec-metric-cumul-te {
+  >       base svec-metric-type;
+  >       description
+  >         "Cumulative TE cost.";
+  >       reference
+  >         "RFC5541: Encoding of Objective Functions in the Path
+  >         Computation Element Communication Protocol (PCEP).";
+  >     }
+  >
+  >     identity svec-metric-cumul-igp {
+  >       base svec-metric-type;
+  >       description
+  >         "Cumulative IGP cost.";
+  >       reference
+  >         "RFC5541: Encoding of Objective Functions in the Path
+  >         Computation Element Communication Protocol (PCEP).";
+  >     }
+  >
+  >     identity svec-metric-cumul-hop {
+  >       base svec-metric-type;
+  >       description
+  >         "Cumulative Hop path metric.";
+  >       reference
+  >         "RFC5541: Encoding of Objective Functions in the Path
+  >         Computation Element Communication Protocol (PCEP).";
+  >     }
+  >
+  >     identity svec-metric-aggregate-bandwidth-consumption {
+  >       base svec-metric-type;
+  >       description
+  >         "Aggregate bandwidth consumption.";
+  >       reference
+  >         "RFC5541: Encoding of Objective Functions in the Path
+  >         Computation Element Communication Protocol (PCEP).";
+  >     }
+  >
+  >     identity svec-metric-load-of-the-most-loaded-link {
+  >       base svec-metric-type;
+  >       description
+  >         "Load of the most loaded link.";
+  >       reference
+  >         "RFC5541: Encoding of Objective Functions in the Path
+  >         Computation Element Communication Protocol (PCEP).";
+  >     }
+
+
+
+Busi, et al.              Expires 24 April 2023               [Page 101]
 
 Internet-Draft          Yang updates for TE Types           October 2022
 
 
   >
-  >   identity protocol-origin-api {
-  >     base protocol-origin-type;
-  >     description
-  >       "Protocol origin is via Application Programmable Interface
-  >        (API).";
-  >   }
-  >
-  >   identity protocol-origin-pcep {
-  >     base protocol-origin-type;
-  >     description
-  >       "Protocol origin is Path Computation Engine Protocol (PCEP).";
-  >     reference "RFC5440";
-  >   }
-  >
-  >   identity protocol-origin-bgp {
-  >     base protocol-origin-type;
-  >     description
-  >       "Protocol origin is Border Gateway Protocol (BGP).";
-  >     reference "RFC5512";
-  >   }
-  >
-  3376a3658,3684
-  >     }
-  >   }
+  3379c3838,3865
+  < }
+  \ No newline at end of file
+  ---
   >
   >   // NOTE: The grouping encoding-and-switching-type below has been
   >   // added in this module revision
@@ -5034,24 +5686,33 @@ Internet-Draft          Yang updates for TE Types           October 2022
   >       }
   >       description
   >         "LSP switching type.";
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 90]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
   >       reference
   >         "RFC3945";
+  >     }
+  >   }
+  > }
 
 Appendix B.  Option Considered for updating RFC8776
+
+   RFC Editor Note: please remove this appendix before publication.
 
    The concern is how to be able to update the ietf-te-types YANG module
    published in [RFC8776] without delaying too much the progress of the
    mature WG documents.
 
    Three possible options have been identified to address this concern.
+
+
+
+
+
+
+
+
+Busi, et al.              Expires 24 April 2023               [Page 102]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
 
    One option is to keep these definitions in the YANG modules where
    they have initially been defined: other YANG modules can still import
@@ -5089,15 +5750,6 @@ Appendix B.  Option Considered for updating RFC8776
    removed before publication, to focus the review only to the updates
    to the ietf-te-types YANG module proposed by this document.
 
-
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 91]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
    During the Netmod WG session at IETF 114, an alternative process has
    been introduced:
 
@@ -5110,11 +5762,17 @@ Internet-Draft          Yang updates for TE Types           October 2022
    Therefore, in order to avoid useless editorial work, this version of
    the document has been structured to become an RFC8776-bis but not all
    the existing text in [RFC8776] has been copied: some editors' notes
+
+
+
+Busi, et al.              Expires 24 April 2023               [Page 103]
+
+Internet-Draft          Yang updates for TE Types           October 2022
+
+
    has been inserted instead.  These editors' note will be removed and
    replaced by actual text copied from [RFC8776] before WG LC if the
    RFC8776-bis approach is confirmed.
-
-   Editors note, please remove this appendix before publication.
 
 Acknowledgements
 
@@ -5147,13 +5805,6 @@ Authors' Addresses
    Email: tsaad@juniper.net
 
 
-
-
-Busi, et al.              Expires 24 April 2023                [Page 92]
-
-Internet-Draft          Yang updates for TE Types           October 2022
-
-
    Rakesh Gandhi
    Cisco Systems, Inc.
    Email: rgandhi@cisco.com
@@ -5170,39 +5821,4 @@ Internet-Draft          Yang updates for TE Types           October 2022
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Busi, et al.              Expires 24 April 2023                [Page 93]
+Busi, et al.              Expires 24 April 2023               [Page 104]

--- a/drafts/te-types-update/draft-ietf-teas-rfc8776-update.xml
+++ b/drafts/te-types-update/draft-ietf-teas-rfc8776-update.xml
@@ -69,7 +69,7 @@
     <abstract>
 
 
-<t>This document defines few additional common data types and groupings
+<t>This document defines few additional common data types, identities, and groupings
    in YANG data modeling language to be imported by modules that model Traffic
    Engineering (TE) configuration and state capabilities.</t>
 
@@ -91,13 +91,13 @@
 
 <section anchor="introduction"><name>Introduction</name>
 
-<t>After the publication of <xref target="RFC8776"/>, a new typedef and a new grouping to ietf-te-types have been defined. Given their broad applicability this document defines them as part of the ietf-te-types YANG model.</t>
+<t>After the publication of <xref target="RFC8776"/>, few additional common data types, identities, and groupings have been defined. Given their broad applicability this document defines them as part of the revised ietf-te-types YANG model.</t>
 
 <t>Editors' note: Copy the text from <xref target="RFC8776"/> and merge it with the content of this section before WG LC if the RFC8876-bis approach is confirmed.</t>
 
-<t>NOTE: These definitions have been developed in <xref target="I-D.ietf-teas-yang-te"/> and <xref target="I-D.ietf-teas-yang-l3-te-topo"/> and are quite mature: <xref target="I-D.ietf-teas-yang-te"/> in particular is ready from WG Last Call.</t>
+<t>CHANGE NOTE: These definitions have been developed in <xref target="I-D.ietf-teas-yang-te"/>, <xref target="I-D.ietf-teas-yang-path-computation"/> and <xref target="I-D.ietf-teas-yang-l3-te-topo"/> and are quite mature: <xref target="I-D.ietf-teas-yang-te"/> and <xref target="I-D.ietf-teas-yang-path-computation"/> in particular are in WG Last Call and some definitions have been moved to this document as part of WG LC comments resolution.</t>
 
-<t>RFC Editor: remove the note above and this note</t>
+<t>RFC Editor: remove the CHANGE NOTE above and this note</t>
 
 <section anchor="requirements-notation"><name>Requirements Notation</name>
 
@@ -156,20 +156,81 @@ appear in all capitals, as shown here.</t>
 
 <t>Editors' note: Copy the text from <xref target="RFC8776"/> and merge it with the content of this section before WG LC if the RFC8876-bis approach is confirmed.</t>
 
-<t>The module ietf-te-types has been updated to add the following
-   YANG identies, types and groupings which can be reused by TE YANG models:</t>
+<t>The module ietf-te-types updates the following YANG identities defined in <xref target="RFC8776"/>:</t>
 
-<dl>
-  <dt>bandwidth-scientific-notation</dt>
-  <dd>
-    <t>This types represents the bandwidth in
-bit-per-second, using the scientific notation (e.g., 10e3).</t>
-  </dd>
-  <dt>encoding-and-switching-type</dt>
-  <dd>
-    <t>This is a common grouping to define the LSP encoding and switching types.</t>
-  </dd>
-</dl>
+<t>association-type:</t>
+
+<ul empty="true"><li>
+  <t>A base YANG identity for supported LSP association types as defined in <xref target="RFC6780"/>, <xref target="RFC4872"/>, <xref target="RFC4873"/> and <xref target="RFC8800"/></t>
+</li></ul>
+
+<t>objective-function-type:</t>
+
+<ul empty="true"><li>
+  <t>A base YANG identity for supported path objective functions, as defined in <xref target="RFC5541"/>.</t>
+</li></ul>
+
+<t>CHANGE NOTE: The association-type-diversity identity, defined in <xref target="RFC8800"/> has been added to the association-type base identity. The of-minimize-agg-bandwidth-consumption, of-minimize-load-most-loaded-link and of-minimize-cost-path-set, defined in <xref target="RFC5541"/>, have been obsoleted because not applicable to paths but to Synchronization VECtor (SVEC) objects.</t>
+
+<t>RFC Editor: remove the CHANGE NOTE above and this note</t>
+
+<t>The module ietf-te-types has been updated to add the following YANG identities, types and groupings which can be reused by TE YANG models:</t>
+
+<t>bandwidth-scientific-notation:</t>
+
+<ul empty="true"><li>
+  <t>This data type represents the bandwidth in bit-per-second, using the scientific notation (e.g., 10e3).</t>
+</li></ul>
+
+<t>lsp-provisioning-error-reason:</t>
+
+<ul empty="true"><li>
+  <t>A base YANG identity for reporting LSP provisioning error reasons. No standard LPS provisioning error reasons are defined in this document.</t>
+</li></ul>
+
+<t>identity path-computation-error-reason:</t>
+
+<ul empty="true"><li>
+  <t>A base YANG identity for reporting path computation error reasons, as defined in <xref target="RFC5440"/>, <xref target="RFC5441"/>, <xref target="RFC5520"/>, <xref target="RFC5557"/>, <xref target="RFC8306"/> and <xref target="RFC8685"/>.</t>
+</li></ul>
+
+<t>Editors' Note: how to describe the path computation error reasons defined in this document?</t>
+
+<t>tunnel-actions-type:</t>
+
+<ul empty="true"><li>
+  <t>A base YANG identity for tunnel actions.</t>
+</li></ul>
+
+<t>Editors' Note: check whether standard tunnel actions should be defined in this document or not.</t>
+
+<t>protocol-origin-type:</t>
+
+<ul empty="true"><li>
+  <t>A base YANG identity for the type of protocol origin, as defined in <xref target="RFC5440"/> and <xref target="RFC5512"/>.</t>
+</li></ul>
+
+<t>Editors' Note: how to describe the protocol origin types defined in this document?</t>
+
+<t>svec-objective-function-type:</t>
+
+<ul empty="true"><li>
+  <t>A base YANG identity for supported SVEC objective functions, as defined in <xref target="RFC5541"/> and <xref target="RFC8685"/>.</t>
+</li></ul>
+
+<t>svec-metric-type:</t>
+
+<ul empty="true"><li>
+  <t>A base YANG identity for supported SVEC objective functions, as defined in <xref target="RFC5541"/>.</t>
+</li></ul>
+
+<t>encoding-and-switching-type:</t>
+
+<ul empty="true"><li>
+  <t>This is a common grouping to define the LSP encoding and switching types.</t>
+</li></ul>
+
+<t>Editors' Note: how to describe the tunnel-admin-auto, which is defined in this document as derived from tunnel-admin-status-type base identity?</t>
 
 </section>
 <section anchor="packet-te-types-module-contents"><name>Packet TE Types Module Contents</name>
@@ -185,13 +246,11 @@ bit-per-second, using the scientific notation (e.g., 10e3).</t>
 <t>This section provides the updated revision of the "ietf-te-types"
 YANG module.</t>
 
-<t>NOTE: Only the typedef bandwidth-scientific-notation and 
-the grouping encoding-and-switching-type have been added
-in this module revision. Please focus your review on this part. See also <xref target="yang-diff"/>.</t>
+<t>CHANGE NOTE: Please focus your review only on the updates to the YANG model: see also <xref target="yang-diff"/>.</t>
 
-<t>RFC Editor: remove the note above and this note</t>
+<t>RFC Editor: remove the CHANGE NOTE above and this note</t>
 
-<figure title="TE Types YANG module" anchor="fig-pc-yang"><sourcecode type="yang" markers="true" name="ietf-te-types@2022-10-15.yang"><![CDATA[
+<figure title="TE Types YANG module" anchor="fig-pc-yang"><sourcecode type="yang" markers="true" name="ietf-te-types@2022-10-21.yang"><![CDATA[
 module ietf-te-types {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-te-types";
@@ -260,17 +319,31 @@ module ietf-te-types {
      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
      for full legal notices.";
 
-  revision 2022-10-15 {
+  revision 2022-10-21 {
     description
       "Added:
       - typedef bandwidth-scientific-notation;
+      - base identity lsp-provisioning-error-reason;
       - identity association-type-diversity;
       - identity tunnel-admin-auto;
       - base identity path-computation-error-reason and
         its derived identities;
+      - base identity tunnel-actions-type and its derived 
+        identities;
       - base identity protocol-origin-type and
         its derived identities;
-      - grouping encoding-and-switching-type.";
+      - base identity svec-objective-function-type and its derived
+        identities;
+      - base identity svec-metric-type and its derived identities;
+      - grouping encoding-and-switching-type.
+      
+      Updated:
+      - description of the base identity objective-function-type.
+      
+      Obsoleted:
+      - identity of-minimize-agg-bandwidth-consumption
+      - identity of-minimize-load-most-loaded-link
+      - identity of-minimize-cost-path-set";
     reference
       "RFC XXXX: Updated Common YANG Data Types for Traffic
       Engineering";
@@ -851,6 +924,9 @@ module ietf-te-types {
    * Identities
    */
 
+  // NOTE: The base identity lsp-provisioning-error-reason has been
+  // added in this module revision
+  // RFC Editor: remove the note above and this note
   identity lsp-provisioning-error-reason {
     description
       "Base identity for LSP provisioning errors.";
@@ -1238,15 +1314,21 @@ module ietf-te-types {
   identity association-type-diversity {
     base association-type;
     description
-      "Association Type diversity used to associate LSPs whose paths
-       are to be diverse from each other.";
+      "Association Type diversity used to associate LSPs whose 
+      paths are to be diverse from each other.";
     reference
-      "RFC8800";
+      "RFC8800: Path Computation Element Communication Protocol 
+      (PCEP) Extension for Label Switched Path (LSP) Diversity 
+      Constraint Signaling";
   }
 
+  // NOTE: The description of the base identity 
+  // objective-function-type has been updated 
+  // in this module revision
+  // RFC Editor: remove the note above and this note
   identity objective-function-type {
     description
-      "Base objective function type.";
+      "Base identity for path objective function type.";
   }
 
   identity of-minimize-cost-path {
@@ -1277,28 +1359,40 @@ module ietf-te-types {
        Computation Element Communication Protocol (PCEP)";
   }
 
+  // NOTE: The identity of-minimize-agg-bandwidth-consumption
+  // below has been obsoleted in this module revision
+  // RFC Editor: remove the note above and this note
   identity of-minimize-agg-bandwidth-consumption {
     base objective-function-type;
+    status obsolete;
     description
       "Objective function for minimizing aggregate bandwidth
-       consumption.";
+      consumption.";
     reference
       "RFC 5541: Encoding of Objective Functions in the Path
-       Computation Element Communication Protocol (PCEP)";
+      Computation Element Communication Protocol (PCEP)";
   }
 
+  // NOTE: The identity of-minimize-load-most-loaded-link
+  // below has been obsoleted in this module revision
+  // RFC Editor: remove the note above and this note
   identity of-minimize-load-most-loaded-link {
     base objective-function-type;
+    status obsolete;
     description
       "Objective function for minimizing the load on the link that
-       is carrying the highest load.";
+      is carrying the highest load.";
     reference
       "RFC 5541: Encoding of Objective Functions in the Path
-       Computation Element Communication Protocol (PCEP)";
+      Computation Element Communication Protocol (PCEP)";
   }
 
+  // NOTE: The identity of-minimize-cost-path-set
+  // below has been obsoleted in this module revision
+  // RFC Editor: remove the note above and this note
   identity of-minimize-cost-path-set {
     base objective-function-type;
+    status obsolete;
     description
       "Objective function for minimizing the cost on a path set.";
     reference
@@ -1485,9 +1579,9 @@ module ietf-te-types {
     base tunnel-admin-state-type;
     description
       "Tunnel administrative auto state. The administrative status
-       in state datastore transitions to 'tunnel-admin-up' when the
-       tunnel used by the client layer, and to 'tunnel-admin-down'
-       when it is not used by the client layer.";
+      in state datastore transitions to 'tunnel-admin-up' when the
+      tunnel used by the client layer, and to 'tunnel-admin-down'
+      when it is not used by the client layer.";
   }
 
   identity tunnel-state-type {
@@ -2393,156 +2487,157 @@ module ietf-te-types {
       "Base identity for path computation error reasons.";
   }
 
-  identity path-computation-error-no-topology {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because there is no topology
-       with the provided topology-identifier.";
-  }
+    identity path-computation-error-no-topology {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because there is no topology
+        with the provided topology-identifier.";
+    }
 
-  identity path-computation-error-no-dependent-server {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because one or more dependent
-       path computation servers are unavailable.
-       The dependent path computation server could be
-       a Backward-Recursive Path Computation (BRPC) downstream
-       PCE or a child PCE.";
-    reference
-      "RFC5441, RFC8685";
-  }
+    identity path-computation-error-no-dependent-server {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because one or more dependent
+        path computation servers are unavailable.
+        The dependent path computation server could be
+        a Backward-Recursive Path Computation (BRPC) downstream
+        PCE or a child PCE.";
+      reference
+        "RFC5441, RFC8685";
+    }
 
-  identity path-computation-error-pce-unavailable {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because PCE is not available.";
-    reference
-      "RFC5440";
-  }
+    identity path-computation-error-pce-unavailable {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because PCE is not available.";
+      reference
+        "RFC5440";
+    }
 
-  identity path-computation-error-no-inclusion-hop {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because there is no
-       node or link provided by one or more inclusion hops.";
-    reference
-      "RFC8685";
-  }
+    identity path-computation-error-no-inclusion-hop {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because there is no
+        node or link provided by one or more inclusion hops.";
+      reference
+        "RFC8685";
+    }
 
-  identity path-computation-error-destination-unknown-in-domain {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because the destination node is
-       unknown in indicated destination domain.";
-    reference
-      "RFC8685";
-  }
+    identity path-computation-error-destination-unknown-in-domain {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because the destination node is
+        unknown in indicated destination domain.";
+      reference
+        "RFC8685";
+    }
 
-  identity path-computation-error-no-resource {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because there is no
-       available resource in one or more domains.";
-    reference
-      "RFC8685";
-  }
+    identity path-computation-error-no-resource {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because there is no
+        available resource in one or more domains.";
+      reference
+        "RFC8685";
+    }
 
-  identity path-computation-error-child-pce-unresponsive {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because child PCE is not
-       responsive.";
-    reference
-      "RFC8685";
-  }
+    identity path-computation-error-child-pce-unresponsive {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because child PCE is not
+        responsive.";
+      reference
+        "RFC8685";
+    }
 
-  identity path-computation-error-destination-domain-unknown {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because the destination domain
-       was unknown.";
-    reference
-      "RFC8685";
-  }
+    identity path-computation-error-destination-domain-unknown {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because the destination domain
+        was unknown.";
+      reference
+        "RFC8685";
+    }
 
-  identity path-computation-error-p2mp {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because of P2MP reachability
-       problem.";
-    reference
-      "RFC8306";
-  }
+    identity path-computation-error-p2mp {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because of P2MP reachability
+        problem.";
+      reference
+        "RFC8306";
+    }
 
-  identity path-computation-error-no-gco-migration {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because of no Global Concurrent
-       Optimization (GCO) migration path found.";
-    reference
-      "RFC5557";
-  }
+    identity path-computation-error-no-gco-migration {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because of no Global Concurrent
+        Optimization (GCO) migration path found.";
+      reference
+        "RFC5557";
+    }
 
-  identity path-computation-error-no-gco-solution {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because of no GCO solution
-       found.";
-    reference
-      "RFC5557";
-  }
+    identity path-computation-error-no-gco-solution {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because of no GCO solution
+        found.";
+      reference
+        "RFC5557";
+    }
 
-  identity path-computation-error-path-not-found {
-    base path-computation-error-reason;
-    description
-      "Path computation no path found error reason.";
-    reference
-      "RFC5440";
-  }
+    identity path-computation-error-path-not-found {
+      base path-computation-error-reason;
+      description
+        "Path computation no path found error reason.";
+      reference
+        "RFC5440";
+    }
 
-  identity path-computation-error-pks-expansion {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because of Path-Key Subobject
-       (PKS)  expansion failure.";
-    reference
-      "RFC5520";
-  }
+    identity path-computation-error-pks-expansion {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because of Path-Key Subobject
+        (PKS)  expansion failure.";
+      reference
+        "RFC5520";
+    }
 
-  identity path-computation-error-brpc-chain-unavailable {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because PCE BRPC chain
-       unavailable.";
-    reference
-      "RFC5441";
-  }
+    identity path-computation-error-brpc-chain-unavailable {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because PCE BRPC chain
+        unavailable.";
+      reference
+        "RFC5441";
+    }
 
-  identity path-computation-error-source-unknown {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because source node is unknown.";
-    reference
-      "RFC5440";
-  }
+    identity path-computation-error-source-unknown {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because source node is 
+        unknown.";
+      reference
+        "RFC5440";
+    }
 
-  identity path-computation-error-destination-unknown {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because destination node is
-       unknown.";
-    reference
-      "RFC5440";
-  }
+    identity path-computation-error-destination-unknown {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because destination node is
+        unknown.";
+      reference
+        "RFC5440";
+    }
 
-  identity path-computation-error-no-server {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because path computation
-       server is unavailable.";
-    reference
-      "RFC5440";
-  }
+    identity path-computation-error-no-server {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because path computation
+        server is unavailable.";
+      reference
+        "RFC5440";
+    }
 
   // NOTE: The base identity tunnel-actions-type and 
   // its derived identities below have been
@@ -2562,26 +2657,170 @@ module ietf-te-types {
       "Base identity for protocol origin type.";
   }
 
-  identity protocol-origin-api {
-    base protocol-origin-type;
+    identity protocol-origin-api {
+      base protocol-origin-type;
+      description
+        "Protocol origin is via Application Programmable Interface
+        (API).";
+    }
+
+    identity protocol-origin-pcep {
+      base protocol-origin-type;
+      description
+        "Protocol origin is Path Computation Engine Protocol 
+        (PCEP).";
+      reference "RFC5440";
+    }
+
+    identity protocol-origin-bgp {
+      base protocol-origin-type;
+      description
+        "Protocol origin is Border Gateway Protocol (BGP).";
+      reference "RFC5512";
+    }
+
+  // NOTE: The base identity svec-objective-function-type and 
+  // its derived identities below have been
+  // added in this module revision
+  // RFC Editor: remove the note above and this note
+  identity svec-objective-function-type {
     description
-      "Protocol origin is via Application Programmable Interface
-       (API).";
+      "Base identity for SVEC objective function type.";
+    reference
+      "RFC5541: Encoding of Objective Functions in the Path
+       Computation Element Communication Protocol (PCEP).";
   }
 
-  identity protocol-origin-pcep {
-    base protocol-origin-type;
+    identity svec-of-minimize-agg-bandwidth-consumption {
+      base svec-objective-function-type;
+      description
+        "Objective function for minimizing aggregate bandwidth 
+        consumption (MBC).";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
+
+    identity svec-of-minimize-load-most-loaded-link {
+      base svec-objective-function-type;
+      description
+        "Objective function for minimizing the load on the link that 
+        is carrying the highest load (MLL).";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
+
+    identity svec-of-minimize-cost-path-set {
+      base svec-objective-function-type;
+      description
+        "Objective function for minimizing the cost on a path set 
+        (MCC).";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
+
+    identity svec-of-minimize-common-transit-domain {
+      base svec-objective-function-type;
+      description
+        "Objective function for minimizing the number of common 
+        transit domains (MCTD).";
+      reference
+        "RFC8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture.";
+    }
+
+    identity svec-of-minimize-shared-link {
+      base svec-objective-function-type;
+      description
+        "Objective function for minimizing the number of shared 
+        links (MSL).";
+      reference
+        "RFC8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture.";
+    }
+
+    identity svec-of-minimize-shared-srlg {
+      base svec-objective-function-type;
+      description
+        "Objective function for minimizing the number of shared 
+        Shared Risk Link Groups (SRLG) (MSS).";
+      reference
+        "RFC8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture.";
+    }
+
+    identity svec-of-minimize-shared-nodes {
+      base svec-objective-function-type;
+      description
+        "Objective function for minimizing the number of shared 
+        nodes (MSN).";
+      reference
+        "RFC8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture.";
+    }
+
+  // NOTE: The base identity svec-metric-type and 
+  // its derived identities below have been
+  // added in this module revision
+  // RFC Editor: remove the note above and this note
+  identity svec-metric-type {
     description
-      "Protocol origin is Path Computation Engine Protocol (PCEP).";
-    reference "RFC5440";
+      "Base identity for SVEC metric type.";
+    reference
+      "RFC5541: Encoding of Objective Functions in the Path
+       Computation Element Communication Protocol (PCEP).";
   }
 
-  identity protocol-origin-bgp {
-    base protocol-origin-type;
-    description
-      "Protocol origin is Border Gateway Protocol (BGP).";
-    reference "RFC5512";
-  }
+    identity svec-metric-cumul-te {
+      base svec-metric-type;
+      description
+        "Cumulative TE cost.";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
+
+    identity svec-metric-cumul-igp {
+      base svec-metric-type;
+      description
+        "Cumulative IGP cost.";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
+
+    identity svec-metric-cumul-hop {
+      base svec-metric-type;
+      description
+        "Cumulative Hop path metric.";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
+
+    identity svec-metric-aggregate-bandwidth-consumption {
+      base svec-metric-type;
+      description
+        "Aggregate bandwidth consumption.";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
+
+    identity svec-metric-load-of-the-most-loaded-link {
+      base svec-metric-type;
+      description
+        "Load of the most loaded link.";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
 
   /**
    * TE bandwidth groupings
@@ -4031,6 +4270,191 @@ revision of the ietf-te-types YANG module.</t>
 
 
 
+<reference anchor='RFC6780' target='https://www.rfc-editor.org/info/rfc6780'>
+<front>
+<title>RSVP ASSOCIATION Object Extensions</title>
+<author fullname='L. Berger' initials='L.' surname='Berger'><organization/></author>
+<author fullname='F. Le Faucheur' initials='F.' surname='Le Faucheur'><organization/></author>
+<author fullname='A. Narayanan' initials='A.' surname='Narayanan'><organization/></author>
+<date month='October' year='2012'/>
+<abstract><t>The RSVP ASSOCIATION object was defined in the context of GMPLS-controlled Label Switched Paths (LSPs).  In this context, the object is used to associate recovery LSPs with the LSP they are protecting.  This object also has broader applicability as a mechanism to associate RSVP state.  This document defines how the ASSOCIATION object can be more generally applied.  This document also defines Extended ASSOCIATION objects that, in particular, can be used in the context of the MPLS Transport Profile (MPLS-TP).  This document updates RFC 2205, RFC 3209, and RFC 3473.  It also generalizes the definition of the Association ID field defined in RFC 4872.  [STANDARDS-TRACK]</t></abstract>
+</front>
+<seriesInfo name='RFC' value='6780'/>
+<seriesInfo name='DOI' value='10.17487/RFC6780'/>
+</reference>
+
+
+
+<reference anchor='RFC4872' target='https://www.rfc-editor.org/info/rfc4872'>
+<front>
+<title>RSVP-TE Extensions in Support of End-to-End Generalized Multi-Protocol Label Switching (GMPLS) Recovery</title>
+<author fullname='J.P. Lang' initials='J.P.' role='editor' surname='Lang'><organization/></author>
+<author fullname='Y. Rekhter' initials='Y.' role='editor' surname='Rekhter'><organization/></author>
+<author fullname='D. Papadimitriou' initials='D.' role='editor' surname='Papadimitriou'><organization/></author>
+<date month='May' year='2007'/>
+<abstract><t>This document describes protocol-specific procedures and extensions for Generalized Multi-Protocol Label Switching (GMPLS) Resource ReSerVation Protocol - Traffic Engineering (RSVP-TE) signaling to support end-to-end Label Switched Path (LSP) recovery that denotes protection and restoration.  A generic functional description of GMPLS recovery can be found in a companion document, RFC 4426.  [STANDARDS-TRACK]</t></abstract>
+</front>
+<seriesInfo name='RFC' value='4872'/>
+<seriesInfo name='DOI' value='10.17487/RFC4872'/>
+</reference>
+
+
+
+<reference anchor='RFC4873' target='https://www.rfc-editor.org/info/rfc4873'>
+<front>
+<title>GMPLS Segment Recovery</title>
+<author fullname='L. Berger' initials='L.' surname='Berger'><organization/></author>
+<author fullname='I. Bryskin' initials='I.' surname='Bryskin'><organization/></author>
+<author fullname='D. Papadimitriou' initials='D.' surname='Papadimitriou'><organization/></author>
+<author fullname='A. Farrel' initials='A.' surname='Farrel'><organization/></author>
+<date month='May' year='2007'/>
+<abstract><t>This document describes protocol specific procedures for GMPLS (Generalized Multi-Protocol Label Switching) RSVP-TE (Resource ReserVation Protocol - Traffic Engineering) signaling extensions to support label switched path (LSP) segment protection and restoration. These extensions are intended to complement and be consistent with the RSVP-TE Extensions for End-to-End GMPLS Recovery (RFC 4872). Implications and interactions with fast reroute are also addressed. This document also updates the handling of NOTIFY_REQUEST objects.  [STANDARDS-TRACK]</t></abstract>
+</front>
+<seriesInfo name='RFC' value='4873'/>
+<seriesInfo name='DOI' value='10.17487/RFC4873'/>
+</reference>
+
+
+
+<reference anchor='RFC8800' target='https://www.rfc-editor.org/info/rfc8800'>
+<front>
+<title>Path Computation Element Communication Protocol (PCEP) Extension for Label Switched Path (LSP) Diversity Constraint Signaling</title>
+<author fullname='S. Litkowski' initials='S.' surname='Litkowski'><organization/></author>
+<author fullname='S. Sivabalan' initials='S.' surname='Sivabalan'><organization/></author>
+<author fullname='C. Barth' initials='C.' surname='Barth'><organization/></author>
+<author fullname='M. Negi' initials='M.' surname='Negi'><organization/></author>
+<date month='July' year='2020'/>
+<abstract><t>This document introduces a simple mechanism to associate a group of Label Switched Paths (LSPs) via an extension to the Path Computation Element Communication Protocol (PCEP) with the purpose of computing diverse (disjointed) paths for those LSPs.  The proposed extension allows a Path Computation Client (PCC) to advertise to a Path Computation Element (PCE) that a particular LSP belongs to a particular Disjoint Association Group; thus, the PCE knows that the LSPs in the same group need to be disjoint from each other.</t></abstract>
+</front>
+<seriesInfo name='RFC' value='8800'/>
+<seriesInfo name='DOI' value='10.17487/RFC8800'/>
+</reference>
+
+
+
+<reference anchor='RFC5541' target='https://www.rfc-editor.org/info/rfc5541'>
+<front>
+<title>Encoding of Objective Functions in the Path Computation Element Communication Protocol (PCEP)</title>
+<author fullname='JL. Le Roux' initials='JL.' surname='Le Roux'><organization/></author>
+<author fullname='JP. Vasseur' initials='JP.' surname='Vasseur'><organization/></author>
+<author fullname='Y. Lee' initials='Y.' surname='Lee'><organization/></author>
+<date month='June' year='2009'/>
+<abstract><t>The computation of one or a set of Traffic Engineering Label Switched Paths (TE LSPs) in MultiProtocol Label Switching (MPLS) and Generalized MPLS (GMPLS) networks is subject to a set of one or more specific optimization criteria, referred to as objective functions (e.g., minimum cost path, widest path, etc.).</t><t>In the Path Computation Element (PCE) architecture, a Path Computation Client (PCC) may want a path to be computed for one or more TE LSPs according to a specific objective function.  Thus, the PCC needs to instruct the PCE to use the correct objective function. Furthermore, it is possible that not all PCEs support the same set of objective functions; therefore, it is useful for the PCC to be able to automatically discover the set of objective functions supported by each PCE.</t><t>This document defines extensions to the PCE communication Protocol (PCEP) to allow a PCE to indicate the set of objective functions it supports.  Extensions are also defined so that a PCC can indicate in a path computation request the required objective function, and a PCE can report in a path computation reply the objective function that was used for path computation.</t><t>This document defines objective function code types for six objective functions previously listed in the PCE requirements work, and provides the definition of four new metric types that apply to a set of synchronized requests.  [STANDARDS-TRACK]</t></abstract>
+</front>
+<seriesInfo name='RFC' value='5541'/>
+<seriesInfo name='DOI' value='10.17487/RFC5541'/>
+</reference>
+
+
+
+<reference anchor='RFC5440' target='https://www.rfc-editor.org/info/rfc5440'>
+<front>
+<title>Path Computation Element (PCE) Communication Protocol (PCEP)</title>
+<author fullname='JP. Vasseur' initials='JP.' role='editor' surname='Vasseur'><organization/></author>
+<author fullname='JL. Le Roux' initials='JL.' role='editor' surname='Le Roux'><organization/></author>
+<date month='March' year='2009'/>
+<abstract><t>This document specifies the Path Computation Element (PCE) Communication Protocol (PCEP) for communications between a Path Computation Client (PCC) and a PCE, or between two PCEs.  Such interactions include path computation requests and path computation replies as well as notifications of specific states related to the use of a PCE in the context of Multiprotocol Label Switching (MPLS) and Generalized MPLS (GMPLS) Traffic Engineering.  PCEP is designed to be flexible and extensible so as to easily allow for the addition of further messages and objects, should further requirements be expressed in the future.  [STANDARDS-TRACK]</t></abstract>
+</front>
+<seriesInfo name='RFC' value='5440'/>
+<seriesInfo name='DOI' value='10.17487/RFC5440'/>
+</reference>
+
+
+
+<reference anchor='RFC5441' target='https://www.rfc-editor.org/info/rfc5441'>
+<front>
+<title>A Backward-Recursive PCE-Based Computation (BRPC) Procedure to Compute Shortest Constrained Inter-Domain Traffic Engineering Label Switched Paths</title>
+<author fullname='JP. Vasseur' initials='JP.' role='editor' surname='Vasseur'><organization/></author>
+<author fullname='R. Zhang' initials='R.' surname='Zhang'><organization/></author>
+<author fullname='N. Bitar' initials='N.' surname='Bitar'><organization/></author>
+<author fullname='JL. Le Roux' initials='JL.' surname='Le Roux'><organization/></author>
+<date month='April' year='2009'/>
+<abstract><t>The ability to compute shortest constrained Traffic Engineering Label Switched Paths (TE LSPs) in Multiprotocol Label Switching (MPLS) and Generalized MPLS (GMPLS) networks across multiple domains has been identified as a key requirement.  In this context, a domain is a collection of network elements within a common sphere of address management or path computational responsibility such as an IGP area or an Autonomous Systems.  This document specifies a procedure relying on the use of multiple Path Computation Elements (PCEs) to compute such inter-domain shortest constrained paths across a predetermined sequence of domains, using a backward-recursive path computation technique.  This technique preserves confidentiality across domains, which is sometimes required when domains are managed by different service providers.  [STANDARDS-TRACK]</t></abstract>
+</front>
+<seriesInfo name='RFC' value='5441'/>
+<seriesInfo name='DOI' value='10.17487/RFC5441'/>
+</reference>
+
+
+
+<reference anchor='RFC5520' target='https://www.rfc-editor.org/info/rfc5520'>
+<front>
+<title>Preserving Topology Confidentiality in Inter-Domain Path Computation Using a Path-Key-Based Mechanism</title>
+<author fullname='R. Bradford' initials='R.' role='editor' surname='Bradford'><organization/></author>
+<author fullname='JP. Vasseur' initials='JP.' surname='Vasseur'><organization/></author>
+<author fullname='A. Farrel' initials='A.' surname='Farrel'><organization/></author>
+<date month='April' year='2009'/>
+<abstract><t>Multiprotocol Label Switching (MPLS) and Generalized MPLS (GMPLS) Traffic Engineering (TE) Label Switched Paths (LSPs) may be computed by Path Computation Elements (PCEs).  Where the TE LSP crosses multiple domains, such as Autonomous Systems (ASes), the path may be computed by multiple PCEs that cooperate, with each responsible for computing a segment of the path.  However, in some cases (e.g., when ASes are administered by separate Service Providers), it would break confidentiality rules for a PCE to supply a path segment to a PCE in another domain, thus disclosing AS-internal topology information.  This issue may be circumvented by returning a loose hop and by invoking a new path computation from the domain boundary Label Switching Router (LSR) during TE LSP setup as the signaling message enters the second domain, but this technique has several issues including the problem of maintaining path diversity.</t><t>This document defines a mechanism to hide the contents of a segment of a path, called the Confidential Path Segment (CPS).  The CPS may be replaced by a path-key that can be conveyed in the PCE Communication Protocol (PCEP) and signaled within in a Resource Reservation Protocol TE (RSVP-TE) explicit route object.   [STANDARDS-TRACK]</t></abstract>
+</front>
+<seriesInfo name='RFC' value='5520'/>
+<seriesInfo name='DOI' value='10.17487/RFC5520'/>
+</reference>
+
+
+
+<reference anchor='RFC5557' target='https://www.rfc-editor.org/info/rfc5557'>
+<front>
+<title>Path Computation Element Communication Protocol (PCEP) Requirements and Protocol Extensions in Support of Global Concurrent Optimization</title>
+<author fullname='Y. Lee' initials='Y.' surname='Lee'><organization/></author>
+<author fullname='JL. Le Roux' initials='JL.' surname='Le Roux'><organization/></author>
+<author fullname='D. King' initials='D.' surname='King'><organization/></author>
+<author fullname='E. Oki' initials='E.' surname='Oki'><organization/></author>
+<date month='July' year='2009'/>
+<abstract><t>The Path Computation Element Communication Protocol (PCEP) allows Path Computation Clients (PCCs) to request path computations from Path Computation Elements (PCEs), and lets the PCEs return responses.  When computing or reoptimizing the routes of a set of Traffic Engineering Label Switched Paths (TE LSPs) through a network, it may be advantageous to perform bulk path computations in order to avoid blocking problems and to achieve more optimal network-wide solutions. Such bulk optimization is termed Global Concurrent Optimization (GCO). A GCO is able to simultaneously consider the entire topology of the network and the complete set of existing TE LSPs, and their respective constraints, and look to optimize or reoptimize the entire network to satisfy all constraints for all TE LSPs.  A GCO may also be applied to some subset of the TE LSPs in a network.  The GCO application is primarily a Network Management System (NMS) solution.</t><t>This document provides application-specific requirements and the PCEP extensions in support of GCO applications.  [STANDARDS-TRACK]</t></abstract>
+</front>
+<seriesInfo name='RFC' value='5557'/>
+<seriesInfo name='DOI' value='10.17487/RFC5557'/>
+</reference>
+
+
+
+<reference anchor='RFC8306' target='https://www.rfc-editor.org/info/rfc8306'>
+<front>
+<title>Extensions to the Path Computation Element Communication Protocol (PCEP) for Point-to-Multipoint Traffic Engineering Label Switched Paths</title>
+<author fullname='Q. Zhao' initials='Q.' surname='Zhao'><organization/></author>
+<author fullname='D. Dhody' initials='D.' role='editor' surname='Dhody'><organization/></author>
+<author fullname='R. Palleti' initials='R.' surname='Palleti'><organization/></author>
+<author fullname='D. King' initials='D.' surname='King'><organization/></author>
+<date month='November' year='2017'/>
+<abstract><t>Point-to-point Multiprotocol Label Switching (MPLS) and Generalized MPLS (GMPLS) Traffic Engineering Label Switched Paths (TE LSPs) may be established using signaling techniques, but their paths may first need to be determined.  The Path Computation Element (PCE) has been identified as an appropriate technology for the determination of the paths of point-to-multipoint (P2MP) TE LSPs.</t><t>This document describes extensions to the PCE Communication Protocol (PCEP) to handle requests and responses for the computation of paths for P2MP TE LSPs.</t><t>This document obsoletes RFC 6006.</t></abstract>
+</front>
+<seriesInfo name='RFC' value='8306'/>
+<seriesInfo name='DOI' value='10.17487/RFC8306'/>
+</reference>
+
+
+
+<reference anchor='RFC8685' target='https://www.rfc-editor.org/info/rfc8685'>
+<front>
+<title>Path Computation Element Communication Protocol (PCEP) Extensions for the Hierarchical Path Computation Element (H-PCE) Architecture</title>
+<author fullname='F. Zhang' initials='F.' surname='Zhang'><organization/></author>
+<author fullname='Q. Zhao' initials='Q.' surname='Zhao'><organization/></author>
+<author fullname='O. Gonzalez de Dios' initials='O.' surname='Gonzalez de Dios'><organization/></author>
+<author fullname='R. Casellas' initials='R.' surname='Casellas'><organization/></author>
+<author fullname='D. King' initials='D.' surname='King'><organization/></author>
+<date month='December' year='2019'/>
+<abstract><t>The Hierarchical Path Computation Element (H-PCE) architecture is defined in RFC 6805.  It provides a mechanism to derive an optimum end-to-end path in a multi-domain environment by using a hierarchical relationship between domains to select the optimum sequence of domains and optimum paths across those domains.</t><t>This document defines extensions to the Path Computation Element Communication Protocol (PCEP) to support H-PCE procedures.</t></abstract>
+</front>
+<seriesInfo name='RFC' value='8685'/>
+<seriesInfo name='DOI' value='10.17487/RFC8685'/>
+</reference>
+
+
+
+<reference anchor='RFC5512' target='https://www.rfc-editor.org/info/rfc5512'>
+<front>
+<title>The BGP Encapsulation Subsequent Address Family Identifier (SAFI) and the BGP Tunnel Encapsulation Attribute</title>
+<author fullname='P. Mohapatra' initials='P.' surname='Mohapatra'><organization/></author>
+<author fullname='E. Rosen' initials='E.' surname='Rosen'><organization/></author>
+<date month='April' year='2009'/>
+<abstract><t>In certain situations, transporting a packet from one Border Gateway Protocol (BGP) speaker to another (the BGP next hop) requires that the packet be encapsulated by the first BGP speaker and decapsulated by the second.  To support these situations, there needs to be some agreement between the two BGP speakers with regard to the &quot;encapsulation information&quot;, i.e., the format of the encapsulation header as well as the contents of various fields of the header.</t><t>The encapsulation information need not be signaled for all encapsulation types.  In cases where signaling is required (such as Layer Two Tunneling Protocol - Version 3 (L2TPv3) or Generic Routing Encapsulation (GRE) with key), this document specifies a method by which BGP speakers can signal encapsulation information to each other.  The signaling is done by sending BGP updates using the Encapsulation Subsequent Address Family Identifier (SAFI) and the IPv4 or IPv6 Address Family Identifier (AFI).  In cases where no encapsulation information needs to be signaled (such as GRE without key), this document specifies a BGP extended community that can be attached to BGP UPDATE messages that carry payload prefixes in order to indicate the encapsulation protocol type to be used.  [STANDARDS-TRACK]</t></abstract>
+</front>
+<seriesInfo name='RFC' value='5512'/>
+<seriesInfo name='DOI' value='10.17487/RFC5512'/>
+</reference>
+
+
+
 
     </references>
 
@@ -4076,6 +4500,53 @@ revision of the ietf-te-types YANG module.</t>
    </front>
    <seriesInfo name='Internet-Draft' value='draft-ietf-teas-yang-te-30'/>
    <format target='https://www.ietf.org/archive/id/draft-ietf-teas-yang-te-30.txt' type='TXT'/>
+</reference>
+
+
+<reference anchor='I-D.ietf-teas-yang-path-computation'>
+   <front>
+      <title>A YANG Data Model for requesting path computation</title>
+      <author fullname='Italo Busi' initials='I.' surname='Busi'>
+         <organization>Huawei Technologies</organization>
+      </author>
+      <author fullname='Sergio Belotti' initials='S.' surname='Belotti'>
+         <organization>Nokia</organization>
+      </author>
+      <author fullname='Oscar Gonzalez de Dios' initials='O. G.' surname='de Dios'>
+         <organization>Telefonica</organization>
+      </author>
+      <author fullname='Anurag Sharma' initials='A.' surname='Sharma'>
+         <organization>Google</organization>
+      </author>
+      <author fullname='Daniele Ceccarelli' initials='D.' surname='Ceccarelli'>
+         <organization>Ericsson</organization>
+      </author>
+      <date day='22' month='March' year='2022'/>
+      <abstract>
+	 <t>   There are scenarios, typically in a hierarchical Software-Defined
+   Networking (SDN) context, where the topology information provided by
+   a Traffic Engineering (TE) network provider may be insufficient for
+   its client to perform multi-domain path computation.  In these cases
+   the client would need to request the TE network provider to compute
+   some intra-domain paths.
+
+   This document defines a YANG data model which contains Remote
+   Procedure Calls (RPCs) to request path computation.  This model
+   complements the solution, defined in RFC YYYY, to configure a TE
+   tunnel path in &quot;compute-only&quot; mode.
+
+   [RFC EDITOR NOTE: Please replace RFC YYYY with the RFC number of
+   draft-ietf-teas-yang-te once it has been published.
+
+   Moreover, this document describes some use cases where the path
+   computation request, via YANG-based protocols (e.g., NETCONF or
+   RESTCONF), can be needed.
+
+	 </t>
+      </abstract>
+   </front>
+   <seriesInfo name='Internet-Draft' value='draft-ietf-teas-yang-path-computation-18'/>
+   <format target='https://www.ietf.org/archive/id/draft-ietf-teas-yang-path-computation-18.txt' type='TXT'/>
 </reference>
 
 
@@ -4155,13 +4626,13 @@ revision of the ietf-te-types YANG module.</t>
 
 <section anchor="yang-diff"><name>TE Types YANG Diffs</name>
 
+<t>RFC Editor Note: please remove this appendix before publication.</t>
+
 <t>This section provides the diff between the YANG module in section 3.1 of <xref target="RFC8776"/> and the YANG model revision in <xref target="yang-code"/>.</t>
 
 <t>The intention of this appendix is to facilitate focusing the review of the YANG model in <xref target="yang-code"/> to the changes compared with the YANG model in <xref target="RFC8776"/>.</t>
 
-<t>Editors note, please remove this appendix before publication.</t>
-
-<t>Note - This diff has been generated using the following UNIX commands to compare the YANG module revisions in section 3.1 of <xref target="RFC8776"/> and in <xref target="yang-code"/>:</t>
+<t>This diff has been generated using the following UNIX commands to compare the YANG module revisions in section 3.1 of <xref target="RFC8776"/> and in <xref target="yang-code"/>:</t>
 
 <figure><artwork><![CDATA[
 diff ietf-te-types@2020-06-10.yang ietf-te-types.yang > model-diff.txt
@@ -4172,34 +4643,58 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt > model-updates.txt
 <t>The output (model-updates.txt) is reported here:</t>
 
 <figure><artwork><![CDATA[
+30c30
+<                <mailto:tsaad@juniper.net>
+---
+>                <mailto:tsaad.net@gmail.com>
 55c55
 <      Copyright (c) 2020 IETF Trust and the persons identified as
 ---
 >      Copyright (c) 2022 IETF Trust and the persons identified as
-65c65
-<      This version of this YANG module is part of RFC 8776; see the
+60c60
+<      the license terms contained in, the Simplified BSD License set
 ---
->      This version of this YANG module is part of RFC XXXX; see the
-67a68,85
->   revision 2022-09-09 {
+>      the license terms contained in, the Revised BSD License set
+65,66c65,99
+<      This version of this YANG module is part of RFC 8776; see the
+<      RFC itself for full legal notices.";
+---
+>      This version of this YANG module is part of RFC XXXX
+>      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+>      for full legal notices.";
+> 
+>   revision 2022-10-21 {
 >     description
 >       "Added:
 >       - typedef bandwidth-scientific-notation;
+>       - base identity lsp-provisioning-error-reason;
 >       - identity association-type-diversity;
 >       - identity tunnel-admin-auto;
 >       - base identity path-computation-error-reason and
 >         its derived identities;
+>       - base identity tunnel-actions-type and its derived 
+>         identities;
 >       - base identity protocol-origin-type and
 >         its derived identities;
->       - grouping encoding-and-switching-type.";
+>       - base identity svec-objective-function-type and its derived
+>         identities;
+>       - base identity svec-metric-type and its derived identities;
+>       - grouping encoding-and-switching-type.
+>       
+>       Updated:
+>       - description of the base identity objective-function-type.
+>       
+>       Obsoleted:
+>       - identity of-minimize-agg-bandwidth-consumption
+>       - identity of-minimize-load-most-loaded-link
+>       - identity of-minimize-cost-path-set";
 >     reference
 >       "RFC XXXX: Updated Common YANG Data Types for Traffic
 >       Engineering";
 >   }
 >   // RFC Editor: replace XXXX with actual RFC number, update date
 >   // information and remove this note
-> 
-545a564,597
+545a579,612
 >   // NOTE: The typedef bandwidth-scientific-notation below has been
 >   // added in this module revision
 >   // RFC Editor: remove the note above and this note
@@ -4234,20 +4729,71 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt > model-updates.txt
 >       Languages - C.";
 >   }
 > 
-982a1035,1046
+606a674,681
+>   // NOTE: The base identity lsp-provisioning-error-reason has been
+>   // added in this module revision
+>   // RFC Editor: remove the note above and this note
+>   identity lsp-provisioning-error-reason {
+>     description
+>       "Base identity for LSP provisioning errors.";
+>   }
+> 
+982a1058,1073
 >   // NOTE: The identity association-type-diversity below has been
 >   // added in this module revision
 >   // RFC Editor: remove the note above and this note
 >   identity association-type-diversity {
 >     base association-type;
 >     description
->       "Association Type diversity used to associate LSPs whose paths
->        are to be diverse from each other.";
+>       "Association Type diversity used to associate LSPs whose 
+>       paths are to be diverse from each other.";
 >     reference
 >       "RFC8800";
 >   }
 > 
-1216a1281,1292
+>   // NOTE: The description of the base identity 
+>   // objective-function-type has been updated 
+>   // in this module revision
+>   // RFC Editor: remove the note above and this note
+985c1076
+<       "Base objective function type.";
+---
+>       "Base identity for path objective function type.";
+1015a1107,1109
+>   // NOTE: The identity of-minimize-agg-bandwidth-consumption
+>   // below has been obsoleted in this module revision
+>   // RFC Editor: remove the note above and this note
+1017a1112
+>     status obsolete;
+1020c1115
+<        consumption.";
+---
+>       consumption.";
+1023c1118
+<        Computation Element Communication Protocol (PCEP)";
+---
+>       Computation Element Communication Protocol (PCEP)";
+1025a1121,1123
+>   // NOTE: The identity of-minimize-load-most-loaded-link
+>   // below has been obsoleted in this module revision
+>   // RFC Editor: remove the note above and this note
+1027a1126
+>     status obsolete;
+1030c1129
+<        is carrying the highest load.";
+---
+>       is carrying the highest load.";
+1033c1132
+<        Computation Element Communication Protocol (PCEP)";
+---
+>       Computation Element Communication Protocol (PCEP)";
+1035a1135,1137
+>   // NOTE: The identity of-minimize-cost-path-set
+>   // below has been obsoleted in this module revision
+>   // RFC Editor: remove the note above and this note
+1037a1140
+>     status obsolete;
+1216a1320,1331
 >   // NOTE: The identity tunnel-admin-auto below has been
 >   // added in this module revision
 >   // RFC Editor: remove the note above and this note
@@ -4255,12 +4801,12 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt > model-updates.txt
 >     base tunnel-admin-state-type;
 >     description
 >       "Tunnel administrative auto state. The administrative status
->        in state datastore transitions to 'tunnel-admin-up' when the
->        tunnel used by the client layer, and to 'tunnel-admin-down'
->        when it is not used by the client layer.";
+>       in state datastore transitions to 'tunnel-admin-up' when the
+>       tunnel used by the client layer, and to 'tunnel-admin-down'
+>       when it is not used by the client layer.";
 >   }
 > 
-2110a2187,2391
+2110a2226,2569
 >   // NOTE: The base identity path-computation-error-reason and 
 >   // its derived identities below have been
 >   // added in this module revision
@@ -4270,156 +4816,157 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt > model-updates.txt
 >       "Base identity for path computation error reasons.";
 >   }
 > 
->   identity path-computation-error-no-topology {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because there is no topology
->        with the provided topology-identifier.";
->   }
+>     identity path-computation-error-no-topology {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because there is no topology
+>         with the provided topology-identifier.";
+>     }
 > 
->   identity path-computation-error-no-dependent-server {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because one or more dependent
->        path computation servers are unavailable.
->        The dependent path computation server could be
->        a Backward-Recursive Path Computation (BRPC) downstream
->        PCE or a child PCE.";
->     reference
->       "RFC5441, RFC8685";
->   }
+>     identity path-computation-error-no-dependent-server {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because one or more dependent
+>         path computation servers are unavailable.
+>         The dependent path computation server could be
+>         a Backward-Recursive Path Computation (BRPC) downstream
+>         PCE or a child PCE.";
+>       reference
+>         "RFC5441, RFC8685";
+>     }
 > 
->   identity path-computation-error-pce-unavailable {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because PCE is not available.";
->     reference
->       "RFC5440";
->   }
+>     identity path-computation-error-pce-unavailable {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because PCE is not available.";
+>       reference
+>         "RFC5440";
+>     }
 > 
->   identity path-computation-error-no-inclusion-hop {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because there is no
->        node or link provided by one or more inclusion hops.";
->     reference
->       "RFC8685";
->   }
+>     identity path-computation-error-no-inclusion-hop {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because there is no
+>         node or link provided by one or more inclusion hops.";
+>       reference
+>         "RFC8685";
+>     }
 > 
->   identity path-computation-error-destination-unknown-in-domain {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because the destination node is
->        unknown in indicated destination domain.";
->     reference
->       "RFC8685";
->   }
+>     identity path-computation-error-destination-unknown-in-domain {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because the destination node is
+>         unknown in indicated destination domain.";
+>       reference
+>         "RFC8685";
+>     }
 > 
->   identity path-computation-error-no-resource {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because there is no
->        available resource in one or more domains.";
->     reference
->       "RFC8685";
->   }
+>     identity path-computation-error-no-resource {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because there is no
+>         available resource in one or more domains.";
+>       reference
+>         "RFC8685";
+>     }
 > 
->   identity path-computation-error-child-pce-unresponsive {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because child PCE is not
->        responsive.";
->     reference
->       "RFC8685";
->   }
+>     identity path-computation-error-child-pce-unresponsive {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because child PCE is not
+>         responsive.";
+>       reference
+>         "RFC8685";
+>     }
 > 
->   identity path-computation-error-destination-domain-unknown {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because the destination domain
->        was unknown.";
->     reference
->       "RFC8685";
->   }
+>     identity path-computation-error-destination-domain-unknown {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because the destination domain
+>         was unknown.";
+>       reference
+>         "RFC8685";
+>     }
 > 
->   identity path-computation-error-p2mp {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because of P2MP reachability
->        problem.";
->     reference
->       "RFC8306";
->   }
+>     identity path-computation-error-p2mp {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because of P2MP reachability
+>         problem.";
+>       reference
+>         "RFC8306";
+>     }
 > 
->   identity path-computation-error-no-gco-migration {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because of no Global Concurrent
->        Optimization (GCO) migration path found.";
->     reference
->       "RFC5557";
->   }
+>     identity path-computation-error-no-gco-migration {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because of no Global Concurrent
+>         Optimization (GCO) migration path found.";
+>       reference
+>         "RFC5557";
+>     }
 > 
->   identity path-computation-error-no-gco-solution {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because of no GCO solution
->        found.";
->     reference
->       "RFC5557";
->   }
+>     identity path-computation-error-no-gco-solution {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because of no GCO solution
+>         found.";
+>       reference
+>         "RFC5557";
+>     }
 > 
->   identity path-computation-error-path-not-found {
->     base path-computation-error-reason;
->     description
->       "Path computation no path found error reason.";
->     reference
->       "RFC5440";
->   }
+>     identity path-computation-error-path-not-found {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation no path found error reason.";
+>       reference
+>         "RFC5440";
+>     }
 > 
->   identity path-computation-error-pks-expansion {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because of Path-Key Subobject
->        (PKS)  expansion failure.";
->     reference
->       "RFC5520";
->   }
+>     identity path-computation-error-pks-expansion {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because of Path-Key Subobject
+>         (PKS)  expansion failure.";
+>       reference
+>         "RFC5520";
+>     }
 > 
->   identity path-computation-error-brpc-chain-unavailable {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because PCE BRPC chain
->        unavailable.";
->     reference
->       "RFC5441";
->   }
+>     identity path-computation-error-brpc-chain-unavailable {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because PCE BRPC chain
+>         unavailable.";
+>       reference
+>         "RFC5441";
+>     }
 > 
->   identity path-computation-error-source-unknown {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because source node is unknown.";
->     reference
->       "RFC5440";
->   }
+>     identity path-computation-error-source-unknown {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because source node is 
+>         unknown.";
+>       reference
+>         "RFC5440";
+>     }
 > 
->   identity path-computation-error-destination-unknown {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because destination node is
->        unknown.";
->     reference
->       "RFC5440";
->   }
+>     identity path-computation-error-destination-unknown {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because destination node is
+>         unknown.";
+>       reference
+>         "RFC5440";
+>     }
 > 
->   identity path-computation-error-no-server {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because path computation
->        server is unavailable.";
->     reference
->       "RFC5440";
->   }
+>     identity path-computation-error-no-server {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because path computation
+>         server is unavailable.";
+>       reference
+>         "RFC5440";
+>     }
 > 
 >   // NOTE: The base identity tunnel-actions-type and 
 >   // its derived identities below have been
@@ -4428,12 +4975,6 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt > model-updates.txt
 >   identity tunnel-actions-type {
 >     description
 >       "TE tunnel actions type.";
->   }
-> 
->   identity tunnel-action-reoptimize {
->     base tunnel-actions-type;
->     description
->       "Reoptimize tunnel action type.";
 >   }
 > 
 >   // NOTE: The base identity protocol-origin-type and 
@@ -4445,30 +4986,175 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt > model-updates.txt
 >       "Base identity for protocol origin type.";
 >   }
 > 
->   identity protocol-origin-api {
->     base protocol-origin-type;
->     description
->       "Protocol origin is via Application Programmable Interface
->        (API).";
->   }
-> 
->   identity protocol-origin-pcep {
->     base protocol-origin-type;
->     description
->       "Protocol origin is Path Computation Engine Protocol (PCEP).";
->     reference "RFC5440";
->   }
-> 
->   identity protocol-origin-bgp {
->     base protocol-origin-type;
->     description
->       "Protocol origin is Border Gateway Protocol (BGP).";
->     reference "RFC5512";
->   }
-> 
-3376a3658,3684
+>     identity protocol-origin-api {
+>       base protocol-origin-type;
+>       description
+>         "Protocol origin is via Application Programmable Interface
+>         (API).";
 >     }
+> 
+>     identity protocol-origin-pcep {
+>       base protocol-origin-type;
+>       description
+>         "Protocol origin is Path Computation Engine Protocol 
+>         (PCEP).";
+>       reference "RFC5440";
+>     }
+> 
+>     identity protocol-origin-bgp {
+>       base protocol-origin-type;
+>       description
+>         "Protocol origin is Border Gateway Protocol (BGP).";
+>       reference "RFC5512";
+>     }
+> 
+>   // NOTE: The base identity svec-objective-function-type and 
+>   // its derived identities below have been
+>   // added in this module revision
+>   // RFC Editor: remove the note above and this note
+>   identity svec-objective-function-type {
+>     description
+>       "Base identity for SVEC objective function type.";
+>     reference
+>       "RFC5541: Encoding of Objective Functions in the Path
+>        Computation Element Communication Protocol (PCEP).";
 >   }
+> 
+>     identity svec-of-minimize-agg-bandwidth-consumption {
+>       base svec-objective-function-type;
+>       description
+>         "Objective function for minimizing aggregate bandwidth 
+>         consumption (MBC).";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+>     identity svec-of-minimize-load-most-loaded-link {
+>       base svec-objective-function-type;
+>       description
+>         "Objective function for minimizing the load on the link that 
+>         is carrying the highest load (MLL).";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+>     identity svec-of-minimize-cost-path-set {
+>       base svec-objective-function-type;
+>       description
+>         "Objective function for minimizing the cost on a path set 
+>         (MCC).";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+>     identity svec-of-minimize-common-transit-domain {
+>       base svec-objective-function-type;
+>       description
+>         "Objective function for minimizing the number of common 
+>         transit domains (MCTD).";
+>       reference
+>         "RFC8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture.";
+>     }
+> 
+>     identity svec-of-minimize-shared-link {
+>       base svec-objective-function-type;
+>       description
+>         "Objective function for minimizing the number of shared 
+>         links (MSL).";
+>       reference
+>         "RFC8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture.";
+>     }
+> 
+>     identity svec-of-minimize-shared-srlg {
+>       base svec-objective-function-type;
+>       description
+>         "Objective function for minimizing the number of shared 
+>         Shared Risk Link Groups (SRLG) (MSS).";
+>       reference
+>         "RFC8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture.";
+>     }
+> 
+>     identity svec-of-minimize-shared-nodes {
+>       base svec-objective-function-type;
+>       description
+>         "Objective function for minimizing the number of shared 
+>         nodes (MSN).";
+>       reference
+>         "RFC8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture.";
+>     }
+> 
+>   // NOTE: The base identity svec-metric-type and 
+>   // its derived identities below have been
+>   // added in this module revision
+>   // RFC Editor: remove the note above and this note
+>   identity svec-metric-type {
+>     description
+>       "Base identity for SVEC metric type.";
+>     reference
+>       "RFC5541: Encoding of Objective Functions in the Path
+>        Computation Element Communication Protocol (PCEP).";
+>   }
+> 
+>     identity svec-metric-cumul-te {
+>       base svec-metric-type;
+>       description
+>         "Cumulative TE cost.";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+>     identity svec-metric-cumul-igp {
+>       base svec-metric-type;
+>       description
+>         "Cumulative IGP cost.";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+>     identity svec-metric-cumul-hop {
+>       base svec-metric-type;
+>       description
+>         "Cumulative Hop path metric.";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+>     identity svec-metric-aggregate-bandwidth-consumption {
+>       base svec-metric-type;
+>       description
+>         "Aggregate bandwidth consumption.";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+>     identity svec-metric-load-of-the-most-loaded-link {
+>       base svec-metric-type;
+>       description
+>         "Load of the most loaded link.";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+3379c3838,3865
+< }
+\ No newline at end of file
+---
 > 
 >   // NOTE: The grouping encoding-and-switching-type below has been
 >   // added in this module revision
@@ -4494,11 +5180,16 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt > model-updates.txt
 >         "LSP switching type.";
 >       reference
 >         "RFC3945";
+>     }
+>   }
+> }
 ]]></artwork></figure>
 
 </section>
 </section>
 <section anchor="options"><name>Option Considered for updating RFC8776</name>
+
+<t>RFC Editor Note: please remove this appendix before publication.</t>
 
 <t>The concern is how to be able to update the ietf-te-types YANG module published in <xref target="RFC8776"/> without delaying too much the progress of the mature WG documents.</t>
 
@@ -4528,8 +5219,6 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt > model-updates.txt
 
 <t>Therefore, in order to avoid useless editorial work, this version of the document has been structured to become an RFC8776-bis but not all the existing text in <xref target="RFC8776"/> has been copied: some editors' notes has been inserted instead. These editors' note will be removed and replaced by actual text copied from <xref target="RFC8776"/> before WG LC if the RFC8776-bis approach is confirmed.</t>
 
-<t>Editors note, please remove this appendix before publication.</t>
-
 </section>
 <section numbered="false" anchor="acknowledgements"><name>Acknowledgements</name>
 
@@ -4546,547 +5235,593 @@ about the process to follow to provide tiny updates to a YANG module already pub
   </back>
 
 <!-- ##markdown-source:
-H4sIAAAAAAAAA+2963rbRrIo+t/fl3fo7fkh0SEoUrIulleSkSXZo7V80baU
-yayTyVkfRDYpjEGAA4CSOYn3s+xnOU926tLd6MaNoCTLVib6MmOJBKqrq6uq
-q6qrqj3P++bRMB4F0WRfzLOxt/fNo28eZUEWyn3x42zkZ3IkDuPpNI7Efx+8
-fSWO/MwX54uZTMU4TsR54o/HwVAcR5MgkjIBOAjAv7hI5NW++G8/mog5gVHP
-H/PL3zwaxcPIn8IoIwCReYGEwTPpp14yHu7t7u54/JrXH3zzKL5I41ACjH2B
-X33zKJ1fTIM0DeIoA2j74uT4/OU3j67j5MMkieezfRjn4Ez8BH8DQuIVfgbT
-BHCTOFnsizQbffMomCX7IkvmabbZ7z/rbyLeaeZHo//xwzgCoAtEcxbsi5+z
-eNgVaZxkiRyn8Ntiyr8MgTAyytJfaM7z7DJO9r95JISH/ycEz+8kA3jixTwN
-+NM4AVL/Ze5fS/WBnPpBuC8CfK53Ac/9+ZK+7QH4ErSDAL4Ur+axBezlPJsn
-Et4Q53J4GcVhPAkQdwu4j69N5nEP6fznCX5YCf5v87EEir0O5hb8kxdvgAeS
-WZz4GZDcAfyRXuiFwXwZ6HM/kR/Eme+PLND/OY+CmUzEW5nh6rlIZyk8/Od/
-8CO9SGYlmO/9DzK9FK9g1S5t8h4G6TAWZ4s0k1NYp5No2HMgJxN6489DfK4S
-278G6WU0F6f+lR+JF8DZ/rQt2lcX9Hgj4ifAiOJFskiBQW1KR6PgKhjN/dBl
-jf+54Ef/vPAvY4XwN4/+NAT+T4KLeUZ8980jz/OEf5FmiT/M8G+AcH4ZpAJk
-bY6MKkZyDGIKoiivhT8aBbicfkh8DAI+QtnOSLaBPIJECeSHZxcoBUAPTeOR
-DFG0QhBwYCwpslhcSBFMgUlQZVws8Jl5CKCySz/jF7S2IHiWxhDr58cdQCIa
-B5M58xghANKYSTH0Z/5FEAKuMu3hrI4B7zhJ10QUZ0DKw3i2gEEABfkxE+Mk
-nopff/1f718eoqr49IkgTWUCOAaZuA6yS3oYSYcUicfwJ5AolUMa90KCmpLi
-p1fi9aEIxvQswtoDjXQBz/mzWRL7w0sBvxPGyVSOepXE1noPXie1xYP7IgLi
-g3YMUH3x+FIRiwnNmtCjhejpZZ0GoxE+AKsOXJIl8PyQhfGbRwfjDHgRwczm
-F2EwZAoCZJsOXTUyggU2ILLwJ3qdcQ2dwcWlfyWBIjJSjDPqiVfBFfwJYwWJ
-uABKjJAiOCYt0YKJWeI3eH4q/FTM/CTTU3aHIt4iLvma1/jtu/Nj0GSXMpU8
-N5Igl1BXMoyBxCgwv/76w4l31Mv3tgWIC/ymMK7+OtwiqsSzWD0GelP8cx6A
-KEx9VPT7TXBhVCRyMJyHfoITSKQ/WjDJcMJ+molDP2QqI2cypUElymkMk0Ba
-IM1Bj+CfOD7RDj8j7vuTeC8BG3gcdz7xNs58zYdAF/FBLgSoxFEqHr/58ez8
-cZf/FUA5/P398f/+8eT98RH+fvaXg9evzS+P1BNnf3n34+uj/Lf8zcN3b94c
-vz3il+FT4Xz06PGbg/+GbxDjx+9Oz0/evT14/Rjp4bIkUlMpK+COZJZI1Fd+
-+mgk0yEoU165F4en/9//HTxVXLY5GDwD2iqWG+w+hT+uL2XEo8VRuFB/AvUW
-j4B9JNIelFgYovrCnR12IeD/9DK+jsSlTGTvkaLmuUymAe3ZC6NFkM/Np2Q3
-KeRQSgtaOMVFHsfzCPGm9xnN3Wfb/U+femqUUzBYgo8gZ4AVmXBv4V3xFvai
-lEc9KdCpSxtVirJDY0XwPG8LMUwysRAQ8cU/QLBol0DizniokQBLBpUKzIbM
-Kj8Zqe+AEmk8DMi21MKKbw/jJJHpLI5GZp5mQ1G7iUVFkq/Mv/DUgKma7W9q
-ssL8/Ga0C4CwP34vx7AU0VDiWyhDQthfk3yxaJGOUh8zfXeePRt8+oQvgobL
-Kl7Ej5tfTJzvzYugjrPAGlS/uLf57Cm/aLSm+2L5Y3jrb/Cj3pn5ww8Gp/yd
-wsfmnV/3xZ9s+gpyC757bHgJuaFizdRSPf7kqhhUFaC7TkNQWBLUzSz0h1Lg
-ULnGxqej+fQCGAx4JJjAloPC6nAms7Q4GCZxtJgyFgfkbwSkidIb7B833xGQ
-SKAok6tAXn9izN6pP7WAK5dHvGH+O+Rd6SZo3qspo42Skk2Q8k43V94hrA+Y
-kgR9HIdhfE0+IIBgAR4BagEKboVhCVozgPGHPiILLDFP2XQEkuX2QEqm7QW8
-eB2MsksvHQYIEuxILzKbzz7bXjwG8BbwJG1PiJV5lRTkRZB5YJV7QCVg2q6t
-pQxgoQGLddmb9Lpi0JdbHSINaAvylj0A6qWwBsNLLasGC6Sttqlt44qtIRrr
-9dmp0KDY1tWgRG73od4m2bxLHrodq5M2BLSl4nWDGK3XG2XFfrWMfW6DgYfA
-12Lr1HBz0TB/7HD/428eWSrOMgnfoQ1AE1TmdSO/0ny/eYTPG/5oYCzLvARJ
-kxi7ULu1klCNdE9r1zHoylQs4nlC34GRH6s30DjsiTMJpl2YxrAKtKKjYDxW
-2+cNbML/Az+0fX7zqFJl/IrqgMYBzUjEHfQGz/FDsjFmuA88nifRPr62Dxj6
-03T/4zTcj9J9fG3fXQN6U1kS+sPnrLbYXCjtv7+yN63ewS+e8ydJbgDwlvkY
-p4879H5N1ItH/1QczLIS3MHwi7sezDUQ3PG0TdE4JloSdWOSuUkSxaOIA/Ag
-DCL4T4zRk+BfVizoMcbfqmKB8DKwcQYCB34LMc4ZbOp+qJz+g7OOwssJ1fFo
-KP0Ux6ARQNh/khf78Ot/XGbZLN3f2EATFEMdH2RCrlAPENu4nmygR7TxvQYM
-SiJIM3jxPzCWksX7+PWf9fPfq+1OGJ4XpUCV9WNgYGQKAzt5vKsKUkV4qgJY
-KRhVBao2HlUBsCIAVQWyGOurgFQb3auCV45pVUCsCGV9z+vNLs7M4irS1rbp
-TiwRRLy9hqHS46CpJzKCGYegg8GEGM9V9MxylUiN2h57OpND2uphXz4/7hmD
-B/wZeD9cKAi4fcQJWJlkhUod8BNv/MifkAtMopNmuCHZzK7eX3/75uig0zPU
-cl3kNXSN17r8Lzq6+Lt2kfF38ozNLwqGeo7d4/y3/H3jFeOfBUd5raugrIG7
-vMYO7Jp2l9fau8sKStFpFuAzr6OKQZe5w7+iw9yp9JcVEPSaRTuv2RASLYok
-mFxmYn3YEZv9zU2hlNA8zdQWBb4o7De42myFjgMbdY7Xp3qjR6MG2OAABie4
-aEamYMjnJjHIsxyBLqGIq97Fgd8Q5xS22iFrOHDS/YS8dgw9kzETJwoA/gVq
-FRkNmY9UaBfNlBn6+xmSdjZP0rkPlM9iJlc6J/8a/s7JJcJgKKOU4wSplgta
-hS4rb7QI4O8XZ0cg4PxsKpUyRdzIGgY7gEXoaW+o6ZBTcS0Vr+XED8Gfjtm+
-SA0dQj9TRi09f6TYRT+wrnU0na9ImetnhTjszuPYkQsggrYOtL1ni36QBw+R
-p9hDdce6vr7uJeOhJ0kj0Wg4ygZ8ho93ngMFpHEzgyyV4TgnCIm9CGnCYNgA
-mmnvsTIrjFGIfOYN+t5gW2+7Ja0FeusAjbR9/afXziZ8nj/P3JotTJwEvqZd
-Hew0olG2qHo6m0eRDD1/NA0iD7g7th66QKvQPDnzAQfQvLM5j+3JJIkTDzb6
-lNk6V99AJphjAuOO9PuBsS4qICdxFoNu9mIQooCxXhFgG4u497jRvsHlXuX4
-Ur9sWS6W6bWxIVyjuBi5ACtlDlyTBy+6yp3AvUcqEAFtJLn5b2xry5B2Oa3v
-9XeA2Zo47TUeMGSO0wIeGXuQzSRCx6vRBKyw5hwrcOPJEwL4hN4B9mbZf7LB
-X5tjBuJGWlM9EeIJsusv5UcP9Sks9q8au40noj/Y72/u97f2+08JHn8RgiUC
-xH486PUGAz25T01SCCOjugaaXylHS2ygVmddPQxBvOAD4NY4yWMGvg0EdeRa
-juUa4d4z37LNAAuAoSpS6KC3LxaZ5H0UHLd8ggH7mWNQYpewZgaGMixCOc70
-WwQhlf+c46rBnvRa+hQn+JdMYvoyVU8aIPrsDLj9yg/neFKwwD07VpsKLihF
-yLLFEr7Y2tnq71ea8nRId/wRPHLaChDxd2enLw0Of1Xae9N8gvC2t/rb++Lk
-zDs5s1+uzR2wXt3d6u/t80ugT0VhPclTIEK8OX19VpRkF3N8wgP0HQau4NDU
-YVGwnmE6hjFZleUPP3e+kApNr/xEA48eKUWY5WJ3zGMUGFeLcwH3qlGbxOx5
-PSqGzlXD18qNobcrP/9+cnNPzEo7t5+xDSq9cehPljOt3p0B8/wbwTt3KimN
-JoeZMlDD3Z9agwrT2VIwDbJw6uNWat4XPDdrty+SQia0o8JKeFMJrw1TMKbg
-AzqHtmkiYVeWKq/AII0fArU+ROhbWFNhPug/zz+pQJYQ/pFfNoxh0YqAMzJl
-2IMWsN/Suz1BGSFDSiOgPApkcz+K4bt4noKrkQk2H9C4r0XEv6hDZbMFKgfq
-7ZbIVCLSsOw5THAJ6WjRt5dW8NLyNGkS62ZIgyYOrYjQ6ebTXXeR429BoueF
-hauR6Ke7g33a4uq3wzeMXL6xuRvY3ubWvji1+PSFj04ZcfqZ1PELVDLHHzGJ
-IshM4EFQ/A0efu1fyFCckfmr3k3F+uuz07QjfqSzC9gyGI9cn1Tjs7e929d7
-cfspVQpfmoQTV+8EUba12bC/nL1//Uq0sN2fboLhx2S37AX0VeczCoGCjfuK
-wz3Bv2TuWLyZh1ngnSr/wyEbze0V6tWOQw+wTXYrbJO7GquScKC0+WTIw+ym
-edpWUc1s4a0T1ePIvwjlqFYRjAq6rg7OUZA2A0Kvw7Ha62GdYHBkKukVCrDV
-AgUDAlx8dPGmPgabIpL/FkOgOWHMEwxeKfS1XUBpcrBO4LdFFM3ikaQNhKTQ
-B2sHXLvxPBTp5TwjcuHnNj6zeTKLU8u/qmRlw87bewPgsVca7JkGq00BdAUt
-FqMPHbyqBFWnHdZR8o7pRxFUJl6BGg6mFZRx0arYbetQOmPhAGSKyrrNnnKk
-0s5U3NfYpvqkV53NUn4hBQDB8T22TFkmRbXZAQKcHyjbwlt0ZMFUy2QCdnD/
-549/+2W9v77+917/h84PP89Of1n/+7edH/o//MYfdX5bcwgpvhVrA/hq/ee/
-j3xvfOC9/OXXfnf708/9zac7e/7B8FAe/wKQOj+U3zPQ1webP/e93V+qYP/c
-H/zy99Fv/R/+PoL/ANBvhKM13KC79+m3v4++Lb+83l1/yBPqdJ6sLffL9DE+
-ndCidIIA5qtOuxhYQxmf9KuFV0FY24v1RQg+ADIYx4XQOsLjTZUhi2zoY4wY
-Q9tC4ok1B2HTXLD0iypHIoKNI5IT9ipGchiAfdNFd4nC8xMMPVlOGX4+DmM/
-2zeBViHW4TXxG333G3/b+fnJ+lp3reKLzi/Wiy/VwaDKF3IzFroq0SuxI3cq
-ISS3QvQJuVjLY6GBlOjIwHBbm2sY7le5pqh99GFljjznY/Q/DmaDfkeTjg7w
-I4ws4nEFvMfOHmZoc5pHr2Ia72DJhz4lJUcp7fb6cGf93fnbTiEjo1uxqIrk
-ZnEwfaUr0jmsI0xjrd/d7G51B2tdeJBsXJs1YCTx7ujHvsqpA9UKf20BV62v
-wS9rnDLHIYE1jSlG6AyAH2G+a70Oz+eIAvw/+VdSRcmOAhURJFNlFsqPZJgc
-/XT0plM1lZkf8FFIGoIdrZkOUaNFcqdo3i9MdcuZKkAfJ+yMLxhsn8Kl+dv4
-GUvUpkpHLrywxfFV68GtPIhwCNZ9hHQJFw7zBVYCEJ330IESsKFMhuim+nmm
-pJIRm43UMfpa/+Ma/j6UOkEExYLpsiyyuurhukHl5PxH71y8l1xWMmI78FVv
-t/8MKwNgMxmDFWFgmNdixR6ZYeSIGblu/xqlHgdxigb8Xr57AayJFI/7vd5u
-i1grWhBHwZjIkXFi5xkmwSG6hziUh9Mn7cbmzDInYLAJNDQGdiFwaFnnOCie
-0nn+tW3Q2VEW23LqWideW71BHYEmYXzhh14wWs3FOYjyg8YE7UzQScDO4UJ/
-vADmg+VCEz9Ouk72m0FdBtoJ5vSkRJBhOgwDzn1UjyHF8/Nsc2TGQRr41/8g
-I060AnqmYmdrt0+cv93vb9lQcAfTMRfzNuXhYckVJjXFGhM0j4kwlpPKM+RM
-Lczs4ggmJq9zEdKSdUZs9sVBlsHeR8fNeQGMOMlJuX5wctLJJciMfjCZJLQZ
-WtYj5dRsoaOrmUAJBXDTOAilDrCddqwRqp1c4ITLeMZnWO3ctDAGA7iNfXug
-HgX4dOQdCakiABTiqzWhUccNs3YjqGdbD9Eg38dqxipUTevMGRQLqgKiueBn
-PCTCX7b0W5uo1t6f/fXUwwQ692ABP6ZBME/ynM4103zbsWV4q27lwiD64PlD
-0EDpKis4i0HKvSz26Je23hMORkfUztu1qzil+AEjt+oQ9ru43Q7DOZlaVIwz
-9FXyw9sXbw7u1GVSyGZKjaPDRCh9/uOk2gXGqIs3ChLFDe3WF5jqGisRWlCd
-wzqg7uKhrw8DOMuZQSBvmuFr1zqReGTfSinUDahBLBnw5vJrz4rOQmk8gxtR
-utYbJkFbdRmAb+NpywgScr9RXZj7aLEn2qg5MJIR923BpSu1ywPgJvFdIWKA
-rYLI7ZYtJzxJZXFgZ9Dy2qng+kpWDgg+v7ZM9Hf3tvfFjynpCzJfA0D/Fczm
-2l/ktt36yatTE3VGYz33D8h1q7Xl7HB13fxw8kUzjo5ERzGe73n/nPujJoOu
-RhlaVh6HDXEc2mTtOJKyghau0Wa9W/ZUnop4mMmMYtAWink0QCUL1Vpwbw7+
-G920KWbTjfQZKZ0kJOJgNEpQh5+//qt53cnf0/vqZu9pb6AzrVCDs38FC68g
-nRw1A9jSL+/sbe6ql5sO+zVURK0aImz1GiZmFNAxju0D2bjVQ9nqbeYT2xkM
-nrlLk2AIRheyoi9M7i3CpvVVtIVnAnnFEZycWacSXo2CdGqcYjoiq0Rjp7dp
-E+jzb6Fdd2kdW3m1BI1KI8y1vYGsAO/0aqcSZyADjdV1F8UFAUQBr2CexZgv
-RR5+fgCmgyEmWHNw9u5tx+EljjwlRIyrTaNqUmvMOoURU2lQ+WSmeGzToDSW
-WVLs/3HhvRopHhv8id2WRqA53ePz4lnIA7kpqpSxMArSf6BFHMlC1OECg3Zm
-6+Vz3JFjLM3ilF3cNkfyVNWqB6va83EE2iOrRmhzMP8aX142gn066ozQ5ryd
-DkrXzy59zEp5H6QfBI1JKSSdhqGbwjM6+GIf9DhrwtsYuu7kbLkeYk2MZm93
-0zhw9eenx9EIHaJjKwfUOe9qdZRKQTEwShd1XJao71c7VS2nRdQtyotY1aTp
-gcAO8yOTZ36tylf4w0Q6NQT8k5v1FOocolB1VXGC0pMBVlbaGyNNQQcw4E0c
-WayjEUjJA+giJPG0Y6PgvIvocBJ5BJZAEkwm8D7sXZGKlIPME+AG5yUnK2HQ
-+jRRUclnfWuKRjUcMFYoYwOTkLGzTxsU5uCCytHtkDBAVMWHs3CXfuqQT5MH
-A9N+EM4TuTGSk8QfUcCLu6d0DQ/MUwz6FTK78Ecvq7OU9ip2uDqvwFzLKYJI
-3Y4cDGGJ7xrwbrLa+utcfiI6v9xmmNXXWA9UucjLR1yVhva8llJPrdM88q/g
-UTxTX3mx6ATcvE7lMD7qcFCbqF11tNh1NXWIeS0VoHQ+YMUJnTVGIw4mK27O
-udh5eyQzVi4340qyG9rOU2NK9AzSdE7SppEFg5ZP4YyAFVXjWJVwtcfz2g8o
-Qgc0pKKtVRdkFGP+A/tu9BFZmxhoL2kJB1lDa01WR/WQs2AUhUpYCcnJcKd8
-icd8PIP3agbrP52/hz0gmFpHU6uE/FSHDrbuiLscRbHMDHiKxrren8U6buXK
-ysYlZCRp8+24vU7UjNDyWN0gcP2Frd29FuF+MKOwwixHsM6YyCRsSth7DsuT
-2+V4bPyw/rPv/evA+3/63rO/e//T++XbzvpG6aM2uQcHeayHCq8RBx1xJeNY
-oyf4sAXN2TzmoL6rNcd1UMIjM2CVyDg2eSglkLYxyg8M5jnCuUVAFe0NWoWq
-ZErjtjHVm8dlyPUjqwqe0sitUmYbR1atBlaz4I/Zbst5A2vUdAlhTXWAvdzF
-s8yKNPEic+clN307121jQwCTZQv1fIl6NbCMqJQEZR/EwlFygpJ6VhWpNmR0
-T2jZ6SmH6TixJ54pJx22F2rAgEkamP4W502OMPTGpQdyEkSREyAppPqEuExs
-dJqXVVLFmjqv58r9NWGZoVYuDA6zRvX/6vE1UxupEmW2nm53CVsZzpzoGJmm
-FxIXAFZ+BCZMpq1WPXvdVGM8T8iiCCJs8pWraTx58kfLkncRhX1xYKU9vOGS
-6tj0ShTn5nC4lmlnbdjVCVQTW/4YcYJGnqnLB9pAr/1gBoYJxT/tN05Or57i
-mlK4Sn1/IybSQi6jER8c4vbHsXdDwkKoliiqw7Q+GmrAa3T6MsVeG3zeZ8Yx
-UEoJUilFCPlwf6u//VXXdzkrDvQ3/fRa9k0BWyC+NppUAaEdxFSuF1qiqGdW
-7moiWmLUwjrIddtaX6VMrv8sj3XOZOeHPKMR8x0H3jP4qvczqDjMktz51PnB
-PL3+DD7e+eU3eGjvF3rit/4P9G/nh4Jpwflwjy9mJku4ipdfmKRG2t3SLh5w
-oRS4/dvKnZE0BEy2w4GcXDvN79LOBMTiV51TiXVrCepWlcLoWYVg+vXhpY99
-TAkul3SZrg283CfHx8did/spLd3J2buNk+NDcfjsmQaAPLi16WFATg3DWY2Y
-Yc5CqvLcTKn2ujfoPHmyftYRT8SgD78df5yB1o8y/GD9LMcxz6HjzDHrK1S2
-qdgVo2ACdDHEQKWBoY6pKZFjA88+A+LPsQRtnprszi0jb1iLRr0FtjZ7fF5B
-OVoqrqdRpXaA6I54z7ZRhr99tmMTxEDlwAU/ubVHT8I/Y3sQgzv6nBcup3T1
-obFaVXSnMPeD1Vmez6Qqsv6FmZF28qoOS4EHnrCfYVYh6o3oR/767acRvPa2
-d0Q/x/D30VFX9GUfadE/7hdWYW20xv0sjtYovKVXnZfiOeyz6vu39H2OYuRh
-iWBSfkGqF47XdGIjZkHNMJeQ6C7zk7gzLHKQH31cZI6uAZ5dMZCDPs/1We/Z
-9pZ81qCfiaHPshEytbfZx4JC9ZFqn4ir81Kz8CmysFmiJMgupzILhgYhSyIw
-fTCvPs90k+iF8NAbAl91OrUsudeqp28KXx+6luXGE9zpxpL6kKam2Ft9IGab
-05mXG83N5V6pihHjpE513gynq5JwwkDrp5tvMLrcWR6K3i6lEOk493tq48FT
-N26ll+/KVVuhimp3GpAzABoKtBzaaSKNk+RGNAJ6vMT0nveSUw/WX75/v5Qw
-/Wew2zuvlROtMHxfyLWqRLyq2Di90TzYVKouODZ0deqev1DZrZ46OuEjPspC
-EBH1rFh96gSGzlZEDqbXMOIdkZzHrSF4ZYG5iwaeZ91ycDrVWj6S6kwSIXJB
-lN2Oxhac6jFpNPTzpqqdWSEhpv2oNJ4NSeXItB6Ym+jCcnjjeeRkUt0GCQNV
-aKhpUaETzCcqFzbT9wZozW4au2Bx90z3AcLtx2kZ04DqC6c/jNYzNihBoAqI
-mTfqCtRXG5PSYJSuUxBLteY1CJBjhnNXUUMPRgyS/MygTRl9Ze8WcvhyuFR5
-x6DvI3V2t5D+bhHcS7NFKO9qnuok2yTOEXCKU+CR6LVph8pdxsCM9C/CIL20
-ym2pC9YlH1jypp7mTULjkDIx75pkTbyAAfKEOhPdFSuQCWHAfi2ckHu+d8/9
-2EQe1joVYMVYvoUlDvDf67P3mOM8FspBug9rx8yecgc/88QpRvwVzZn2pURK
-dPF4X0oY3dvOmmJf+JDxo1SCnM+7ViK9fFCxzj6t4dXhPMHCIn4UrDlwjzvs
-dBJydJqP3cV1WwpqYCjzKCpmGuj0Bz9aEB0SplZKqQgBGArSH4l/zFVTGj+0
-M1E1EYCcCktpd6uglaHTXUJQfgTbapnh+nR3awePzdzteqzq9WpOvwxC65wV
-UxvGe40FGeGiuoeEgUJ9KNBT6dTsBPE4w+7vGO6/Qwk4A7AiB4uz5gXRur21
-+tveHWzu1ycI00CnZqAalV7RtWZ1e6alLSE5GQr/Yf6r20Qaeuk024P5CMKM
-APvqpX+F2dcUrEYdc2qYgM4DOGvd7L3UZl8FrDHrlVpFq+rPvA+l0Lno6gRE
-jYFZCTkSvLLqcNiu3bI2enxoqbw82wQ9d5j40YcLf/jB6iNciDrnXRWcVgpK
-DeZ/I/s8RZjHOkQJiB9Yy6hh4QyObcoYGNx+pTnQ0JT3bMIMDla71KWlIqrA
-oprjqA+FdO+YHAptA++4bej68ft3NfJ9gbeG+Mnic/Giht/MiRYHlpljCSdq
-Dsw5Uk7wFe+CGu04zJddAhKTSxHRjiGGhpUauZLD2GYmWK8rXoCZBppfJZyv
-H7x43xGmTSHlLUfxFLsO8QVkpefP8AU8+8N444g6kqjqGwME1xXX/DhJwJNM
-U7xiC1znDIaf0jak837yTzWOOSIv3m/gWCpXHthlQvn/YGFQo1sKwaNziAXU
-YJgjRhkSyhJwylDDJk80nGQAhhoI6Q+xvW+xdXj8c8muK0ifbStZRYBxxD92
-jS/OfshS1Pkigb/IP7g7riP7HUlnBtBmfgtr8Gs9BfhC64RJhMFkDvuQh+tx
-p9pBuW75ELxore32wfZAtbTwjjif0hXAyvXw8uVqXFavcTENjLqmffcqSGmm
-21rf/frgkhj4Ky1ODQHODDCKvtV2xqtzX6ulTC34F9Nn4Il62Nwsgs0UCU5R
-irtbBR3epCseLmQe+TZZXXmYw+lTh9ckLFmqnX4f5KjYPs4UzdT0T3EXy3vt
-L8iS1Km37+UEpUn3mBPrb16/3Xjz/u2XWh88np9dzjxtedz1AiH807+cinX6
-RUZIhClGeP4Sz0Drz7AXfcfYPQZ9faqwkuLb2R7Agr2tH0i80PYVLsi7eebF
-Y++F3UD/jc8P4vg6tle1+Xyh1YrjC2/KKN71QqXGeFMpL9odCfjyQbvDfpDP
-H6sfYk7j0u3DrgKfACjHrFyT/uLVaWfZ2frvfy0lqqPZQnXaMPcwL+4qUkXQ
-ubtEfsvzUp23iwFvdMpVa4FjBYcokh/2v2SPutRU/v4kwZ96Uznz+M+72N/f
-HbwBlslbex7zQJTlgHWWbKOCwj6GiTjHuQpiCw21u7kD9OE9uaK2k8qqdQGz
-dZpkJ17oojgb1XXAvYPXFuZXfDdQLbg3qpENOpUj7FnG5MMN7+Q03+w0HR8I
-/ShVI78c6y4ISKkb1n1bLQnxGQTNkeQ9Mn5qaHyo0MVTgLySOvfWTEW1WMfp
-dewEubqj33iGMYS7oGjjaZi5vJsLSCLLyjD4G68bQ4HIwgY9brGsAi4Y0VMB
-lzxI4wZe+BIF/TJ1xNXbq9OupnaRB0u4/XUMcE8wEWdOkcR893utRq0xyzmX
-0MsSyWeDlUeRKxJe5RMKBFo4c1TQlxU4DJ6qA/fiPMtHee4hnJl2ZSChwjFq
-NAQq8gsN5ZJs6qUyuwtGBfcawYICOg+mUryRfjrnm9/BoT4HjZSXMxA75wey
-y8i4g2Ssh653cbfTdUkmsfWUdURvV7O1zwuibETrEL585UTtgPNI/VEkcwVi
-DWT+0QJD2LTpk//F2y/UUkV+hH3M09W5t6DLMQHSwnEDGn2R2tR2REp5W7oF
-ddTG9rtinYEHNPcGtyHLu0gSECzXWx/sDzq/NwrNwnl6exIRFKbRt783Gsno
-Eq3mW0nXAfUmwZPOyg1C6DsMqYKGG5DDR6Gfaw+rm07+7tA24XX2rq6zcntq
-FmdZvA1y9Z1OoWMBajmU6a/jULT4VBM180fzEmYNtGuMUg2RDF59NashaIql
-8GoO9vtfI6M6rsrO7l5fWY0HZ2fvDk8O8L5d7drUXLXTtBh8+kF7iFVxeEeL
-oo5WFPB8cSTdLmP5IO6DYjSnf6b+B+lxNbF3kUh/WYtYWJ4t7UOc8envvVBx
-FM9hOh6aoCPvIhgFyZ3S0QYvCDxrAD8k3s5d/zLv490Ahv/hd2Z57SJabc7B
-e5QzrOmIsnBhX2YHiKgMEV2QvNSR2653pvX8APALeyK5J9eyBKp+MfBM/DMu
-hg3+bhZD3xkAO6h5WammIC0sBe6yOPSGqQ7X1feUVlPx/mgR+VPV+XAIMmR1
-44lXWda2IuPI2f3wglP93eLG43ut/W6Dzx3wJ/XlyyHW7ILXl9hdfeb4//m1
-7Py6ZDuE75BBDmlmjL29fr8m/lqqQ2pna5QrjZr86HjsYbxzCjurN4zTjOq+
-HIrW4NFk1JYxoNuqeBzcmVRR2NIgz/b204Gb4ZPDfqnrqHTYEhncLMthfqe2
-OOZib7oJZB6pTi3WGdPp4XFd4rVNnjD2R/dDHo4E+kZlqV4nZnJtuvp/FaTz
-PzLpEowvzf2wfGHXHdOQB8QJ6yHzkpaHQDDNa/5kktOKyjDnKkf/c/Oer27y
-kDnhzEQtPB4SMUlw8ZZj+g2TS6y+s/cixCa4iYZjbjTiuUCSmA7yl8EEL1am
-tx4Sfc2+gcHue6ErjsiNfUgf2zfdfqX0UuXUBhbWN1/Go6W7uRM5UEGKvKo6
-R810Pa8reCEEqGoyXChECmGZGhRbpRD4eYm3qh1XyaPqaiU7eMC1Y6kwSFzo
-sy8sw319vCyTfWsTowjvrvBaK3lNJuMp+LvDgPp96CsOIpk1tRnIO5Bv9542
-UEz3xwGi/XMOb96aZofL6GToE19k9JjdeRJxIH1Blwip1j3s/ef33fkCGFFg
-OiZYn+bVE3UFK6LN/muUp0xxGytV+GumLNSUc68syKgrDh1lUis2P/dCTF1x
-fhsW+BvqyiqroCJ2Gw+p2AVa28HI5umObtLmU4ExdbexYh7ZPIly5imCQyzV
-2azppEYMZm1mufQoFT2SeFHafbCf4+Y93dne3ecT+Sptg2ql4+oc87rRPa/U
-3Zjvec74YlNlqTS3XHt68e+JrQ3qOQpWMymfVYnJcMC7H/gmK6DzRpzwBVcG
-xmW8tC/JyoXZztLcyWLXJx1za4obxpARZ9UlQxFwmAdbanso5KMmMuS2I8Vj
-aQurxtQJWRhejmzciMB6+fESV4WCJcJjvNoySIvrz+09DXpKYZy80tO1RJhL
-gdWIa3jbXhBiSGZZpPNeJc6iqX+RxuE8++poDqaUxoyo/7XSL4hAkQelQ/6b
-ELAF2XJyGfSxgD0nXa7DnovEx02G6vfo5m4MyOGFkxpjA8KcUyFHtwiC3C+x
-MdGHFOGqWglnxTTU2kiHUUkfqT5wdFRXo5vyoWebM2eBXaSa1vc4z+pROZin
-m6cdG5P76U9iz2V6i8lsvjldAfmvtfCqhkZMBf9GKUP17ObnQU83TLuE+xxs
-sOVHNi8sXAnf5sUr4EM1KNJPsCXGdWQdA8O+pftq2EWc68EYe2R0+JqSDBuK
-Z7SimC6nCxqxty0YJnnfnWXTUrlx8q5nlkPmxqKz0B+ygiqcHat3AeP1tNMK
-ab55oBR5vQOkGbLC2CyG6oE0J0fJOvQ2at+6k6dC7nMOwqshbsXRgLVCl6Gt
-xM8GE7qFI7/uSSshB89m0ikkrvWVHmk6nodLx8VLGG4/qHO3RzOjBJi9x6Uo
-tx42oHCQhrdkeHMJmLyBLW+xZvmir1pDvmLoGnVVQK5p9loCqhChC1Bm7bEh
-JfeZ8cExCm30Kg8znaH9OcU5vsAZZhmNu6BPkToEmN7n5sSV18cZRRJEipx4
-ARZfY0K3I6n4DYBacxCbz9bwwD2q0ul0bKoCMnxNugixplFdzVQEhauX3zdA
-QNl4RiO7DlYzA95eBtsIXZO4rcbYrSWrWaZuOGhZfAol0TcmJlc8N1CSuljm
-UaZi7pQ7fMOkzmgupXB4K+1dwEG1//xwp4i02jIrEXHvw7oTZBq30hw4WL7U
-xqTA4CuObu5QwkOhWvZ2Rp3Pbkl+ttlb09we+Pbk5sFb0vjWtG1BUXQ2qKFB
-UWvcdCVhd4jaKY07GLJhHJKVILryw2DEwnIzH5J1leplmENzPMhVURglsbu0
-jcg2EOLHGeoxGy1VDebeDdq184nBIPEDK4mMXu5SY0Xstjjzhx9kpi87oTss
-rZeR5oD87D56nW72tlddWmDmElfdlLaNq64G+oJEQGFJ8pKYm4dGVDdHDah1
-JK6IgLqiz0MmKkp1EdEGsh+ojp/+eMwVDnhxt7kDUd1dESeroxWGt0JLo0Oh
-YNXdmPAATLGkE+FbafDGXbNSsi6S+IOs01c2LunwUk5vYlUV15IB1emniiFn
-mKVvsmFtetXg10Ayq2BLHyK74GcJtltQZzNqhR9QjVgd+SrSJu6OeAr475J0
-3DLkM5HOAH/gpFOt/W9YROuq/UKVVJXW/6rKdFpRpLbKt0y4BiZas6p816qI
-9WDpo1ppc93vbSi0/nIehh3VyBzQ+V2S6TYEMpShDmzY2cgpkf590YtrgcsO
-3Qr0Guy/te775bZ1v3uKDW5BsQI1gIADm4BYsLL2YMkzj7BiqaaCekXG+nYg
-foycQrKcTL8vprq4U6K9+LegWUMHjJVI5jbAuAGFvl4zk48DWtuZ8dieOgf5
-Vb2yrqCfzZNZnNb6pnwTZdNiENSG1XjLEPiQq3oQ9gkorIvd/iyUbzEu3xmd
-r7u5414Nekn5izw0+R+YFj8KbBg6kxnpSAUfCXstdNZz6Uf6Nk9smsDpCcgx
-5m3wEqf+8vzGr4nb4uGHmFsu3s0iHIjXcUr0s6a1/jo+7WjqIHl9Ku54QHTi
-NVfJLrejT4l9HjRhLEm+pexykLFGQK1SfRRBbHalS1XNtFTKqMXHVirQA6Ll
-SE4Sf9ToAK1OTg10CUXNvPiSxIdOURArLGy9C7FlUL8Xsb32A0oWVbH025Hm
-p/P3IgumQBI8JZhHeFvlA6LFKMZ76oEUgEq5beJKlDiK8YI1QJ9ArR+9xRts
-jMQZRhEXcujPqS+vmVFEoQ98jx/gnsgPiIwqoqtNCQJwC2IWrHiVeKQVf05A
-ullODadQsOwxRfoHREbXPaKyOU9pmlUuXMvjzU5oLVTFgKoeTwM2M6HELiq+
-SKgxT3oZx47X0OJ8UieYJlIWMpmb5tYoV5heDSuQLAqNwXQ6KBY0+vrMErY2
-ah0clwxzNu9nKGbYwRgPTC19rlNakXQqpcL/IHPfAAB0BWevXHYFT4+Tk3WC
-uO3yPAReG4bST+5yoSIngZvAM4WU3lNDPTQ6KY62nKUKL/nLMzf2HsPWsPmN
-GgpNHWFRSpQuFHaLflU6fZP//IDWi/n68yzXMhZXoxYLK6JyUOQhULLM+TVh
-gq+R+5uCQVbVoMYgCBcsHldgRtA9tXhWbV70jRixS2XeX1dulFpioL4Tj1x2
-QcZXuNz10Y4bL3N5n61bWXtF+a18paj/vR3r5aXoVik7/RU7sbkgzsNQO8Uq
-F6GBT7piHoVYspLfclzhAeJdrv+c89oXw4ac7Cwpi+nhcUK9A/0gOcF5/2ac
-kJuD4G5gDVnu3/GN1tQXjOMqLgi8HQNvufn35CT5USbDIP0cdiZsqgkWX8Ks
-6MxfXTkeJ6TOD07PiLzlAmyM8/MlI/DWME64KLwnxIk+A0A7qXgEAF6DgcDr
-rK6DSB5g/J/sl3uxiyI0yfCqa8tAykUhH7VbDpB3y8G3LgWdiPB56i5efKq5
-7OEtRaofy6+QQo2xUhoq3oSTjH3sNmwGtaEtS5t+ulu8KK/VhAw98otjdd8u
-WLWjHPVlM5+lQ/fovJooDXx4Sln0HqMoDvGlUHoDWNqzQ2+wzBb74gSQV7Pw
-dgQ4RpWEPW/+GiTZnJIHgitqkhpgF/vjv56+XnplW7//tOG+RJ0zQJf4yiyJ
-hR7TkOFlnMynfE9pb68/GJgnxBk26wH+NCRcRpFwMx3ejiJ0c6O3KVyeEOuv
-N88Ov3qGyEbT280e74zxjgIuk1XNIUL5MSfD+dGbr54KcRbdjgrvzt96MFFW
-huHS+5oGW3v7lT033EqSd2enL3kPcK7DPlQXlGJSzVUcXuGLr3q7/WfiHWCF
-ffTOjWXYfHNPPs/R8LZicORnvji89Kk6Il8qwwdHh8vFATTDZoNmsIfI175m
-KFIPBh9QDcxEyxrUW5rh9ophejHyvZJeeABqYXzbub8MLkApFqf+8qudOp4e
-SdUh1OOc+ZUsI/2uUzf4Nc9RlQMWT9BcGiw1hCgZTr/zAGYttZ1w43kbS+OB
-zXw2KicotJ70wduzk43j87MTcXr0l4c28/Q2Mz+D+Z6c/+id0w67KzbE2bu3
-x+cCKSLOB71Bf/uh0WMUTIIMvO7rBEuBk5vT5ogBiZ8UoAdGh5C255tPn7d3
-sT67BJyjYNh5aAQY4x598/nTFv8g5+wNlVl4u7lr4/KBkSAezct9NlrPXDka
-Rz9+ADtbKQDs9rcS9z/d2ty7IzIULsZZ5gcVnag29GJgt2caF7cbcM+DIluI
-8aCbK1eKJsnepNcVey82Bv0XKzHYqiEmMz9j3t06xMR3ImiC30GHS8pYUzce
-zGcrt7jUdzTMuRdLoSCmAtsmq4gBqBw6jv3ofGlGbzkSSXpV0SulNQq63si8
-UB78M3d5tQma3IaYfNuep2tKWxJxGM9W7iRRwVU8GgLLS8UNV7XhKMIjVTcG
-lqlg0Gz0JQ0OCtDykrPaywqX4iq5EA3Pim6NrtSZIS3K6lfEmIu556k/uUnD
-EK5xprfrmoQQ/CAahvOR9PiyFocgRQQaKLJ2wmD4nTV19UvjwPLjnQx8/LF+
-4Ia1eIpiz2/SvfCp8HI9UG6c/NfqztpeVQjXtE1uM/s0CSc3nbuaQCrO3r9+
-tSzk9EXnTKJ1q+sOSEup3u0NF9o5A8myeLfsE39sj7dsM9nd294XP3KuOF0I
-gV1IXvmZvPYX1vVAJ69OO2RrwAx8J98HO+co+6SSttiBm19cPulgUrGntps1
-NqR/qNO+rGq71m7af4FXy9NuGmwkQ3/h+aC5QUhvOuyBen3uVq/TPWE0wLIj
-JHIk6YBoCfWWnniU50YXbs2nN53bG/X6Vza3JfcQrjDBQsuB9/q2wRcacFdZ
-WcXrlQz3v8G7CoFE5g1QoShVO1v9Dt53NufclhxTVQIQ5rkhmGU9pKy2jK/G
-XSaxALv60JEIWj55NCP9FS9GxZZ15pPPuEq6kby2TNIbS5jZLzBhyO1PH82n
-GLsC1aVGGZl7tHOXKm/5HuBlc/k9c63Qlx8/E/ox4DJV7OPORQ2ZJ96bOa04
-lyyQdGW4TG6zXedQlm7Z1oDA/OOg0NKvCqlm/eO9DLhtH6Ni7iNoi4T/8dZI
-+B9viUQCwh9XKOH2OLxnCK0xMDfaozhHdMR7E9dDm5HD0MfMZgNriYLa3MXD
-f/uSGm7SWqFc8E4uMh2Wz8N4OMU+kXWTbTIML6nRL6UWZiCcF+hjAaNkeE+Q
-dRkeNTjKTR3uGNmlTpLwKm8N03ma4YV72MEOnUGcqk97ZP4e3cjnD4dylrXI
-KrkJ/RyNfkdxkWrqF5qHfgHqR4t/O+prN/Mroz5Qb0SvsU04jx4clcFHV1sy
-N7Ac4i1fSZAXLbXfK8HbtEEJBcpfGsT8bJcTYrW6NjjcGFnttBsY5509OV0h
-OJuFQW1ckW72u6NhJV3B/BBumyfP6G6n3cbZ+uLzLt19gDGxG5gdGAUr3XpQ
-1x8KhwgmUbE1RT0uTYETgqPCcJpSqyCiLjm9PSLaY/L1valEk+GlHH64CV4z
-4phiv+jbopZDvR121zKYXC69xnpF5AzQVXFzrh66cJizhBPMPgbzXvqpqgNR
-AIIs1Scu+m2s0NC3FVHbjnu7rqgZ65Uks3QVCYESDKrxjoXy+FHsZfGMqmSa
-F95Gd9lZjo0bdnFT14HoJiCZ7nYUxUIPbrQg2Tuqto/uujaPeDwX8Lrr7i2q
-n+NIztBGijKPb/K+t7nGEVWaTWM6T1ZImMmWVpKx464dYMbpyuaeeeP80oJT
-9z58NA9HdnzMFy/84YdrPxl57+VwnqS4HZVuQV1/8f70sEOXhYDCk/7UvI93
-oJNJP7wMADL82bwNbj99OuiivOzt7DVdTlGm+gysaGvm97ZQOENtTRmyL5tj
-f1U+JPeNKjsqQ+yfX+DMikbxiDiTPAYjaxcLh2MNui0uB195pUdU/8mfzKMP
-EXCdRxeZ4bUr90kbYWHCdLG6DSjMcGcIolHAEWL7Bcb3jmkTUasvDvt8SS7J
-5dCgE0SuUqPp3zVvkJpRugBGnsG+Vrxc/XOSwmg5pRIMPXJcPqMwMEm1THwx
-SWA08o0Z3lAo3fHcS5c6f9YNecz3QAOw4SVX3uTGB+hB4PXpkvlt9XdWFebJ
-MPamwUT1SrnHuYKJ9SqMLzA/Mo7UoZeZrhNKWH91+A7PyjSSZFuM4/myVJzt
-7e3dm5AjjcP5l6DG4TuhhzaE+BzTpI8x9EPAP88sYT75MjluwB2bLrMPqSc/
-znzObblPWUXw/yUX4mx+wclIZtHWT//rrCNEjlarO2q2tzdXm/pFMhtirjJp
-5C9jl6JZLggFyyxpb6UOVpqvimTf9+6jrAtlfrXbaVZm4wqT894m2MLIvHt/
-45693aI/aiao8KCFval71RAScm4uV2esX2sgqArXhvCPdaG5ih2XD/+bgmU6
-zTBOgkkQfd2kqUR2tdCYjpAzhMZEicJg/ixw5aQCmSbxKIwM87sKfHGAJzN5
-+B6Mq+mU9o8T3fol388OTk86LZEFz2h2x9iWokF8rlU8dCgL7TLlVMDsophS
-eWvMX8QJsHBFsuSLV/X4bg82XRl68oSee4IHiHme2CSJ57MgmrCufvJkg5/W
-H+OZUin9rfq4FxA1b3ESG+dOTbCoJhg6w+bxvpfA1Gk8lYI3K7xX3puFfoSn
-WcNLam8E8trN6w9AKiVWSeSqN0vmw2yeqF7AJnOpx8FEPNnAQm48sALhXrMn
-lN8nT5KI2lv3G55HeQqUjYkbqdTI5EiIoR9RHsCccvbhbWxxnBBM6s6VD2lD
-1Ys4jKMMzCBMgaogfCXpgfiH+VvUf0xhnro0Z5SHl3FgZ62JMsaIq6F3zYoY
-jIWCmH+7yNFFhLkr3WPFBvlrNZNRnUGKQy7ce3MY7zTnrl9tCKH0x9XfqJW2
-ifvc/b4GKUIsz74s5MfpscbY6C9zsCQBLP2qfvlUJ6AhFea1EE5+8LaCSVBW
-Z21qZOEPL61lciW7Toq6Yi3JuKZvf5IX3fFscqlUAlktHc7MV5YMlUnBE3ck
-A6dpLd+/mWTUL8sKcmIY+I7EROFtcqhtzLU804CeeeR5BaFhWDwhakNoLow1
-0CxUKyTXlseKw7wm6Txg1mKDhJPK0CBWQKoZv2GIOjGwYArrLQPWmh9RWp2X
-JDBEFa0nFHGDL6uo3G9D34PIxgMbfkfBP+cyNOgt+B4FwqLnMNjJWMTTIANx
-7IJ1j6lk8ykJtOqybCaqXxcnRw6AKz+cS/Gd6It1DgkT4p3yGitiDMMAD1a/
-KCkYhxsSgl++LRkstqsihPV1FSnaUOKnS8mpE6hZ+R4YxaEpONhYABNqLHAP
-cWazZo2/BoJLrVfnQXpJzl52LRn0tOfQzQFhUUGsy+ksW3SU9ahy72A7IkoE
-qSL2qFkvODv6DLwhVHtooHOmfrp0f7feUVUAqRdH0gMvQFXehHi5WYN+ObVG
-faNGXT990wF9zEo4oH7HGFQN6c4c1S7V2gJxA2QnT7UgxxPVlNvLgt/OTjuQ
-9fSNqV1RHrQBYSaEBroLzDJCAICfimsZhviv6jd1fmygnL75HHVABjxB2Nvc
-2hcW0Tx0wUfsO57JUG0/Y+qpjtMI7AobqpIcOU0V1LspdnE7TTvixxQxgcky
-HubVGnz2tnf7++LkzDtZWvRWKppRYuvwSy64JLbzIMq2Nm1pTvxoAg5kv9cb
-7Ozu7m4OtivUQfUe844HUnmJePIOjk80XCA3TINhEnMFX24ffarDUl2PgM61
-i28mlXFSJRjmpeer4GnectEq7uxVA2bX8SqS+Ga5zNXLmsF/mcw1yFoujktl
-7g9Zu5GsORzxOWXtnAe6may5fPtZZc3F8xaypvVDq1jULUQtt7BWEi1XpAyM
-P0Trzrex+qLcogNrHvACKaU3DmMfBNAwLFjZWSoeXyywsQF2o2OReWxxtLbi
-P/Zn/cdLON3U9OZ4ccRhfpEl/hCvA+BTDiwgSq58PurABiuWDVpR5asz2LCN
-KiwTmKRW4a9v3Y0ttL+D94gJfzJJ5IRyuRKJaS4jut4iwU3qf8dnXGrnxCpK
-vHjrMmCrELhpyy+v6N3pJLWC/NUNlrBGYxVmYA78vjamPDCn+QWuLNaZC70I
-1uLlr+T15VPp45VGI+vL/IY+61IbgYd5SEoVclGVIninpO7DxEWmqBTRkHnp
-XEQCg8+jER68Iu93rSy9fNzSFNzxwT1TV17ReS0sFXjAJEkVwJpt0orl/UIc
-WrWe7Vh0ngUcyvvKODTXdIwh79jEo4lUxZbm2g6XP+0X1ErT+q4HPdmjixEN
-t6qKDOqVk3TsKArxXYHbLipxcvjN5lQ+/63nt0pwzRxXXq0vxHDVy9PSjtOz
-qcCsyXrT/hkYYNllEmcZsLuG2au0Ce7U3C6H7j6ju/uHNfN7s2b+sAV+17bA
-H/voV72Plg7kVKhjxS1Ihy2Wb0GfJeLTdgu6WRSoVWjzMsGrtsPmK75faRBj
-Pgzg21IpIpK/j99pBsoDI7ojRI7bHC/zbjAZ7McalvV52ynmKDRN8VCfP2Gg
-tIx0fi7bELRadjirLQmuVLMObOqCWC32udvFkO4iinSrOFJlJOkuYkmKgdod
-rLV/p5hM9KkNeyguXnp2rx67S/bY2cLunvpKFjSjMGn1iPTIGxbWqW5z47RE
-EYULohqpUz4guYEeIu3r5ZRcIqxJHKaW3rYVtpVEoZW6IT3191lL5zPcK6l+
-la4uvAKSfv+d1l/mszVbqXN6+RRew/6MjyuBrGHIGUtvYZej63vp5s7HFlmt
-n28BSGlEJ1mm7gAdCJCCfQ4vYTePGkxcM1uIxrGWnEO8/kNl3YPKqjghjcfj
-NL+VCH9qTI5mo8PJulotbeUdY8BZJKr31YjbGbjuAVsn9FxtbkmRBWsmVpVY
-stUK2xMFuItcqcyiLqKqRiaU8X7ZCKcwLS6typZJayfgj65kkgUpqc2bTON2
-szDD33YelRpwBS4b9HpT/+MyBhts3m66GkuX7MpvcKZbIEV5+pX6SGmkFeTW
-GTSX4S4oHVY5OxUUdzYktpc9vInYImz93mos7DaEHLsiOfMTHwBhWrofwn4J
-g4LLj5UrYk43M11gvaUzJ8pNDENw8Ti5TLX8VY6Pou46d8WjS6qrQdS+Gkfh
-oqNKZ2S+rqMy85ouFiHsLqOFQZ6cXRoVu8eJNT+Kp34Yz9M1Bwbuw/OI21qK
-dfOQuAgy7FfXEdfYhBO90SSYTIAzKpK8qpcub+pwfysHrsmDXTiFu7NuYo2D
-y+3XjG72lqNbrBs2Ewzx2nUJvzsK5dflC5TnLAZjXX9j5RuCSw6GZU4VRYmi
-DUbhDi5ez9eaH5Ufh1KOUs5AMEgji7tWXM7urVncRaGCbKtx8bIMSBUy1qkS
-y5IfpTLQPL7iwOonU9duUr+hLrOA2SeLctxGJ+VbtXe1rlcd0ELGPeXbc19l
-4CEsfrXRdfmu8TG1C9NXbpotLZE68FFfP3e/xevl/SxG7JK5LHzZmK1/Ke0M
-ZGzYqQp4I10mUUpId1bcwhzm47mUdVHX35fQU5YB96F7vAL2Z9y5DqNfcQzL
-ACM0YVkL6vFbtTA8d17tMrBKa8G02FyxV2i3MBttLDztbXXF8d9OX58cnpz/
-z/t3P8ISwGIoyIWX1DVxu/vqti4q2vkx0nyG96x/oDaD+rqO4vvyTF/ekZcW
-etUGj3ttR4G8n6rFAeMWLcSh6jHFVPRVNmuQCPryzuThmGgmzmUy1QXtpzE6
-1euvz087lqw8fHGor6ux0aQFqCqtcZAFiZnEpklsO3SJ0Cxr6mKfqpqbEtot
-pJjCZQXl/Yc431ic51FLgV7y4JcT6fNTW3JVyV88vdAirk6dsHYNWadQLYM/
-2siFR2iPODkyJcPAEXm1TmQRoQREwV8qlH/YAH8ovbZKz1IPf6i9O1V7fuqp
-+1IqlZ35ukbNVb6OP9xvIJLZvnnkLkX5YJ7F4Pah03e2SDM5FesHZx1lbD18
-Aa6XhIOzZcxfs9CFanJ7kbmyuLTA9Ujw8QG+UKrM1gfYslRT7cRJq2MN55ca
-z/Ici0M1lSmDromTkfKr8W7X5gY9l5JunkxGfDxSkwmBSVkfKzMglmQxOLBx
-JgRJbdAMNd9lLXrY+y175WqvCoM0U69z4xS86ggeCJyuF1YeysWC3oMhEmrP
-jDHYRIYLTmIUH+SiGDfW57urhRKcmX7uQMLKjm5lNbhZ3gdrjnjIDmIc+pO0
-EnlqF2ZSOzx6cAVM6WTRyiWh93tF3Vez3950xy0ZlXRjZ/9Zf1+8xHjje8mr
-WoaE2XYKWNkybQK+vTPYF0eSb39ha9l3GZqvgYDd9f27TgnGW+SPkxF2OfT4
-wdpla6EIl4dqPkcsoq3T2VKi7tkFMjiWfaE/JOjfV4Jcjq2VoD/c/4fg/v+x
-pYo/FELlsrWPHRTN8VUiB1+D/16v84ozXa717t4prPXX8KfONfxD6h6k1K3k
-0df4hhWZWpUuPbNjIjn0wtlb47jJrWd+xBS+AONDVuKm69dbMAvevQRxkm7H
-f/zBj/XFKleyrXjklIiVcKmUsiDNgVUHctSQdHflXQ1pgC2JHZmYl8Exf746
-EHCiLllJxfWlxIagJmahFsKaLyJWxsSuS7px1CUPruiaHyaAtdqEE7FiKe5R
-UINp5idWtgwlUz9ej+Jsvdfb4EdkNNrQqm3DhLspcchOg/5WPMYcofWKRzvF
-54A4hY+WDSe+ExWAW8CtQakK+xY4rKlKuLVWc7opGSsQLoztSG0hi91aWEoZ
-F2sGgTVeYGqejZxTn8ae+lPZ1ESxnjlRCrhejVAwKk4EqK4Lwpq3/LUwsWHw
-8yoJDQFgDneoP7ch2GcZYKzw9bNkCyAcmwb5pbYqrS2/Ix1/qvbyGumR0ahZ
-dogE9yk9dQPer/w0YHELCVqJmL8TGYIBbypBVWy+RIZuJgVpJi1bun7Toudg
-h1QVSjrXkoCY21St6bkz0l8xF6DkcWSfUyJ5OaiWYYi3YMFY1m1C1t2NKfg4
-uHFqYHKm6pblR386C6WtRlw2+A+HCSRaXdhzeC0nwpr4XvRr3/++xfv/IfoP
-uwlxsUrCwXSw0lG7xee0TMut9U8Om7INjO97F0E29WcFY2sBX+1fyo8edwpd
-YnXpbGHsHwb/m/izvDtpo7qwGSoryaWOQbEI8mnWLE7JwbHdIGXq0eMsML18
-ozR14lzofRFMSG9g+wUbxlo+2bWibE3xIm6UDeyP7aN0LjITYMrf02ppDDO9
-BIPTnhsXD4VynOn3CEYq/zlHtxPwfS190mb/At9QcP08P2mB0cXIJot66i9Q
-qlXfV/IcL/Bij2xhz+EYe5ljlrQmnsZhzeaANYcGAHqWujPQ6lWXyxP36UtI
-sEmGu9Y99uXUj61FuM0sFbJjkrzLId+JwU6/3y/kkhcw/U70P/YHffwZdBGb
-aN8ZzXOnu97vkCqXWdeEO8Ev5VsBieoAdVYIa/JkaV75dAEKo/ctABVPHAXV
-sRta4g8/iYuipdzRZzDTXgPOm08/B9KbT1tgDQ81Yu34TdU+O6C91Fd3Cu2N
-u2j2H8tp09swnV1fA9MYjNUGOeVOAVNqx0j1qDUd9ksRhbTN7lyBUGWTccS/
-NIK9F+Ch+2NyUNtsSTi0f5FS9UWdP2thIgIQLzcdQLCIYaWMohQ1eRwO5SzD
-lgbP+faO6yAFscSaFwO6irHU26WLoPCnvt5sd3v32b54xY33daG1OA7Z0rGK
-e4/xMhP7DhT8Qd54hcXanqqDxk4c5WptZZRVB4xaxZpi61ZFVQ/iccSqgYWd
-qxh1Cw7TM4I+rc4rUQO4ORZsJagbeICgNufkl4BZr7a1mk/0CQnvUGsWiLW8
-s3rtNWDUtmiIlYlEZLr0xZp4ZQiHr5CviOHsWcZE2fapbfRPyKniLNWpS5Gd
-R6oP5hQqbijyNJIe5yha4n+NVsxj8Kjstfmu6Hat5a3JrMVQ5DDQ07VlU8qv
-8NDab029y9H0NZ1ESXk/Bd+Dhq6cTksiUCzusxFBQb8REdS7qxGhMJ2m7Qn4
-ewoCPjRqZ0mjFHxa2E/nXXisnrvoPloz8603+LtEObsh3tTN9xhQON9tFLPK
-7UgHoHLBekwzp1cVXrQAioIuVSuIc6WY0pE13uVVzBpeqosKb9bqIyXjhmOK
-780j9YccLWOX1+rSc40st6YCKgRJ3qFLNRdXLGHvYspwZZJQ1Wl22aKDw9PN
-/uY+HWHgqltnNgDvbD6bxQkaLdY4r/I7ZsQbmHzgmaM/uwUDHfrR1tapWhlg
-m/kMCBXESbk/IilSe0nydgi7lbEUtQq7LTQtHmTlrEVoCI1Gm150q56WVU2e
-Kli/+NwRi3ufekoHzXi5202MA/ftNvLIrxGzJenVrAWRVMUr6RcznhspqW5b
-xldotlS9TKL7VL0VNxDZT5R3judVs1QXtZqH1BZV2Gkrzy6V+5OX5JLBRoE7
-rc7M2Rn+jpu1mbgqZ2bylI25Cl+oYBMoDD0/vPYXS92im9ov5CPZAxoLpjhu
-nbdE2c/Yq3BBuc0t/CiXsHolMKTBQ2rEjd+MxHO8kCpCGoktnFYaYS21RWk6
-ttWNe9zT+pZJ4/hzy8RxAnGb5HH8sQKPJDLlYveyRiozhLbm9LLcJ0do8zMX
-M03G1XiiMPM5nZ2UWaRGn+MP6XTr7XJtSiEVqqjYq0zjxy25seI4v5I2xcY0
-wqGo4jqNWuBQOMjqWOfuhOq9XY1WZKta2SrMqJAF+fXKlkstdb0jMASQ7XGR
-u+gYI03CSfELe4Oo/r7xaILIfvb+9avaLHH+YVOnBn79UrfEQONQbM+V/3wq
-flT6oHEIvN4uH6Fhjy4NXhin6ZSn4hZFfbxUqJTCLxGdEqIqzaapArPyhKjS
-qGkMHSw3aCwtaxOLIg658WIQazRi6jcNJeyGq6p2jLr9os7r5FlU7tCl6ZQO
-bWrnUKfo6lqqVe9kjorTuqml0XBrtXZLpWZYr9lYWMaRNRG9VTnSMavvgCNd
-tO6dI810/uDIu+NImypNG2zt9rpsc23edZZurI3bavOm2mpTr9tQC7vaKpvc
-zTbStoXTt91CqzfQVnumGsizQ+TUEK457OEedagXyu2+8h7MteBbnqaol2oP
-NEsDlBwy66ygzbGmVl+VeJRdqcqjMvxp5UHVHpmtwEXW8VmVXsK5uEdqmPJc
-dACYdDpYoube6AJR78MyyS1B3nlacISq2q42lsnk7RV1cExGIy+LKX3TXSBQ
-vweUnlL0bIyvSDViBAxklzs3hsE0yMys9SXzBQgO8W4paPbB5BI505qA5ui8
-1yBu9nOtcgd4I8S09/E84nMLu12jbxxTm2GsihV0P6czbB9Bdgnv23RdYwUT
-qaw4P5xgzPpy6ibF1bQ8dmZkXi1nvSk5dVgxGHtj6WfYa/hxif5K7lxm3Hgi
-1IiYBKWBYp/E/BmWqjKkooQ3aZ+GKWsGsLVPReGSvr2hLjGgXpXAHM8DeZFI
-/4NM0sLkrNW3nvm1Pebl0KvWQhbA0lzomfyBsoFAxMwfqCToMgPlvBIZAW9k
-IGo+xVxnM47E+1V2hvzn3A/h+7F/FSd8/ISwcKVSapjM1h/AmQXDDxUAKLdO
-plmdcVSYYK2d1LCv8M/y3YV/SoGF5aZWi/2maaWbzbHqUi4ScKOqPKOqVhD2
-8ttlwS/pwnrhWIbM8rrgG2le/rmp/uUf7mxfwr+G4dqw20X18lTzXEUoqxgb
-jscetT3GbI1hnGa0d64q7OXVLNRVVSK0aujJ2d2xbBYrHJuvt+Giz/zRZdZz
-/qin8uaX7OvFAewkYz8tu5W5HV0cqmRLU6x/FSs68qc4KsNd2OelZVP6xscQ
-qrrZRv8zGtOqm7SaUoHz6iZYtJ5L5FVz9UfA+R6xhFtIbKSkrfFM6Zma7uwZ
-lw485HSWLZabtHUsufBweW/LjwSjiR15mD94sYIX3SndgBcRTi2ZFaHxY5fr
-uFtG6WlFo0JVxpJpFiZaXKUqnd2SfpXrHtQdXLXW8hjAWq7gKWy0TLUTKOox
-0E6ICOgsiWfY2V4ui4rk0G8vO3kUrCnn4w7laIWj5RXlxzfSg5Oi6cgAT5EL
-fFk+UG7S6Ezn4gZt5otr0VJxV5D8BiqaF7+Vfq732FhyiEwNHHaX2tksye+D
-wwqTujM+K6yrmXSF6m2rH4urfBPVOArSf2DT9giz8ZdpSOfh6jqEKnh5P6bS
-kEsOptD4oXfjsdmnnSHsgqef2J0yJW0cnp8lwdSHRcahu+oKEgvFUF5J+5pX
-jCaoLDkscuHrlPB9vNasVzOI9X7+QtOAIr6SSUL3NnMdn4tEAT6dE1rTaM6K
-VGmFpbTBtjd5UoK6OtLLUyWX1KA0JTSqb+uPL2qfyg2A2kdInz1fyuYtc0Rf
-hfGFHyrxWpUGBXVeMWTDAUr9kCVzwaZ1wyq7z9cKfRMrOS9ZRswKYXDrrWUE
-Kw+gJQFvcUplC12hY7A5qIbDp9seOy0L+H4lh03L0Cz6uf5wOJ/OQ58CQ3VO
-b+VhUUsM7AEqDoDL3YNaKIZm1YA/BWarTKJuWu16k8vN/WCDAXarbJ5w1oBD
-jbxgxFcBLuzYhpYE3zgeLjiP4YJSFmDTcVnKsLCNf4UDWEppbUpqbWNxLJtk
-cWIFi2m1adanbDYlHTT5q7fJIcGfO0jYXDGXpPR2hV9R0AHLUqSb7cONDfH2
-HZaZ4Fzy68VUDa3nRyMv1XVGrM8uZBhfi0sfmzNw4QDA4NtNiTow32k8mocY
-Y7kKUrUu8AzWthyPgixO9uGraay6u0RxhvXJ+CcXqHMvFensSU0ILbdr8oqP
-WK0FjYwlNBqw3SnAwOcuc46la553rdymipq8Zi2deWYi9NHzwsrUpmrZmBZ0
-eU0Z0dazp9uOxajTeiqJt8o0cghDf+ZfBKGrkltMxSXwDeYC/wf//R/4+ebR
-r/viT2AteLOhh/1GBOAfyu9w+zlHdMV/H7x9pTjy8TeP2JsYYqNCsKzx4Ou7
-x9gw97GwvkGz7LvHgczGnp71nzf7m5veoO8Ntns4zGOSnz/pa8Ld0d7QaPgA
-83u6Rhy9Lw7jGauATH7MuFDk11//F8xwb3d359MnkCjYZqT46ZV4fYiNhPBR
-/HZvd8e7wMYmM7BxsA9HoOzSZEptiRCTk4O3B1QHD4vIxmqKX7xU+9Y4DkFu
-qfHo+xPTC+jxyfH5S/G3N6/FezkBpZYsHgNGPyDNd/b2Pn3qMliU9vlshLdA
-ckcIvU4CfOqQ2qvQR9yiBDVeDLs98BI11OB14uWEwfcFbB/7SN19urEz3f84
-DfejdJ/axThU128p5Hyu9M9gN9ln7XtyfPbKeIMwjX3xduOgq3DUBXgwJhIM
-lDhOlFzymT+UVmuR1ljNaLnvBzkm2zePzm2Cgn+a4pXGo3xBLAZPdY+Yxw4f
-vkWoj2FQXmLFc7vPtvufPpVWCFHY518r18KgeIN1nAGXBB8JevErw1L7tFH8
-DX7y9anAqWolVkStCoSLYdUTlYjqtcr3OPGWJP4UlC4dN8xCwIuezjtl4dPq
-Chw/xRpIfUO4teBKus/kcE5VrGUJvzcdQx3GNB5DBw9j4vBl1GTk7qJV5Axt
-hVkol1gbCLoticMzNl/3ynLwjzndHQtyEMlr2kcAhZRMCHN5qpYGR0JyTGHv
-cLDj9jgJ0yfIYCzJbd0CbBkymg/pFndqrOOHBQIQhp7nwV6JCSW8LQ0vsaY4
-RbKq7eKQP+FloWu0YWyanHVJPEUmx3PKkHBJhARI/DEzBY6A/Ozh7boM/0+F
-jegIvkkN7fTCwPpemSgUvuxcymsRy17Nrd6gvJ6qoZB+hXrKKHzxwudfCT3c
-Uj99MhyEN6dHmT0lbEAUjYKPqrRr7A/RpvApnXY4T3UtKoKGpVa8Yo1ZHEov
-uyI/OSh4DXIueMWX8zn1LIkigeqKmRZhZbLaGCthms0vQsxexAxfBICyjw26
-acGQwNpcZl+V1HY+MWtrfnvyNwry+JhLC9NQqJcWRpM5bbNERfoYlQ8qi7Ar
-WTp9r78Dxg5ZOu63/NH3TDzivF72MQO7Cma0lm78vxuoIjfWCt87L3ikolP3
-PXzte3zV/LJW/YoBxdufAvN/8s1S4qXn4JCK9dJzHdXKLU6oLh9E3TT82t4e
-bm/zr//Beh71aELdZ9aHHYFEEWQsnSekeRTrz8CCpGXQJwwj0xEOtAH/8n0N
-wM0VAe5sD3dcHInBruANW5wcAcYGJ9RZwmib58AvVsllEctVQeKOVgC5s+vv
-7HX3tnO4RiuQFd1/Bv9p/4KHLfkK32vz/wBV4r77oaf1fd6yxEuHARNs6IHY
-kig+L76l3RvcbeNh4JvkJ2AymnK2qH9H9R3gxA9/nsWlR8lNMs+rIK2JjXjc
-ATUBZUJpiyP3dbBsstQ0wlNQcr+qdhTVE8SLgbUClRx2c+BtHG7jr33v2kOF
-hdPMsS9+VIaq8sZ5Z/IzX+1UGFlTVxm4IKx7DewhP+W/lqIKRSuL406WodVV
-ZrPA/3MAWU3eSRhtfa/jEfiw0hdPt/3tnafd7We7DpQ8mNKKRSuiKQbU0phK
-DQ1aRVb43XY4OpJqHV+6X1BFWCaTqMh6a/31v/f6P3R+WP9ZHv+y/vdvOz/g
-X7+tuQ9+K9Z+HnjP4IHez33499d+d+dT5wfzzvoz+Hjnl9/gob1f6Inf+j/Q
-v50f1hyO/GT/MY+Q9R9fzFKXbes1zgvTBomDb12MriUyTZ1NOyeU0IRy4VCb
-UBga6xf4fLDnPnBOZRIqqMO8Z3oSf0RCAuOO5DCY+qFn9Q11gYCNkwCT0xjc
-BdRqNow4nBwfH4vd7afEAidn7zZOjg/F4bNnLhiUwa1N7IyphxTjMPYxQ9Wb
-0fXeLD5pQROve4POkyfrZx3xRAz68Nvxx1kcAWHwg/WzHOtO133xmvq8Wg9w
-HHMXzKUJUK1AqoOIuhJKtwqLGNokqanueT7FmPUstjZdQNjaNIj8ZLG12aMF
-4K4/yqbUyOMykIXuPdtGK+zbZztlcpkRuLEmP7+1R8/DP2N7qMJsMH3qwuWy
-rrIENRfkDRQ5ycKFoFvXyVEXfo+8SE7oYIVRwU/GyBVAkMJ6Rb0R/chfv/00
-gpff9o7o5xj+Pjrqir7sI436x/3K9Vobqea7R2vUxFHzCi/ac7EWqe/f0vdF
-pCMPC3+S8mtSvXa8ZuqA8BA/vubQOjgMBRKexVOpO8FyP0nAvCsGctBnGjzr
-Pdveks9a7lUkJGfZCAXF2+z39/aF+ghv1Ur4QP6lFgi6776wpFTsIrNgWEDU
-kjiAaW0xVndoDy/1mST+NK8T1q+/Bvac++jEeOKwV7kL8r/P9jb9QX9ruzvo
-P7WY1dmRWpg/X3g/aoOhs+lc8D3E7sMt9fxB/hpZIiIfQ/eM1pDprAC7mMTq
-eDYtbHLko5ELz0BUFyCJcRTqjdreaNrb6/cbFnqwOdjxB5t7g+5g89nmspUu
-Ga1fywKXESuvq/MMXcW7yvKqzl/0NsVn6eSZhiJYrP8LX+M38+LiooudKZvR
-TzN0+DHcq1qI47qvOajOZ2tc5WE8IgNKNT3Tp6AUpQjRkBChv0DrlOhWBDiK
-r6OCtcQDBJm+eaAOYpPO2BwM+v7mYG+3u7n1bFDDSis6NcK1qSu9DsODV/LL
-MmHzbFo6qC8cAlW1zOS7LwSDTZtWpA12UWxazFXITOOUWkrOaRF/1BZjP8Ce
-yRdy6M/5xpdEXXthrkYscqiOtql440hUtMa7A2qMJAbj4DEvlclVXpP4BagS
-c7bDNCbbSKFVIEuJOxhrtmLmUd4Xu/Ael4QomHVQ4KN5OCrZi2BMvfCHH/Be
-Fu89RvDpAi2a0aEFY/3F+9PDjkB1AxpR+tMClNPDY0rmAK8jgFHgz/bb2vbT
-p4MuHTTs7G3fctFnQ+lZlPqCC44UURq43NC8DU2atvqW/K9uRIOPrNYiX1Yl
-FPiGrlLFe+RU513WBhcLR17MNPAGyHQFe+n2/ATzztRVt8BXHyLgf4+23akf
-RF+WosLCTV1JWzRPFMa4Z2rnaeS8xvO4V4oCW5rM7a+RI3PdYdDEqnBbfRPR
-7pcPSa0q7cY3dNhXNn4BAho9r5RcgYo5jl9MXHmZtNR+RbLKiBVNIsyjYVTv
-lWKzzemX3BnisTjdfIM9scEf5oyxorEIuwJI43QFqmz1d26vpCbD2JsGE/ei
-1i9DITCkVSHCYRyBiZaUTUfnnpD1V4fvOiJHnizCMZZWrGCAbG/v3g0R0zic
-fx00PHwnNDIF8t0/cehj0Jve2G6/9LlpA1TImcFxPu/VNJ19SD35ceZT8/ov
-rH1wqP+SC7yZmtPBC6yxfvpfZx3s06bRRRjzZBVbfnvztgS7SGZDsAF4P/ta
-vBt0CQUhVTI7b+bxDG5JJVW3/+V3fGU3KqN89X39DkSswnH5ggRp7arct4f8
-xeNCxWhNgSwKP2KizxNGaAjp6kgzN1IyCSQPKpBbNYeW4dv8JhL1tijluDQx
-nTMyMI6+varhOMNCsiWLvc/BOri2QrUpml+TPPSg1r5yEjeP3es7lhjaasxQ
-RMWfBVVKpwLhtrqmgB2m6gW+OMC8ak4/NUfJZDqcRJlMxn5RaYj1g9OTzo2n
-NRvKSm/yTudVCk5zNpgwj66DdXLaqdOSq+8eBewvJp9/ji+4ePCVn8lrf2FN
-7cWrZTPbHmw2zGxra3fH39rZ3utu7ew9tcF8aqTGXVQD3qcSWKU+cNn63KRW
-UL9cUzHIX1fWDeo368rujKi2rSHUL3xy/6ydb2NVoX6oxugoV+WVmKux2vCm
-k2+sPLwhAWpqEVeiANdixDSIrvR4R3+Zch3V1IOST3EwlaGvU9aHMQyRkFK4
-BHniVBJS4XgVI2esNlbIcAlCeilHxYoGU2k8kqG/YM6OxXQ+NIezE0xu1Dlw
-U+7M+dMrU2qTqtKNRNLF6WmAaKnJ5vu/nbCeUYUaQSWhVbMjOO8i/bIq9/gg
-YTeBkcmB4AJ/VddQKt3hJDT4eMHj0sNUVk4YqMqefc64cV/Fa97AOwlDasOZ
-0FW1U04BGSX+NVbt2PUopgKKG3wi8bBnqU7+5AYJ8PzQSmnWQ4XBh+JCpQEq
-bvWwPctrxAivn5uBzzESfkIhmyle9zgL807XzgBExgOVU+rSMldYU64iwtqo
-Mo5iXfYmva6LpCc/Zp0VKEKow7wSqo4hfc2lbPCSQw8+8CPSBdFCcbOpzWqu
-+TrA8ZPSLK9g15nB9FoXkJEQIEUiLXlYlNV2tkpO6O5iTv0kBLh960UwsWFy
-YRp3IbLmy6jH4jKYXPbEmxg8hSvK9wHmmE8mXAs6mlNaNVWFDAZbeEE1oE+y
-GKTDeYpT7apVrZu6XbJoU6AL0hPwnKiE1CrYc8sD55lT+xZJnYLKQ1LKKXym
-m3/leocmjjVLl3xffJZaRgteXWkRaR0LRrjQ+NnW4OmnTx213ON4nqg+6jjX
-Ya4+lULw+n0kiKpQ6dKRShZTHY+nlP2FWW46lNEVg3QxOfVfaMmB1FAmNolV
-VvXhcx5OdwRDKNeXcShLNbngqlmo0HHyRTxaqPdBSYoUM1nRqkm7hsxoAY0q
-asu6GljFMFg4h9VyTqkczTi+o0nTCqHHZJr8j4EPUHJUtrTi26cOt2Z2PZEp
-g6P05vkwo25XNO0h0sEVT57uihS6JzocsagiiFxKU0mTFqAyNC0wow8EjtL5
-KcNQ6xFDClNcOiImvsyyWbq/sYG5hlmCwpz0EMlenEw2plLiHrQBgDdgo8Zm
-6GG6kYZYzenBh15EuHg+Xr4wC4be1I/8CZlfl9KTV+pcxIvHHk2cigKVngbB
-6s1GY+oZwLWnmlSm9FRLEicZ+WEwiZwsL6aXVp+64pMLat226/5VHGA1hQyR
-FpJsf5iLuI6TDwWeUfrNDG4I14KDSJtRcg7sVVxYEaS8i2NxdFH3GdBDIB4a
-EsR60q6vdhYulVRICL9ksHvTbpIWnjc7vOZZLi2iOiVuhMMVSoQPD7tCzfbu
-0prtW5eygmXL+7ocffeYOnLp1hcHQwzmhnI0obqMVNuy/hzsTRjymriErCES
-Nj/6AK7m+xhgZeKnIMxQXF/Hc/FCJhPcC9/4QL9L8Z8Sn8XE+yggcv2nHI/F
-X3wsg1RdmIKETDAykIMIiz2VOOea55tH4DnO3b2bdAPW2lLnf85DKhklvqMF
-/BANs4W1zfmpYjLdP8KtS8f9CIw5LjjmcqEPiT/FnDp44f8H0OkeqZwYAgA=
+H4sIAAAAAAAAA+2963rbRrIo+t/fl3fo7fVDZELQpO5WZpKRZdnRWr5oW8pk
+5mRy1geRTQpjEOAAoGStxPtZ9rOcJzt16W5040ZQknXJRN9MLJFAdXV1VXVV
+dVW153lfPRnF4yCa7olFNvF2v3ry1ZMsyEK5J36cj/1MjsVBPJvFkfj7/rvX
+4qWf+eL0ai5TMYkTcZr4k0kwEofRNIikTAAOAvDPzhJ5sSf+7kdTsSAw6vlD
+fvmrJ+N4FPkzGGUMIDIvkDB4Jv3USyaj3Z2dbY9f8wbDr57EZ2kcSoCxJ/Cr
+r56ki7NZkKZBHGUAbU8cHZ6++urJZZx8nCbxYr4H4+yfiJ/gb0BIvMbPYJoA
+bhonV3sizcZfPQnmyZ7IkkWarQ8GzwfriHea+dH4v/0wjgDoFaI5D/bEz1k8
+6ok0TrJETlL47WrGv4yAMDLK0l9ozovsPE72vnoihIf/EYLnd5QBPPFikQb8
+aZwAqX9Y+JdSfSBnfhDuiQCf65/Bc385p2/7AL4EbT+AL8XrRWwBe7XIFomE
+N8SpHJ1HcRhPA8TdAu7ja9NF3Ec6/2WKH1aC/9tiIoFib4KFBf/oxVvggWQe
+J34GJHcAf6IX+mGwWAb61E/kR3Hi+2ML9H8uomAuE/FOZrh6LtJZCg//5Z/8
+SD+SWQnmB/+jTM/Fa1i1c5u8B0E6isXJVZrJGazTUTTqO5CTKb3xlxE+V4nt
+X4P0PFqIY//Cj8QL4Gx/1hbtizN6vBHxI2BE8SK5SoFBbUpH4+AiGC/80GWN
+/z7jR/9y5Z/HCuGvnvzHCPg/Cc4WGfHdV088zxP+WZol/ijDvwHC6XmQCpC1
+BTKqGMsJiCmIorwU/ngc4HL6IfExCPgYZRsFCkgWjOF5+B5/B1oJkisQJp5q
+oLQBvTGLxzJEOQtB2oHLpMhicSZFMAOOQf1xdoXPLEIYODv3M35Bqw6CZ6kP
+0Tk97AJG0SSYLpjhCAEQzUyKkT/3z4KQEOvjFA9hEnGSrokozoCuB/H8CgYB
+FOSnTEySeCZ+/fV/fXh1gHrj82eCNJMJ4Bhk4jLIzulhpCOSJ57An0CvVI5o
+3DMJOkuKn16LNwcimNCzCGsX1NMZPOfP50nsj84F/E4YJzM57ldSXitBeJ10
+GA/uiwhWAlRlgLqMx5eKWExoVoserUpfr/EsGI/xAWABYJksgedHLJlfPdmf
+ZMCYCGa+OAuDEVMQINt06N2EA8S5fyGBNjJS/DTui9fBBfwJowaJOAOajJE2
+ODot1hWTtcSG8PxM+KmY+0mmJ0/EAKZxZs7cRnzzkFf94AdA81C8e396CPru
+XKaSp0pUdul2IcN4jtOMANXvj7yX/XwHvAI5gt9wmaq/m/vZuQdLNl9ktLxq
+itUPhxtExngeq8dAD4t/LQKQppmPG8deAwYNcCuQgMngUgajRegnNA58gnT0
+00wc+GHIkhzP6ugyiy+AJqA+XH6xWIRXRW+8wC1gGSwQDC0AShfzBuh4idBo
+9ax1Af2InyIeNAYyEAnSf4gPEqgCbxHgd3Hma5GClRQf5ZUAVT9OxdO3P56c
+Pu3xvwgTf/9w+L9/PPpw+BJ/P/lh/80b88sT9cTJD+9/fPMy/y1/8+D927eH
+717yy/CpcD568vTt/t+fsgg+fX98evT+3f6bp0jYAo0So3eBrZN5IlH1+umT
+sUxHsEkwr704OP7//u9wU4nH+nD4HJZNycpwZxP+uDyXEY8WR+GV+hOIePUE
++F7CsgIUXEnQxGixoHIA0TmPLyNxLhPZf6KoeSqTWUC2yJVRiCig5lOyBxVy
+qPcLG0qK4jWJFxHiTe8zmjvPtwafP/fVKMdgiAWfQEEAVmSavoN3xTvYY1Me
+9ahApx5twCmyEo0VwfMpTxcmmVgIiPjsn6ARaMND4s55qLEACw3QRb4ic9FP
+xuo7oEQajwKymbWWwbdHcQJ8Oo+jsZmn2RvVxmhRkTRC5p95asBUzfY3NVlh
+fn4zahFA2B9/kBNYimgk8S0UViHsr0mQWcRJuaqPmb7bz58PP3/GF0FFZxUv
+4sfNLybO9+ZF2D+ywBpUv7i7/nyTXzTq3n2x/DG89Tf4Ue/M/dFHg1P+TuFj
+886ve+I/bPoKcnf+/NTwEnJDxZqppXr62dU0qCpAhx6HoBlx+5qH/kgKHCrf
+avDpaDE7AwYDHgmmUYWWY5YW+6Mkjq5mjMU++VEBaaL0Ghvf9bcyJBIoyuQi
+kJefGbP36k8t4MqVE2+Z/w54O70Omne1P58a46rAWNo6Q1CTOAzjy1xSjRmk
+rR2W0Bx9Mr216AOCBJM+/E7sizPkChsSK750MVca4M3JsbDeZvML1UFpuO2d
+3QEbBfjX5u7OuvPXhtmuCbfdweAzrRzrMTDQvMkiGl0DQ9zphYEiNBRWWiUs
+t7Y2h0plFe0hUaSSB+6OTFIcUo/dqyAzTQXMhJStBLBbtfyUQfJ0NLQ+DRtP
+PNh1glnwP9Lzp1PvDMh0GYzJfonSxWyOb/ecx0KwYb1ZnGb0mxx74OF85H3C
+emqED5AhlMqsAnOmRc+ycHQoA7wiOfIXgCqIiDGWQ9rDESBMdZHhHydX0egc
+VELwP8wefz08QKXTOYFfunqPuqHxUysXhuQLFQoChID6zXLS0yzsOA2X5wGI
+5MhH+QX0Fik7hoBUbtunxJP56qSjAIGCl+hFyh5TXMvOlfZWUOuCtibDDVEz
+EHAlzgJYIpnACsFij3v29m3ACw1edGR/2u+J4UBudImqYTqHnSJmDw23L5kk
+ceIloO0NNrUyBHiBCOF4KOU2GEFgBINJ+7CJ5NbEm+OThmfJGLE4rbyJGBSK
+Jvo1cSf5t8C4+NRogc1NS1fBX0Prr611+7utrZ38r92Nwbarx7Z3t5Q6MbsK
+77hgLSE/avuWfd5GVGvJ9j1FPRdRJEPPZ+XWSkfyK0K9UoXk6FyOPqIVTdal
+WWL3RbT8FiGqhFoMBYwGTEpDAG9k8SgOvTgJpoGjzRtQxe0XZQW2Uw1AMICm
+FbRWYmtruL7CSrhjKJ3QuADphRx5N96tUDGuultV8xvhM5NZAvrny+NAQ4LR
+TsF4DxDyUjCFRufaZLY1H1o5OmajVSyvAIIm+qPC0dDY7dbQRB5MarGOWirG
+sOl5/iKLe0qVB/WrybNMAnTmydpzgGAkb5FWbNbfa6eODPfbNDBvZgeTqwSU
+lMoQNogRC7xV0boHbPVaYGhfGStTV+/qxQDkU8cKePrVE8v/KRt2yvOZwOKn
+4ipeJARPXnIAIY6soVJtteV7/h6gBiZJmMZAHaL0OJhMlDhc36T5P/BDru9X
+Tyotm1/RMafhyAAFLIf94bf4IcUH5ujDPV0k0R6+tjf3E3+W7n2ahXtRuoev
+7bkkojdVFEB/+C1HINjVL/nOv3KEX72DX3zLnyS5887u7lOkAnrXezUncTz6
+5+JglofvDoZf3PZgrnPvjqfjAY1jYhSgbkyzgX3gUcQ+bOgGEfwnxhMdZSIz
+2Kd4Jlh1PgkvgxrMQB4WCTPOCTjkfqjOHvZPugov5/iQR0PhpLMVGgFk8Sd5
+tge//uk8y+bp3rNnaJLi8ctHmVC8tA+IPbucPsOw6bPvNGCQ4SDN4MU/4flO
+Fu/h13/Rz3+n4mXCsL4oHZ5ZPwYGnpbhYVN+BlcFqeLIrAJY6YCsClTtGVkF
+wIpDsSqQxfPHCki1J45V8MrnbBUQK47XvuP15p1wbnEVKVM77EYsEUS8IYeh
+UrOgSKcyghmHoALB15ks1ImeFeakDdCOg6dzOSJvBJTk6WGfI6Yci4T3wysF
+AbV7nMyMLlWHkOKtH/lTCl+T6KQZ7hc2s6v3O+/evtzv9g213PD2Goa113r8
+L6pY/F2Ht/F3imqbXxQM9RyHtvPf8vdNRBv/LAS513oKytrb/b+vcfB5TYe6
+19qHuhWUYsBbDDdFB1UMhru7/CsGu7uVsW4FBCPeol3E2xASN3wwds8z0Rl1
+xfpgfV0oJbRIM7VFgWEM+w2uNls9k8BGnXMIUr0Po80BbLAPgxNcOu+QyUV+
+yAjyLMegS+gUWB+VYlQBcE5hKx6xhjsLIj8hIxWPw8nWiBMFAP8CtYqMhszn
+cywE6D3HWH1GAaBFki78COMRTK50QbYt/J2TS4TBSEYpx/hTLRe0Cj1W3upk
+78XJSxBwfjaVSpkibuyvnygR2uyPNB1yKq6l4o2c+qE41v5xaugQ+pkyg+n5
+l4pd9AMdraMp50PKXD8rxGF3nsSOXAARtHWgzTFb9IP8WAp5iqPL7liXl5f9
+ZDLyJGkkGg1HeQaf4ePdb8n60SHiIEtlOMkJQmIvQpowGDaAZtp/qswKY7Mh
+n3nDgbc+1NtuSWuB3trHmNme/tMj5QO6RzQGW77Nn3cMddEYFLHeMi/UB/6q
+ni75HLWINEY4kFVzpQ/ENU5JHqyqhVwRDSDWt8FYwJcDrPLab4Rhk7tcRHUl
+TIt+b2nelTCMH9rgw/b14/pflWJmMabFvFr8XexqZlwC/V5HWvcqOKxVRHjJ
+e5Uh4iXvOAHjp40GMeqHVXLw9MuWqWvZ6s+eCdeZKh5TAaMvQM3kJ1U95bOh
+sSIViIAsjzwpx/hkluflqqaBN9gG7dSkmt6gY5g5Tij4dRykaCYROtKNPkOF
++e+4Dc++/poAfk3vgD7kzeLrZ/y1VpKsiIjB9URILsgRPJefPNyAgfN/1dg9
++1oMhnuD9b3Bxt5gk+DxFyGYrkDsp8N+fzjUk/vcpLaRdTCjiwJJjMIzSnug
+zX0UgmaFD0CvcMiWw+C+DQQ31bUcyzXhiIsyMmEB8FySLADY6M+uMsmGlxTW
+BAN1RAa73jmsmYGhLNFQTjL9FkFI5b8WuGpgxLyRPoWi/kcmMX2ZqicNEJ3z
+Bdx+4YcLTE+5QiMvVlYILigdh2ZXS/hiY3tjsFfp+1Fy2eGnDPZ7MrkB8fcn
+x68MDn9V2/26+QThbW0MtvbE0Yl3dGK/XJsAa726szHY3eOX8NCqsJ7kWhIh
+3h6/OSlKsos5PuEB+g4DV3Bo6rAouFswHcOYrM7zh791vpAKTa/8RAOPvlS7
+QpaL3SGPUWBcLc4F3KtGbRKzb+tRMXSuGr5Wbgy9Xfn595ObO2JW2v/8jJ0W
+2MZDf7qcafV2Cpjn3wi2DVJJueA5zJSBGu7+3BoUWrbLwDTIwjGeP+XvC54b
+MU41KWRCOyqshLK4UrC+4QPKmrRpImFXliof1iCNHwK1PkbojFpTYT4YfJt/
+UoEsIfwjv2wYw6IVAWdkyrCHLWC/o3f7gtKaRyrBws/42D6K4bt4keL5rGDz
+Ab3BWkT8szpU1lugsq/ebolMJSINy57D1Cd9vr20gpeWp0mT6JghDZo4tCJC
+t5dPt+Mix9+CRC8KC1cj0Zs7wz3a4uq3w7eMXL6xuRvY7vrGnji2+PSFj148
+cfqJ1AEvVDKHnzCLIchMpEpQwBZzXPwzGYoT8gXUu6novDk5TrviRzqPhy2D
+8cj1STU+u1s7A70Xt59SpfClSTh19U4QZRvrDfvLyYc3r21priP75joYfkx2
+y17A4AYfEaKN+5rjg+AV5N7Z20WYBd6xPjq1yUZze416tevQA2yTnQrb5LbG
+qiRcho4MGt3qLK+toprbwlsnqocR5sGMaxXBuKDr6uC8DNJmQOh1OFZ7Payj
+iLOWyVHBiGwtUDAg5j4yojfzMToZkfy3GOKUct+VeYLRToW+tguo1gPWCfy2
+iLOEaCRpAyEp9MHaAddusghFer7IiFz4uY3PfJHM49TyrypZ2bDz1u4QeOy1
+BnuiwWpTAF1Bi8XoQwevKkHVtTN1lLxl+lHInYlXoIaDaQVlXLQqdts6lE5Y
+OACZorJus6e8VEUSxRQnnb2kjv+pLoYixuD4HlqmLJOi2uwAAc5zpGzhLTqy
+YKplMgE7ePDzp7/90hl0Ov/oD77vfv/z/PiXzj++6X4/+P43/qj725pDSPGN
+WBvCV52f/zH2vcm+9+qXXwe9rc8/D9Y3t3f9/dGBPPwFIHW/L79noHeG6z8P
+vJ1fqmD/PBj+8o/xb4Pv/zGG/wGg3whHa7hhb/fzb/8Yf1N+udPrPOYJdbtf
+ry33y3SmCDILHUaBAOarTrsYWEMZJ5OohVdRe9uL9UUIPgAyGMeF0DrC83BV
+2YVs6OOhAp6FCIkZCBy2S3PB0i+q7L8INo5ITtmrGMtRAPZND90lOs+ZYujJ
+csrw80kY+9meicwL0YHXxG/03W/8bffnrztrvbWKL7q/WC++UifJKjncTYrp
+qaz+xA5jqkTH3AoxmVRredQwkBIdGRhuY32tkOSjT7dz5DnHcPBpOB8Oupp0
+lCURYZhVFc6ws4dlhpy62K+YxntY8pFPxXRRSru9Pg3svD991y0k/fQqFlWR
+3CwOJmb2RLqAdYRprA16672N3nCtBw+SjWuzBowk3r/8caAKKEC1wl8bwFWd
+NfhljdPdOCSwpjHFCJ0B8CPMd63f5fm8pBOhn/wLqaJkLwMVESRTZR7KT2SY
+vPzp5dtu1VTmfsBnZ2kIdrRmOkSNFsmdonm/MNUNZ6oAfZKwM37FYAcULs3f
+xs9Yota5uqr4wgbHV60HN/IgwgFY9xHSJbxymC9Ic4VPB4R0AglsKJMRuql+
+XhajZMRmI5V3sTb4tIa/j6RO+EGxYLosi6yumo1hUDk6/dE7FR8kl2iN2Q58
+3d8ZPMfyVthMJmBFGBjmtVixR2YYOWJGrtu/xqnHQZyiAb+b714AayrF00G/
+v9Mi1ooWxMtgQuTIuIrnBCseEN0DHMo7VfmTGZszy5yA4TrQ0BjYhcChZZ3j
+oHis6/mXtkFnR1lsy6lnHZFu9Id1BJqG8ZkfesF4NRdnP8pPphO0M0EnATuH
+OkN/cgXMB8uFJn6c9Jy8boO6DLQTzOlmiSDDdBQGnKOsHkOK5wkQ5oyVgzTw
+r/9RRpw4B/RMxfbGzoA4f2sw2LCh4A6mYy7mbcowxyMgQJ3MZcIEzWMijOWk
+8gw58w4z9TiCiRWTXEm/ZJ0Rmz2xn2Ww91F+Ql7FLY5yUnb2j466uQSZ0fen
+04Q2Q8t6pCSsDXR0NRMooQBumgSh1AG24641QrWTC5xwHs/5HK+dmxbGYAC3
+sW/31aMAn3IkIiFVBIBCfLUmNOq4UdZuBPVs6yEa5PtQzViFqjlll1Jurqh6
+neaCn/GQVIWx7KBhHdXah5O/HnuYCekeLODHNAim4p7ScXKabzu2DG/UrRye
+KHr+CDRQusoKzmOQci+LPfqlrfdEFS6Y0+C8XbuKM4ofMHKrDmG/i9vtKFyQ
+qUWl4yNfZcu8e/F2/1ZdJoWsToNHh4lQ+vLHSbULjFEXbxwkihvarS8w1SVW
+EbSgOod1QN3FI18fBnD1DoNA3jTD1651IjFbo5VSqBtQg1gy4PXl154VnYXS
+eAY3onStN0yCtuoyAN/Gs5YRJOR+o7owWdYpWvKjHBjJiPu24Drl2uUBcNP4
+thAxwFZB5GbLlhOepLI4sDNoee1UcH0lKwcEn19bJvo7u1t74seU9AWZrwGg
+/xpmc+lf5bZd5+j1sYk6o7Ge+wfkutXacna4um5+OPmiGUdHouMYz/e8fy38
+cZNBV6MMLSuPw4Y4Dm2ydhxJWUFXrtFmvVv2VDZFPMpkRjFoC8U8GqCyy2ot
+uLf7f0c3bYbpl6bOk04SErE/Hieow0/f/NW87iR86n11vb/ZH+rUPNTg7F/B
+witIRy+bAWzol7d313fUy02H/RoqolYNEbZ6DRMzCugYx/aBbNzqoWz01/OJ
+bQ+Hz92lSTAEo9uuoC9M7i3CpvVVtIVnAnnBEZycWWcSXo2CdGacYjoiq0Rj
+u79uE+jLb6E9d2kdW3m1BI1KI8y1vYGsAO/4YrsSZyADjdVzF8UFAUQBr2CR
+xZgvRR5+fgCmgyEmWLN/8v5d1+EljjwlRIyLdaNqUmvMOoURU7lr+WSmeGzT
+oDSWWVLs/wXUO0iNFE8M/sRuSyPQdjXYl8KzkAdyXVQpY2EcpP9EiziShajD
+GQbtzNbL57hjx1iaxym7uG2O5KmFiR6sas/HEWiPrBqhzcH8G3x52Qj26agz
+Qpvzdjoo7Zyc+5iV8iFIPwoak1JIug1DN4VndPDFPuhx1oS3MXTdubrW8RBr
+YjS7O+vGgas/Pz2MxugQHVrZus55V6ujVAqKgVF6Vcdlifp+tVPVclpE3aK8
+iFWNoR4I7DA/MoUJl6reiT9MpFN0wj+5WU+hTkrD7alqFqUnA+wYYG+MNAUd
+wIA3cWTRQSOQkgdUiWjXRsF5F9HhqoMILIEkmE7hfdi7IhUp5zr1hnNem6yE
+QevTREUlzgHPmyFoONihATM2MP+cMo1boLAAF1SOb4aEAaJKhJyFO/dTh3ya
+PBiY9oNwkchnYzlN/DEFvLgBXM/wwCLFoF8hswt/9LI6S2mvYldXejrMtZwi
+iNTNyMEQlviuAe8mq62/Lv4govPLbYZZfY31QJWLvHzEVWloz2sp9dQ6LSL/
+Ah6lHiWrLhadgJvXqX7KRx0OahO1q44Wu66mDjGvpQKUzkcsUaKzxmjMwWTF
+zTkXO2+PZcbK5XpcSXZD23lqTImeQZouSNo0smDQ8imcEbCiapyomr/2eF76
+AUXogIZU5bfqgoxjzH9g340+ImsTA+0lLeEga2ityeqoHnIWjKJQCSshORnu
+lM/xmI9n8EHNoPPT6QfYA4KZdTS1SshPtWNj6464y1EUy8yATTTW9f4sOriV
+Kysbl5CRpM236za2UzNCy2N1g8D1FzZ2dluE+8GMwpLEHME6YyKTsClhA2Ws
+Z2+X4/Hs+87Pvvc/+97/M/Ce/8P77/4v33Q7z0oftck92M9jPbgyhIOOuJJx
+rNETfNhil86Y72rNcR2U8MgMWCUyjs2LSgmkbYzyfYN5jnChI1WDVqEqmdK4
+bUz15nEZcv3IqoKnNHKrlNnGkVXriNUs+EO223LewKJGXXNaUx1gL3fxLLMi
+TbzI3HnJzcDOdXv2TACTYa1bZkdxPi+BZUSlJCh7IBaOkhOU1LOqSLUho3tC
+y05POUzHiT3xXDnpsL1QEzJM0sD0tzjvaImhNy49kNMgipwASSHVJ6ReVWR0
+mpdVUsWaOq/nVg9rwjJDnTYx8CQ1jFCPr5liWpUos7G51SNsZTh3omNkmp5J
+XABY+TGYMJm2WvXsdZOUySIhiyKIsKNrrqbx5MkfL0veRRT2xL6V9vCWa/Bj
+0/BbnJrD4VqmnbdhVydQTWz5Y8QJGnmmLh9oA732gjkYJhT/tN84Or7YxDWl
+cJX6/lpMpIVcRmM+OMTtj2PvhoSFUC1RVIdpfTTU/JBPX2awQanzPjOOgVJK
+kEopQsiH+xuDrQdd3+WsONA/b2/YqqgamDSML40mVUC4p6FudaBkQpdEqmdq
+uuFg4WV1GxzREqMW1kGu29YGKmWy87M81DmT3e/zjEbMdxx6z+Gr/s+g4jBL
+cvtz93vzdOc5fLz9y2/w0O4v9MRvg+/p3+73BdOC8+Gens1NlnAVL78wSY20
+u6U9POBCKXCb9Za7/WkI3CWwkGun+V3amYBY/KpzKrFuLUHdqlIYPasQTL8+
+OvexGT/B5ZIu0+aDl/vo8PBQ7Gxt0tIdnbx/dnR4IA6eP9cAkAc31j0MyKlh
+OKsRM8xZSFWem6ly7njD7tdfd0664msxHMBvh5/moPWjDD/onOQ45jl0nDlm
+fYXKNhU7YhxMA+ouyc+h0sBQx8yUyLGBZ58B8edYgrZITXbnhpE3rEWjZhQb
+69ybk3O0VFxPo0q9n9Ed8Z5voQx/83zbJoiByoELfnJjl56Efyb2IAZ39DnP
+XE7p6UNjtaroTmHuB6uzPJ9JVWT9D2ZG2smrOiwFHnjCfoZZhag/ph/56zef
+x/Dau/5L+jmEv1++7ImBHCAtBoeDwiqsjde4AcrLNdXpkVedl+Jb2GfV9+/o
++xzFyMMSwaT8glQvHK7pxEbMgppjLiHRXeYncSdY5CA/+bjIHF0DPHtiKIcD
+nuvz/vOtDfm8QT8TQ59kY2Rqb32ABYXqI9X6EFfnlWbhY2Rhs0RJkJ3PZBaM
+DEKWRGD6YF59numbTq6Eh94Q+KqzmWXJvVF3UaTw9YFrWT77Gne6iaTm96kp
+9lYfiPn6bO7lRnNzuZdq+UeTOtZ5M5yuSsIJA3WO199idLm7PBS9VUoh0nHu
+D9T3hadu3Eov35WrtkIV1e42IGcANBRoObTTRJokybVoBPR4hek9HySnHnRe
+ffiwlDCD57DbO6+VE60wfF/ItapEvKrYOL3WPNhUqi44NnR16p7vqexWTx2d
+8DEfZSGIiJtarzx1AsONVnMw/YYRb4nkPG4NwSsLzF008DzrhoPTqdbykVRT
+mgiRC6LsZjS24FSPSaOhnzdT/e8KCTHtR+U+3xYklSPTeuBya5bbQKKij2pR
+oRPMr1UubKYvv9Ka3bHRV2hkdEc2ektkGij5wpmTVoPlFtIFuuUNf2rq51cb
+k7J0lCpWEEul8DUIkN+Ic1dBTQ9GDJL8SKNNlX9laxnyR3O43LSWQN9FZu9O
+ITvfIriXZlehvK15qoN2k9dHwCmMgie2l6YhMHfNAyvXPwuD9NyqBqaubud8
+nso2R5r3pI1DShS9bZI18QLG7xPqInVbrEAWjgH7UDghd8xvn/vxQiNY61SA
+kWW5PpY4wP/enHzAFGxsCk7+210YY2b2lNr4hSdOIewHNGfaNhMp0QPlbTNh
+dG86awrN4UPGzVP5ez5vqon08kFFh11uw6ujRYJ1T/wo7HHgvXfZJybkKNkA
+u4TrrhnUkFPmQV5MhNDZGX50RXRImFp8l0UAdoz0x+KfC9Uzxw/tRFlNBCCn
+wlLazTRoZejwmRCUn8D0W2ZXb+5sbOOpnmtNTFQ5Yc3hnEGow0k7tVHGN1gv
+El5Vt7gwUKhNBjpS3ZqdIJ5keBOR5JZzt7YhAFiRg8VZ84Jo3d5a/W3tDNf3
+6vOXaaBjM1CNSq9oqrO6PdPSlpCcq4X/MP/VbSINrX6azdV8BGFGgH313L/A
+5HCKpaOOOTZMQMcVnFRv9l66rUPF0zEplzqgq+LUvK+q0Kny6oBGjYFJEzkS
+vLLq7NouLbM2enxoqbw8Xwc9d5D40cczf/TR6otdCIrnTR+cTg9KDeZ/I/ts
+IsxDHUEFxPetZdSwcAaHNmUMDO4O0xwHaUrLNlEQB6sdaiJTEfRgUc1x1GdW
+urVNDoW2gffcBrdz+OF9jXyf4Q12fnL1pXhRw2/mRIsDy8yxhBM1B+YcKaf4
+indGfYAc5svOAYnpuYhoxxAjw0qNXMlRdjMTLCcWL8BMA82v8uE7+y8+dIXp
+okhp1VE8w6ZIfMlv6fkTfAGPJjEcOqaGKao4yADBdcU1P0wScHTTFG+uBc8+
+g+FntA3ptKT8U41jjsiLD89wLJXKD+wypfIEsDCocTOdEKDvivXdYJgjRhkS
+yhJwSqDDHlQ0nGQAhhoI6Q+xvWuxdXj8S8muK0hfbCtZRYBxxD92jXtnP2Qp
+asyRwF/kH9we15H9jqQzA2gzv4U1+FAPKe5pnTDHMZguYB/ycD1uVTso1y0f
+ghettd0+3BqqjhveS073dAWwcj28fLkal9VrXEwDo66n4J0KUprpFuS3vz64
+JAb+SotTQ4ATA4yib7WN++rc12opUwt+b/oMPFEPe69F2CUdCE5RittbBR3e
+pCtLzmQe+TZJZ3mYw2mjh9d+LFmq7cEA5KjY3c7U9NS0d3EXy3vjX5ElqTOD
+P8gpSpNugSc6b9+8e/b2w7v7Wh/MHpifzz1tedz2AiH84x+ORYd+kRESYYYR
+nh/iOWj9Od4b0DV2j0FfnyqspPi2t4awYO/qBxIvtH2FC/J+kXnxxHth38Tw
+1ucHcXwd26vafO5pteL4zJsxire9UKkx3lRGjnZHAr4I274AIMjnj8UZMWeZ
+6e5mF4FPAJRjVi6Zf/H6uLvs6P/3v5YS1dH8SjUCGflzXbp9S5Eqgs7NL0QO
+fRnZdzDgjU656nxwqOAQRfJchFfsUZd63t+dJPgzbybnHv95G/v7+/23wDJ5
+59FDHoiSMLAMlG1UUNiHMBHntFlBbKGhdta3gT68J1eUnlLVt66vtk6T7LwQ
+XbNno9oB3Lt4SyZ1g/frw7FEteDOqEY26EyOsaUakw83vKPjfLPTdHwk9KNM
+kvyyt9sgIGWWWPfHtSTEFxA0R5J3yfipofGBQhdPAfJC79xbMwXfooPT69r5
+e3VHv/EcYwi3QdHG07AkC0aL0E9UfUtkWRkGf+N1YygQWdigxx2gVcAFI3oq
+4JIHadzAC9/xoF+mhr16e3W66dQu8nAJt7+JAe4R5gktKJKY735v1Kg1Zjmn
+OnpZIvlssPIockXCq3RHgUALZ44K+rL6i+GmOnAvzrN8lOcewplpVwYSKhyj
+RkOgIv3RUC7JZniD020wKrjXCBYU0Gkwk+Kt9NNFwtc4dj6cgkbKqy2InfMD
+2WVk3EYy1kPXu7jbiLskk9gZyzqit4vt2ucFUbKkdQhfvhGjdsBFpP4okrkC
+sQYy/2iBIWzatPG/9+4QtVSRn2Af83Tx8A3ockiAtHBcg0b3Ujrbjkgpb0s3
+oI7a2H5XrDP0gObe8CZkeR9JAoLVhJ3h3rD7e6PQPFykNycRQWEaffN7o5GM
+ztFqvpF07VPrFDzprNwghL5vkgp8uD86fBT6ufawmv3k745sE14nF+syMLfl
+Z3GWxXtKV9/pFDoWoJZDmfY/DkWLTzVRM380r7DWQHvGKNUQyeDVVw0bgqZY
+qa/mYL//EBnVcVW2d3YHymrcPzl5f3C0j/dHa9em5iagpsXg0w/aQ6yCyFta
+FHW0ooDniyPp8hvLB3EfFOMF/TPzP0qPi529s0T6yzrYwvJsaB/ihE9/74SK
+43gB0/HQBB17Z8E4SG6VjjZ4QeBZA/gh8Xbu+pd5H68uMPwPvzPLaxfR6sIO
+3qOcY8lJlIVX9l17gIjKENH10ksdua16Z1rPDwC/sCeSe3ItK7TqFwPPxL/g
+Ytjgb2cx9JUGsIOal5VqCtLCUuAui0M/M8XrujkApdVUvD++ivyZasw4Ahmy
+mgXFqyxrW5Fx5OxueMEpfGlxF/edlqa3wecW+JPaBuYQa3bBy3Ns/q4BUOt3
+Kn/lggl+XbIdwlfcIIc0M8bu7gD4gqJxB/kF5eKQy6fpbo1FpHqf5MciGkLn
++AAjzIYzOM5TG+l7aSaoARyYurE8I6eeOSwqVt+6rd6ou2682BdGP//luKYO
+k5UMNi42K9WXNYUnKm/zdhi1BrMmX6GMAd1RxuPghq9KAZfGzra2Nodu4lQO
++5WuntPRYOQfo1NW4FHmzeXkoQvS74Q8HGD1zU6gOtyYybW5y+FBkM7/xKRL
+MGy38MPyNW23TEMeECesh8wrhR4owap3NZvx/Ok0JxxV4i5mhhzwurvNATXx
+mpjsi25yrdBbYY11rzuF+o2kx1c30Mh86fXbFnJfihu+NDOQFsKLuuk3TEBS
+vebunxEqUbsnJrBVqInYozekYdBZV5KYSxvOgyneZU4vPVbeMBs4HuY8DJ5w
+ULpHXkA8uAEY7eD2jdgPaztwCytHOSzsg3Aej1ezCFW0MO++kKNmbkeoqzwj
+BKh8ObxSiBTiozUotsrl8fNWEKrHhMriVlew2VE8LuJMhUHiTB9CYz38m8Nl
+JSUb6xjOe3+B19/JS+Lc4ySIRgH1BdJXoUQya2pHkt9UsNXfbKCY7qMFRPvX
+At68Mc0OltHJ0Cc+y+gxu0Mt4kBKji4bUy2+OAyX34vpC2BEgXnR4AaaV4/U
+Vc2INgeSojx3kdvdqQp8M2WhppyHR4KMumdRTgG1bPTzcIAp8M9vzQPHX11t
+Z1U2xW6DMhVERLc3GNs83dXNHH2q9KcuWAZKIrNFEuXMUwSHWKokCdNxkRjM
+QLClR20rY4kXKt4F+znxls3trZ0GZxzVStfVOeZ1o3teqzt0P/Cc8cWmEm+9
+ViFmWPHi3xFbG9RzFKymcz6rEpNqhHfE8I13QOdnccIX4RkY5/HS/kUrd0hw
+luZWFrs++59b2FzzMAdxVt10FAFHedSztplJPmoiQ25PVMwPsbBqzGGSheHl
+2MaNCKyXHy97VihYIjzBK3CDtLj+3AbYoKcUxtFrPV1LhLkmX424hrdyBiHG
+RpcdOdypxFk09dECWmQPjuZgSmnMiPoPlX5BBIo8KGXbXIeALciWk8ugj50k
+ctLlOuxbkfi4yVAhLW6pFBnHi2k1xgaEOTBGjm4RNrtbYmPGHSnCVbUSzopp
+qLWRPs8gfaT6RdKZeY1uyoeer8+dBXaRalrfwzy9TiVDH68fd21M7qZRkD2X
+2Q0ms/72eAXkH2oFZA2NmAr+tQLk9ezm52HyXG5bcJ+DDfbeyRaFhSvh27x4
+BXyoGEz6CfamuYysfAzYt3SDG7uauhNMsFlNl68zyvDigYxWFPNWdWUx9sAG
+wyRvgLVsWipJVd72zHLI3IB4HvojVlCFJA71LmDcSbutkOYbSkqx+ltAmiEr
+jM1iqGZkC3KUrOwTo/atu7sq5D7nILxC5kYcDVgrdBnaSvxsMKHbevJr4bQS
+cvBsJp1C4lJf/ZOmk0W4dFy8rOXmgzp3ADUzSoBptFwTduNhAwoHaXhLhjeX
+Bcpr2PIWa5YvBKw15CuGrlFXBeSaZq8loAoRuihp3h4bUnJfGB8co9BuszKs
+6gztLyjOcQ/JBGU0boM+ReoQYHqfm5hXXjOpYQSRoibek8e3HdElaip8A5DW
+HLwW8zVMfHHqlhX3UvaCCseMQuxnL0IsLVYXuBUh4dqZtvwEki1ntLDrQDVz
+380FsI3ENcnaalzdWqyaBeqag5Zlp9CY4NrE5L4DDZSkXrJ5iKmYwegO3zCp
+E5pLKRbeSnUXcFA9gj/eKiKt9stKRNxL824FmcZ9NAcOZi81Eyow+Iqjm4vW
+8Jyolr2dURfzG5KfDfbWNLcHvjm5efCWNL4xbVtQFD0NaitS1BrXXUnYG6J2
+SuMWhmwYh2QliC78MBizsFzPgWRdpTqK5tAc93FVFMZJ7C5tI7INhPhxjnrM
+RkslvrkXCPfsrH6wRvzASuWkl3vU3hR7ns790UeZ6RuR6KJb62WkOSA/v4uO
+w+v9rVWXFpi5xFXXpW3jqquB7pEIKCxJXph2/biI6qmqAbUOwxURUPd4eshE
+RakuItpA9n3Vd9efTLjOCOy7/KJUdcFNnKyOVhjeCC2NDsWBVY9xwgMwxcJq
+hG8VoxhfzcrgO0vij7JOX9m4pKNzObuOVVVcSwZUp58qhpxjrYzJSbfpVYNf
+A8msskl9guyCnyfY9EQdzKgVfkSVmnXkq8iZuD3iKeC/S9Jx454vRDoD/JGT
+Tl2wcc1SdlftF2oVq7T+gyqWa0WR2lr7MuEamGjNqrVfqyLWo6WPamjP1fc3
+oVDn1SIMu+o6AUDnd0mmmxDIUIb6IGJ/MadRwe+LXlyRX3boVqDXcO+ddSk4
+N4/83VNseAOKFagBBBzaBMSysbVHS55FhHWDNX0MVmSsb4bix8gp58zJ9Pti
+qrNbJdqLfwuaNfShWYlkbhuaa1Do4ZqZfBzQ2s6MJ/bUOcivugboPhbzRTKP
+01rflK+rbVoMgtqwGu8YAp9wVQ/CPgGFdbHnpoXyDcbli+XzdcdjMmJuNeg5
+JS/y0OR/YE78OLBh6DRmpCOVqCTstdBZz7kf6St/sXUJ5yYgx5i3wUuc+cuT
+Gx8St8WjjzE3Pr2dRdgXb+KU6GdNq/MmPu5q6iB5farseER04jVXmS43o0+J
+fR41YSxJvqHscpCxRkCthhkogthyTlc2m2mpfFGLj608oEdEy7GcJv640QFa
+nZwa6BKKmnlxcftjpyiIFdZB34bYMqjfi9he+gFliqpY+s1I89PpB5EFMyAJ
+nhIsIrwz9hHRYhx7UZwBKQCVcvPSlSjxMsZrDgF9AtV5+Q7vkTISZxhFnMmR
+v6Du2GZGEYU+8D1+gDuTPyIyqoiuNiUIwA2IWbDiVeKRVvw5Ael+RzWcQsGy
+xxTpHxEZXfeIauY8pWlWufYwjzc7obVQVQKqYjwN2MyEEruo8iKh9ljpeRw7
+XkOL80mdXZpIWUhjbppbo1xhbjWsQHJVaM+nc0GxmtHXZ5awtVED77hkmLN5
+P0cxwz7ieGBq6XOdz4qkUykV/keZ+wYAoCc4e+W8J3h6nJmss8Ntl+cx8Noo
+lH5ymwsVOdnbBJ4ppPSeGuqx0UlxtOUsVXjJ98/c2AEQGzTn99ooNHWERSlR
+utbbrfhVufRN/vMjWi/m6y+zXMtYXI1arKqIykGRx0DJMufXhAkeIvc3BYOs
+kkGNQRBesXhcgBlBt0XjWbV50TdixC6Veb+j3Ci1xEB9Jx657JqaB7jc9dGO
+ay9zeZ+tW1l7RfmtfKXoFgo71stL0atSdvordmJzQVyEoXaKVS5CA5/0xCIK
+sV4lv2u8wgPEG5X/teC1L4YNOdlZUhbT4+OEegf6UXKC8/71OCE3B8HdwAKy
+3L/je+WpjRzHVVwQeEcN3jX178lJ8pNMRkH6JexM2FQTrLyEWdGZ/7kk8scJ
+qfP94xMib7n6GuP8fNUPvDWKE64I7wtxpM8A0E4qHgGA12Ag8DqrS1mSRxj/
+J/vlTuyiCE0yvHDeMpByUchH7ZUD5L1y8K1HQScifJ66i9cPay57fEuR6sfy
+i9xQY6yUhor3USUTH3t+m0FtaMvSpjd3itdVtpqQoUd+fbNu2gWr9jJHfdnM
+5+nIPTqvJkoDHx5TFr3HKIoDfCmU3hCW9uTAGy6zxe6dAPJiHt6MAIeokrDh
+zV+DJFtQ8kBwQa2KA7xL4vCvx2+WXpw4GGw23FqqcwboKm2ZJbHQYxoyvIqT
+xYxvC+7vDoZD84Q4wU49wJ+GhMsoEq6no5tRhO5P9daFyxOi82b95ODBM0Q2
+nt1s9nhzk/cy4BpZ1RkilJ9yMpy+fPvgqRBn0c2o8P70nQcTZWUYLr01bbix
+u1fZcMOtJHl/cvyK9wDnUvoDdU0wJtVcxOEFvvi6vzN4Lt4DVthE79RYhs33
+Z+XzHI9uKgYv/cwXB+c+VUfkS2X44OXBcnEAzbDeoBnsIfK1rxmK1IPBB1QD
+M9GyayIszXBzxTA7G/teSS88ArUwuencXwVnoBSLU3/1YKeOp0dStQf1OGd+
+JctIv+vUDT7kOapywOIJmkuDpYYQJcPpdx7BrKW2E649b2NpPLKZz8flBIXW
+k95/d3L07PD05Egcv/zhsc08vcnMT2C+R6c/eqe0w+6IZ+Lk/bvDU4EUEafD
+/nCw9djoMQ6mQQZe92WCpcDJ9WnzkgGJnxSgR0aHkLbn60+ft3fRmZ8DzlEw
+6j42Akxwj77+/GmLf5Rz9kbKLLzZ3LVx+chIEI8X5T4brWeuHI2XP34EO1sp
+AGz1txL3b26s794SGQrXUy3zg4pOVBt6MbCbM42L2zW451GRLcR40PWVK0WT
+ZH/a74ndF8+GgxcrMdiqISYzP2Pe3TjExNckaILfQntLylhT1x0s5iv3t9TX
+Niy4F0uhIKYC2yariAGoHDqO/eh8aUZvORJJelHRK6U1CrreyLxQHvwLt3i1
+CZrchJh856Wna0pbEnEUz1fuJFHBVTwaAstLxQ1XteEowiNV93aWqWDQbPQl
+DQ4K0PKSs9orQ5fiKrkQDc+Kboyu1JkhLcrqV8SYi7kXqT+9TsMQrnGmt+ua
+hBD8IBqFi7H0+P4WhyBFBBoosnbEYPidNXUbTOPA8tOtDHz4qX7ghrXYRLHn
+Nz/gm6nwrOsMS12T/1rdVturCuGansltZp8m4fS6c1cTSMXJhzevl4Wc7nXO
+JFo3uuuAtJRq3N5w/6EzkCyLd8sm8Yf2eMs2k53drT3xI+eK020Q2IXktZ/J
+S//Kuhvo6PVxl2wNmIHv5Ptg5xxln1TSFttv84vLJx1MK/bUdrPGbvSPddrn
+VW3X2k37B3i1PO2mwcYy9K88HzQ3COl1h91Xry/c6nW62IwGWHaERI4kHRAt
+od7SE4/y3Oi2rcXsunN7q15/YHNbcm3lChMstBz4oC+nfKEB95SVVbxbyXD/
+W7zaEkhk3gAVilK1vTHo4mVni1Rdc6u/ViUAYZ4bglnWI8pqy/iC6mUSC7Cr
+Dx2JoOWTRzPSX/H2XmxZZz75gquku8hryyS9toSZ/QIThtzm9NFihrErUF1q
+lLG5zT53qfJ+7wHeNJdfMtcKffnpC6EfAy4zxT7uXNSQeeK9mdOKc8kCeZZI
+/6NMbrJd51CWbtnWgMD8k6DQ0q8KqWb9470KuG0fo2IuI2iLhP/pxkj4n26I
+RALCH1co4fY4fGAIrTHQ/OKhOEd0xHsd10ObkaPQx8xmA2uJglrfwcN/+4Ya
+btJaoVzwQi4yHZbPw3g4xT6RdZNtMgzPqdEvpRZmIJxn6GMBo2R4SZB1Ex41
+OMpNHe4Y2aNOkvAqbw2zRZrhbXvYwQ6dQZyqL/T1r/weXcfnj0ZynrXIKrkO
+/RyNfktxkWrqF5qH3gP1o6t/O+prN/OBUR+oN6bX2CZcRI+OyuCjqy2ZG1iO
+8IqvJMiLltrvleBt2qCEAuUvDWJ+sZsJsVpdGxxujKx22g2M896enK4QnM/D
+oDauSNf63dKwku6MbnHL2r3fEEye0e1Ou42zde/zLt19gDGxa5gdGAUr3XpQ
+1x8KhwimUbE1RT0uTYETgqPCcJpSqyCibji9OSLaY/L1palEk9G5HH28Dl5z
+4phiv+ibopZDvRl2lzKYni+9w3pF5AzQVXFz7h06c5izhBPMPgbzXvqpqgNR
+AIIs1Scu+m2s0NBXFVHbjju7q6gZ65Uks3QVCYESDKrQJ245BlHsZfGc6mQ0
+GnWLb6P8rX60Amd9pmPjiN3c1LUguhlIprseRbHQKOQgyPBRRX5047V5xuMp
+gfud91tZZbpjOUeDKco8vtP7jqcdR1R8NovpiFmhksMorS4jyZ08wLTT1c79
+/JXTcwtSHQD4aBGO7aAZyOcLf/Tx0k/G3gc5WiQpblKli1E7Lz4cH3TpChFQ
+g9Kf5QDwXnSy9EfnAcCGP82CVOyPvENubW4OeyhKu9u7Wysv3xyMbIsId7x0
+OF9tcpl1aDPjwXX4lHw9KgOx4vF3L5v5m1E8JtYlL8OI5dmVw9IGa/c28Vrq
+XIsNxlQ7yp8soo8R8KZHd6DhlS13Typh4cNUsvoVCIUgbi5BNA44yGy/wWh/
+IVJF1DWMI0gPgIdy0TVYBZGrE4kaX4pzSFMpNQIYzGHHtO5svyPKGHWptEn+
+eo7SHUgOU1oL0D2LDSNj7f/wisLsC5HCvkn6rvb+CV9BDQBH51z3Y5k8oFJB
+MGYtprsx2L6OIpiOYm8WTFXLljufOth5r8P4DJM140idwOVQnMBG5/XBezy5
+07iSUTOJF1ZiUP1+u7W1c13qpHG4uD/iHLwXGoEcwJecNX2M8Ska5EtOGqaX
+r6HjsXwhA2r+MfXkp7nP6Th3L+Y4xH/JK3GyOOMsqhxG5/i/TrpC5NgVb9dp
+WOT11SlxlsxHmG1Nqv4+TWd0JAQhYhtHq1nSw5Wnr0Lz97PLKRNH2YSiZBR+
+IeavsI/veOJtLOIv5zrdi2NfdLzz1xU6eNPoiuxenH1DXMy5u10dND/UaFgV
+rg0xMOtKdxVAL2dANEUMda5lnATTIHrYpKlEdrX4oD4mYAgVtGoYzp8HRbGp
+QGiZtBQwgHleBL7Yx2Oq/CwDbLvZjLaiI90Hx9oj94+Puk3hvQJW4NGVjPlb
+QbwUD+Pzvvwwxt7X8VimSq7bKLMCtmfTLzOfF3ECvF6RWvridRPuW8P19qoo
+vZAjlYkOQuVN1LnXwxa8RqRXOzr76+GBMJCEhtTiaps7PD2s1QhMhwlnrWLq
+nT+d5jmesIFG6WI2r3CSmgi4hE/fl4mFhFQoICkAiUROsTFSnsSZA7CR6rx9
+cVDJyEVT+rqkvjatW1E7jP2xN4vTjH6TY4+irXdIaZwvDi1injuNT1mTORiQ
+n5GfJFf6eep9mGb8XuftmzePeAEwucHTxWh3TXjK1cBjTFO2Zu8vbw8eM2dj
+jz+kFVbDBll1sP6LEzhP72V0LPIqxHQAGsl9+rIFvTH4uFdhJzTTr2g2FEuI
+EdkfApn4yeicqohLA+QQ9FCdHzyA1RX7+A52RrSDCi1WKD33k3vSOPm6MBLW
+7BAdXI2TNlrld7cYdknbA1iME/7gQ5B+xBaFH8XrJF7MYXkww6OLq3Ty77hK
+GOJIH9AyMT6wGu9+d6uxzO+wCyMftK9x7QpO8i/K1ZsP3adQ8x0tZovQKie1
+paVcy1MnIQcIxadJnB66CamPwjByiBGUfP3rUwPrTh85OcrpLtcnR3U96uOi
+ivF927vh7Wm1X+FYW8AfJcHIh4ZdGkZs5Uq3p9YbcozprhiBkAVDJhv1YZPq
+2ddf099fo77Ml3qK5hsgw6czX3/9jJ/WHwub6RpD9LjPmbe4SpeLQ6fYNQh2
+KnvYPHnxFexnaTyTgg+pxn7me/PQjzBdf3RO/dthm+7lDVZgM5bYBsZASLNk
+QYYCp0ia0sw+J0Zi6jZ2qkSiw0Kt2RNaM0BoE8bzGX2h2iLKazxtTHLMT4kF
+GJkcCTHyIyp0WlBTEmQNkK2EYNL1A/mQNlS9WCB5GTifWONZQfhafZe/RRcs
+KMxTl+aM8ug8DuyyXFHGGHE19K5ZEYvZGWL+rZVHjAjztRtPFRvkr9VMRnDr
+4+KQV66lw3inOXf9akMIpT+p/kattE3cb93va5AixPLy8kIBsB5rgjeZZA6W
+JIClXz8b2awW0JA6j7UQTn7wpoJJUFZnberU64/OrWVyJbtOinpiLcm4adne
+NO8qxrPJpVIJZLV0ODNfWTJUqRhP3JEMnKa1fP9mklG/LCvIiWHgWxIThbdp
+EmFjruWZBvTMI99WEBqGxWT3NoTmzn8GmoVqheTa8lhRpNAknfvMWr5x8X3k
+Sg2kmvEbhqgTAwumsN4yYK35EaVVcncCQ1TRekpZfPBlFZUHbei7H9l44I2G
+UfCvhQwNeld8USxh0XcY7Ggi4lmQgTj2wKnHWtnFjARaXSNnJqpfF0cvHQAX
+friQ4s9iIDqchEqId8trrIgxCgMsFrlXUjAO1yQEv3xTMlhsV0UI6+sqUrSh
+xE/nkk1f1Kx80bXi0FSkeNcy3fw113uIM5s1a/w1EFy6W2oRpOcU48kuJYOe
+9R26OSAsKoiOBPfnqqusRxXPgu2IKBGkitjjZr3g7OhzmZDawxN19jfSpfu7
+9Y7yUVIvjqR36V+p1kJhnDZ21j+2Rn2rRu0cv+2CPmYlHNCFbpiKGdKl4Oo+
+KGsLxA2QEzfUHYscj6f7s6KI9WMKZD1+a5rzqMCZAWEmhAa6C8wyQgCAn4pL
+GYb4r2qof3pooBy//RKNjgx4grC7vrEnLKJ5GH0bc+jyRIYyj8UefsJpBHYL
+IWoDN3a6xqp3U7ym4jjtih9TxAQmy3iYV2vw2d3aGeyJoxPvaGlXr1JXICW2
+Dr/kgktiuwiibGPdlubEj6YSFFe/P9ze2dlZH25VqIOamDUPpAqvsUwIHJ9o
+dIXcMAtGScwtylLbMa3GUt3/il69i28mlXFSJRjmpWWxdQdP85aLVnFnrxow
+u4xXkcS3y2WuXtYM/stkrkHWcnFcKnN/yNq1ZM3hiC8pa6c80PVkzeXbLypr
+Lp43kDWtH1rFom4garmFtZJouSJlYPwhWre+jdV3HSw6sHmsPJBSepMw9kEA
+DcOClZ2l4unZFXZuxes2WGSeWhytrfhPg/ng6RJON00Lc7w44rA4yxJ/hPed
+cgYzdkhKLnwO9WIHacsGrWhjqMtt8Z4oWCYwSa3OhvCY9bbyd1K8k9ccGWAn
+PkxnGdP9vQluUv87PuFeYrJFkeUN+hxanQ6btvzyit6eTlIryF9dYwlrNFZh
+Bial/6Ex5b4p9ilwZbGRptCLYC1e/kreQHMmfbyzfWx9aSLm9q3dAhP1kZQq
+5KJOO6I48nSjee6ih0oRDZlXzk3LMPgiGofqXKVnFQ3n45am4I4P7pk+p8GS
+DFgq8IBJkiqANdukFct7TxxatZ7tWHSRBRzKe2Acmms6xpB3bOLRRKpucuZe
+Ypc/7RfUStP6doK+7PdwzzXcqk7UqBl40rWjKMR3BW47q8TJ4TebUznto57f
+KsE1c1x5te6J4aqXp6Udp2dTgVmT9ab9MzDAsvMkzjJgdw2zX2kT3Kq5XQ7d
+fUF39w9r5vdmzfxhC/yubYE/9tEHvY+WDuRUqGPFLUiHLZZvQV8k4tN2C7pe
+FKhVaPMcWOY8DseNZHqtQUz4MGASTBcJR0Ty9ylvWTFQHhjRLW9z3EB3pE0m
+g/1Yw7J+23aKOQpNUzzQ508YKC0jnZ/LNgStlh3OakuC22pZBzZ1QawW+9zN
+Yki3EUW6URypMpJ0G7EkxUDtDtbav1NMJvrchj0UFy89u1eP3SZ7bG/g9UX6
+zmk0ozBX/SXpkbcsrDPdx9vp+SzMFYYtKFo+ILmGHiLt6+WUXCKsSRymlt62
+FbaVRKGVuiE9NTBfSxdz3Cup516ANekXQNLv/qz1l/lszVbq3EViBq/hBTRP
+K4GsYcgZ2wbCLhfCd7gzR+KpRVbr5xsAUhrRSZapO0AHAqRgn8NLWENYg4lr
+ZgvRONaSc4g3f6isO1BZFSek8WTiVKfWmhzNRoeTdbVa2sp7xoCzSFRz/zG3
+aXXdA7ZO6Lna3JIiC9ZMrCqxZKMVtkcKcA+5UplFPURVjUwoS6Q9TmFWXFqV
+LZPWTsAfX8gkC1JSm9eZxs1mYYa/6TwqNeAKXDbs92f+p2UMNly/2XQ1li7Z
+ld/gTLdAivL0K/WR0kgryK0zaC7DPVA6rHK2KyjubEhsL3uggGzC1u+txsJu
+Q8iJK5JzP/EBEKal+yHslzAouPxYsCYWdPX8GXZpc+ZEuYlhCC4eJ5epO82U
+46Oo2+FrP+LLWhC1r8ZReNVVFXMyX9dxmXlNB94QdpfxlUGenF0aFa/HEGt+
+FM/8MF6kaw4M3IcX0UjVG5qHxFmQYbl9V1ziLUPojSbBdAqcUZHkVb10djH7
+Xa0cuCaPduEU7s66iTUOLrdfsxHoLaDMDdYNb0sJZYLhRc9VKL8uX6A8ZzGY
+6IY5Vr4huORgWOZUUZQo2mAU7uCGmPla86Py00jKccoZCAZpZHHXisvZvTWL
+uyhUkG01Ll6WAalCxjpVYlnyo1QGmsd3uFpFgXX36eg31G29MPvkqhy30Un5
+VtltretVB7SQcU/59lyNrWrB3RpGm+8aH1O7MH3lptnSEqkDH/X1t+63sD5j
+P4sRu2QhC182ZuufSzsDGW8kUi37Il0mUUpId1bcwhzm47mUdVHX35fQU5YB
+X7TxdAXsT/hqDox+xTEsA4zQhGUtqKfv1MLw3Hm1y8AqrQV9uLDqZUi9wmy0
+sbDZ3+iJw78dvzk6ODr97w/vf4QlgMVQkAsv0cibOzt74oSuSKeinR8jzWfU
+pYGKCvV9xMX35Ym+nTivIfSqDR73XuICeT9XiwPGLVqIQ9Vjiqnoq2zeIBH0
+5a3JwyF3tjiVyUy3sDyO0anuvDk97lqy8vjFob6uxkaTFqCqtMZBFiRmGptb
+sNqhS4RmWVM3l1fV3JTQbiHFFC4rKO8/xPna4ryIWgr0kgfvT6RPj23JVSV/
+8exMi7g6dcLaNWSdQrUM/mgjFx6hPeLopSkZBo7Iq3UiiwglIAr+UqH8wwb4
+Q+m1VXqWevhD7d2q2vNTT3VZqlR25usaNVf5Ov5wv4FIZnvmkdsU5f1FFoPb
+h07fyVWayZno7J90lbH1+AW4XhL2T5Yxf81CF6rJ7UXmyuLSAtcjwccH+EKp
+MlsfYMtSTbUTJ62ONZyeazzLcywO1VSmDLomTsbKr04zP2tuvg2jfqA3+Hik
+JhMCk7I+VWZALMlicGDjTAiS2qAZar7LWvSw91v2ygPdsDTN1Ovc6xjvcocH
+AqfrhZWHcnZF78EQCV07hzHYRIZXnMQoPsqrYtxYn++uFkpwZvqlAwkrO7qV
+1eBmeR+tOeIhO4hJ6E/TSuSp06tJ7fDowRUwpZNFK5eE3u8XdV/NfnvdHbdk
+VCKUzcHzwZ54hfHGD5JXtQwJs+0UsLJl2gR8a3u4J15Kvt6arWXfZWhuZQS7
+64f33RKMd8gfR2O8DcXjB2uXrYUiXB6q+RKxiLZOZ0uJumMXyOBY9oX+kKB/
+XwlyObZWgv5w/x+D+//Hlir+UAiVy9Y+dlA0x1eJHDwE/71e5xVnulzr3b5T
+WOuv4U+da/iH1D1KqVvJo6/xDSsytSpdembHRHLohbO3JnGTW8/8iCl8AcaH
+rMRN16+3YBa8ewniJIt3iQr6WN8CfSHbikdOiVgJl0opC9IcWHUgRw0pP93i
+kAbYktiRiXkZHPPnqwMBR+oK6FRcnktsCGpiFmohrPkiYmVM7Lqka0dd8uCK
+rvlhAlirTTgRK5biHgU1mGZ+YmXLUDL1004UZ51+/xk/IqPxM63anplwNyUO
+2WnQ34inmCPUqXi0W3wOiFP4aNlw4s+iAnALuDUoVWHfAoc1VQm31mpO1yVj
+BcKFsR2pLWSxWwtLKeNizSCwxgtMPfORc+rT2FN/JpuaKNYzJ0oB16sRCkbF
+iQDVdUFY85a/FiY2DH5eJaEhAMzhDvXnNgT7LAOMlcvzYHTOtgDCsWlgtkqd
+1gaq1Jph1V5eIz3Svnm3SnaIBHcpPXUD3q38NGBxAwlaiZi/ExmCAa8rQVVs
+vkSGricFaWZf4Fi/adFzsEOqCiWda0lATO90a3rujPRXzAUoeRzZ55RIXg6q
+ZcAW+LD/OTeU0+EAKyXwcXDj1MDkXNUty0/+bB5KW424bPAnhwkkWl3Yc3gt
+J8Ka+E4Mat//rsX7fxKDx92EuFgl4WA6LPokjUftFp/TMi231j87bMo2ML7v
+nQXZzJ8XjK0r+GrvXH7yuFPoEqtLZwtj/zD4/9Sf591JG9WFzVBZSS51DIpF
+kE+z5nFKDo7tBilTjx5ngennG6WpE+dC77NgSnoD2y/YMNbyya4VZYtuREDZ
+wP7YPkrnVWYCTPl7Wi1NYKZ4baA9Ny4eCuUk0+8RjFT+a4FuJ+D7Rvqkzf4H
+fEPB9fP8pAVGFyObLOqZf4VSrfq+kud4hvf5ZFf2HA6xlzlmSWviaRzWbA5Y
+c2gAoOepOwOtXnW5PHGfvnsIm2S4a93Xd1nQj61FuM0sX/fkZwUO+bMYbg8G
+g0IueQHTP4vBp8FwgD/DHmIT7Tmjee50O4MuqXKZ9Uy4E/xS4It5zHsIQJ0X
+wpo8WZpXPl2Awuh9A0DF146C6toNLfGHn8RF0VLu6DOYab8B5/XNL4H0+mYL
+rOGhRqwdv6naZwe0l/rqTqG9cRfN/mM5bXobprPrS2Aag7HaIGfcKWBG7Rip
+HrWmw34popC22Z0rEKpsMo74l0aw9wI8dH9KDmqbLQmH9s9Sqr6o82ctTEQA
+4uWmAwgWMayUUZSiJo+jkZxn2NLgW7694zJIQSyx5sWArmIs9XbFVe9N9WY7
+WzvP98RrbryvC62t215Mca++QcYZGHnjNRZre6oOGjtxlKu1lVFWHTBqFWuK
+gf4z1X9DX53DEasGFn5vvWT6X5ueEfRpdV5JxS1p2kpQV/8AQW3O4buyMRha
+da3PEqv5SJ+Q8A61ZoFYyzur04VSo/xGHmsd5kk8wspEIjJd+mJNvDKEcymD
+6XlWmBvGcHYtY6Js+9Q2+rduu9KduhTZeaT6YE6h4oYiT2OprjC0xP8SrZin
+4FHZa/Pnotu1lrcmsxZDkcNAT9eWTSm/wkNrvzX1LkfT13QSJeX9FHwPGrpy
+Oi2JQLG4L0YEBf1aRFDvrkaEwnSatid1Xe/IqJ0ljVLoNl376bwLj9VzF91H
+a2a+9QZ/lyhnFzSsuoCa68bcRjGr3I60DyoXrMc0c3pV4UULoCiQnEVxrhRT
+OrIG6c6KWcNLdVHhzVp9pGTccEzxvUWk/pDjZezCfRlyZLk1FVAhSPIOXaq5
+uGIJexdThiuThKpOs/MWHRw21wfre3SEgatundkAvJPFfB4naLRY47zO75gR
+b2HygWeO/uwWDHToR1tbt2plgG0WcyBUECfl/oikSO0lydsh7FTGUtQq7LTQ
+tHiQlbMWoSE0Gm160a16WlY1eapgvfe5IxZ3PvWUDprxcrfrGAfu223kUd8J
+D8yWpBfzFkRSFa98lbsez42UVLcto/faql4m0V2q3oobiOwnyjvHt1WzJHpa
+D6ktqrDTVp5dKvcnL8klg40Cd1qdmbMz/B03azNxVc6sb1Gu1f61NoHC0PPD
+S/9qqVt0XfuFfCR7QGPBFMet85Yo+xl7FV5RbnMLP8olrF4JDGnwkBpx4zfP
+nUsqiWhlQhqJLZxWGmEttUVpOrbVjXvc0/qWSeP4c8PEcQJxk+Rx/LECjyQy
+5WL3skYqM4S25vSy3CVHaPMzFzNNxtV4ojDzBZ2dlFmkRp/jD+l06+1ybUoh
+Faqo2KtM46ctubHiOL+SNsXGNMKhqOI6jVrgUDjI6ljn9oTqg12NVmSrWtkq
+zKiQBflwZcullrreERgCyPa0yF10jJEm4bT4hb1BVH/feDRBZD/58OZ1bZY4
+/7CpUwO/fqlbYqBxKLbnyn8+Fz8qfdA4BF5vl4/QsEeXBi+M03TKU3GLoj5e
+KlRK4ZeITglRlWbTVIFZeUJUadQ0hg6WGzSWlrWJRRGH3HgxiDUaMfWbhhJ2
+w1VVO0bdflHndfIsKnfo0nRKhza1c6hTdHUt1ap3MkfFad3U0mi4sVq7oVIz
+rNdsLCzjyJqI3qoc6ZjVt8CRLlp3zpFmOn9w5O1xpE2Vpg22dntdtrk27zpL
+N9bGbbV5U221qddtqIVdbZVN7nobadvC6ZtuodUbaKs9Uw3k2SFyagjXHPZw
+jzrUC+V2X3kP5lrwLU9T1Eu1B5qlAUoOmXVW0OZYU6uvSjzKrlTlURn+tPKg
+ao/MVuAi6/isSi/hXNwjNUx5LjoATDodLFFzb3SBqPdhmeSWIG9vFhyhqrar
+jWUyeXtFHRyT0djLYkrfdBcI1O8+pacUPRvjK1KNGAED2eXOjWEwCzIza33J
+fAGCQ7wbCpp9MLlEzrQmoDk67zWIm/1cq9wB3ggx7X2yiPjcwm7X6BvH1GYY
+q2IF3c/ZHNtHkF3C+zZd11jBRCorzg+nGLM+n7lJcTUtj50ZmVfLWW9KTh1W
+DCbeRPoZ9hp+WqK/kjuXGZ99LdSImASlgWKfxPwZlqoypKKEN2mfhilrBrC1
+T0Xhkr69oS4xoF6VwBxPA3mWSP+jTNLC5KzVt575tT3m5dCr1kIWwNJc6Jn8
+gbKBQMTMH6gk6DID5bQSGQFvZCBqPsVc53OOxPtVdob818IP4fuJfxEnfPyE
+sHClUmqYzNYfwJkHo48VACi3TqZZnXFUmGCtndSwr/DP8t2Ff0qBheWmVov9
+pmmlm82x6lIuEnCjqjyjqlYQ9vLbZcEv6cJ64ViGzPK64GtpXv65rv7lH+5s
+X8K/huHasNtZ9fJU81xFKKsYG44nHrU9xmyNUZxmtHeuKuzl1SzUVVUitGro
+ydndsWwWKxybr7fhos/80WXWc/6op/Lml+zrxQHsJGM/LbuVuR1dHKpkS1Os
+fxUrOvJnOCrDvbLPS8um9LWPIVR1s43+FzSmVTdpNaUC59VNsGg9l8ir5uqP
+gfM9Ygm3kNhISVvjmdIzNd3ZMy4deMjZPLtabtLWseSVh8t7U34kGE3syMP8
+wYsVvOhO6Rq8iHBqyawIjR+7XMfdMkpPKxoVqjKWTLMw0eIqVenslvSrXPeg
+7uCqtZbHANZyBU9ho2WqnUBRj4F2QkRA50k8x872cllUJId+c9nJo2BNOR+3
+KEcrHC2vKD++kR6cFE1HBniKXODL8oFyk0ZnOhc3aDNfXIuWiruC5NdQ0bz4
+rfRzvcfGkkNkauCw29TOZkl+HxxWmNSt8VlhXc2kK1RvW/1YXOXrqMZxkP4T
+m7ZHmI2/TEM6D1fXIVTBy/sxlYZccjCFxg+9G0/MPu0MYRc8/cTulClp4/D8
+PAlmPiwyDt1TV5BYKIbyQtrXvGI0QWXJYZELX6eE7+O1Zv2aQaz38xeaBhTx
+hUwSureZ6/hcJArw6ZzQmkZzVqRKKyylDba9yZMS1NWRXp4quaQGpSmhUX1b
+f3xR+1RuANQ+Qvrs26Vs3jJH9HUYn/mhEq9VaVBQ5xVDNhyg1A9ZMhdsWjes
+svt8rdA3sZLzkmXErBAGt95aRrDyAFoS8BanVLbQFToGm4NqOHy66bHTsoDv
+AzlsWoZm0c/1R6PFbBH6FBiqc3orD4taYmAPUHEAXO4e1EIxNKsG/CkwW2US
+ddNq15tcbu4HGwywW2WLhLMGHGrkBSO+CnBhxza0JPjG8fCK8xjOKGUBNh2X
+pQwL2/hXOICllNampNY2FseySRYnVrCYVptmfcpmU9JBk796kxwS/LmFhM0V
+c0lKb1f4FQUdsCxFutk+fPZMvHuPZSY4l/x6MVVD6/nR2Et1nRHrszMZxpfi
+3MfmDFw4ADD4dlOiDsx3Fo8XIcZYLoJUrQs8g7Uth+Mgi5M9+GoWq+4uUZxh
+fTL+yQXq3EtFOntSE0LL7Zq84iNWa0EjYwmNBmx3CjDwucucY+ma510rt6mi
+Jq9ZS+eemQh99G1hZWpTtWxMC7q8poxo4/nmlmMx6rSeSuKtMo0cwsif+2dB
+6KrkFlNxCXyNucB/4H//B36+evLrnvgPsBa8+cjDfiMC8A/ln3H7OUV0xd/3
+371WHPn0qyfsTYywUSFY1njw9een2DD3qbC+QbPsz08DmU08Peu/rA/W173h
+wFsf9nGYpyQ//6GvCXdHe0uj4QPM7+kacfSeOIjnrAIy+SnjQpFff/1fMMPd
+nZ3tz59BomCbkeKn1+LNATYSwkfx292dbe8MG5vMwcbBPhyBskuTGbUlQkyO
+9t/tUx08LCIbqyl+8UrtW5M4BLmlxqMfjkwvoKdHh6evxN/evhEf5BSUWnL1
+FDD6Hmm+vbv7+XOPwaK0L+ZjvAWSO0LodRLgU4fUXoU+4hYlqPFi2O2Bl6ih
+Bq8TLycMvidg+9hD6u7RjZ3p3qdZuBele9QuxqG6fksh53Olfwa7yR5r36PD
+k9fGG4Rp7Il3z/Z7CkddgAdjIsFAieNEySWf+yNptRZpjdWclvtukGOyffXk
+1CYo+KcpXmk8zhfEYvBU94h56vDhO4T6FAblJVY8t/N8a/D5c2mFEIU9/rVy
+LQyK11jHOXBJ8ImgF78yLLVHG8Xf4CdfnwqcqlZiRdSqQLgYVj1Riaheq3yP
+E+9I4o9B6dJxwzwEvOjpvFMWPq2uwPFTrIHUN4RbC66k+0SOFlTFWpbwO9Mx
+1GFM4zFy8DAmDl9GTUbuDlpFztBWmIVyibWBoNuSODxj83W/LAf/XNDdsSAH
+kbykfQRQSMmEMJenamlwJCTHFPYOBztuj5MwfYIMxpLc1i3AliHjxYhucafG
+On5YIABh6Hke7JWYUMLb0ugca4pTJKvaLg74E14WukYbxqbJWZfEU2RysqAM
+CZdESIDEnzBT4AjIzx7ersvw/6OwEb2Eb9JKvpxrvlR2GC889rT6pDlkvjgL
+MSUP01YN/fXiAo9cmEgWIuBc7GsR3OaIjf6wzBOqKZF+hfrSqDnjpdG/0hRx
+W/782XAh3r4eZTZZDPJcHjbxR2iX+JSSO1qkup4VQQO7KH6zxiwOpVlHLSE5
+OXiVci68xZfzOVncioTRpjL7qaSyc4Ssbfnd0d8owONjHi0Mr4YsEVSTJ21D
+2uK8jLoHdUXYlaycgTfYBkOHrBz3W/7oO540cV0/+5SBTQUzWkuf/b/PUD0+
+Wyt877zgkXpO3ffwte/wVfPLWvUrBhRvfQrM/8k3SokXnoMzKjql57qqjVuc
+UE0+iLlp9rUxGG0M6Lc/icLPn2Z+EGbxXpb6/vgv/1xEwVwm/Uhm3/GrIPFP
+NNb1L+ILf5niJ31YVPXq1tZoa8seFRV3Qu1uOqOuwJUQZJ2dJqTqlJzA+Cmt
+vT7SGJsWdAVkSvDWV4S3PRhtO3Rh13ckI3IHklkeqURGY8vmhNpHEZwXJy/F
+G/V4KrNKJNuA/IAMXwdve6u3vT2C/z5/bqNK4ncBc7OVhKOWsPUL9dwwevhb
+gGoVoypI+G2QpTKcUAxossAuWHKKAeM4C0aWc16Y2qoosCVhAeicZ9k83Xv2
+7PLysp9MRp4kDd6Pk+kzbEj1DD7Dl7oGcQtZB9ISxL8T+dNG+eYOj3YFGVjJ
+rdO8/3Qfd68990NPb815dxkvHQXMayMPMKEN5tviW+RyandUoOdMOw5ihp4n
+d5NNYA+reNe8BkZVPAp8k+MG+oTWI7uqf0e1l+D8Hn+RxUtQU7F4EwJzUMuj
+CrmCgOUx/Q4VlNx9rhtFY8XZjuy6k3q3gJUGagt8rvrKeDGoiyAy0G8F8/RC
+jiqSOiuncO0Z0CB20L1ImwZIbWJMffcl968f2Q8rMb4lKNrgcLGuoUrjYO/P
+0jiUVcPlYK2sTH86zXtB0ZHRYlYhujVvh7E/9rBvKf2mbi1q9abJBsWeME8d
+mhdiPEZ7aBW4pwkqVPSOLVk/85Vli8pMXX3igrDuQbGH/Jz/WopCFr0yjlNb
+jllPudkC/+MAsi6FIHazTWkdv4RdfnPL39p53tsertsv5zHXVuqxIuhqQC0N
+vdZMvVUAlt9th6OzS1hZDu4XVDgKO31UFPa1Qecf/cH33e87P8vDXzr/+Kb7
+Pf7125r74Ddi7eeh9xwe6P88gH9/HfS2P3e/N+90nsPH27/8Bg/t/kJP/Db4
+nv7tfr/mMOJn+w+w7EBdPD2bpy631u92L0y3NI7R9zAIn8g0dez7nFBCE8qF
+Q92EYWgsc+I0goL8n1I1lYr9MsuZ1uWfkJDAr2M5CmZ+6FnthV0g4MYkwNs0
+BjcLtnqSIw5Hh4eHYmdrk1jg6OT9s6PDA3Hw/LkLBkVvYx0b6OohxQRUAyay
+e3M8W1ZSkxa0U8cbdr/+unPSFV+L4QB+O/w0jyMgDH7QOcmx7vbcFy+pHbT1
+AB937IBnNQWqFUi1H1HzUukWaxJDm1xW1WTTp6MoPYuNdRcQdkAOIj+52ljv
+0wJwczClxTXyuAzkyHvPt9Bh++b5dplcZgTuv8vPb+zS8/DPxB6qMBvMsjxz
+uaynnEbNBXmfVc7FciHoDpdy3IPfIy8C6w/3G0YFP5kkbFIU1ivqj+lH/vrN
+5zG8/K7/kn4O4e+XL3tiIAdIo8HhoHK91saqR/fLNer1qnmFF+1bsRap79/R
+90WkIw/rA5Pya1K9drhmygUx1ye+5BO4TEYFEp7EM6kbRnPbWcC8J4ZyOGAa
+PO8/39qQz/vttigSkpNsjILirQ8Gu3tCfYSX7yWct/NKC8QxCkRhSakmToL1
+XUDUkjiAae0sVhN5D+/+mib+LG8noF9/A+y58DFO4YmDfuXmp126bX97Z7O3
+vTus3o5WsLvvbTtqiV5Lr+WFM2PdWs8Gy3dXpE10fb677g8HW7u94WBno5qy
+LbySe97m22DoEPWMb4F3H265fe7nr5FdJ/IxdMd+DZlOarGHFJZPlWyJcxZs
+TkVlIKoHm8QoNnWmbinfFAYfDBrWubSqS4185706P8iECPWZTsHS/EKL/nx3
+awQMu+3EvlggKqrenLPaYuCrQoy4IHoJnOFguOUPAYke/Of5EslZ0bMBIK5A
+ATbKe/pyNIUJ7cCELHNf4IUq2SI1o5uprw9G8KQTBORqEDWVWmpXPQPgNhDc
+rgvuwEo7yrulz2Zg8I4KN0p2jg8Oj7t1Y14bECCGS7w+hCVeX6YcV3A/72l5
+13F517dbLO8GLu/6c3c98FTNT5Ir7SCcB1O85kPgFGvXu9VLMCAywMb6w2OA
+DWSAjS1ggI2dFRjAiSLc+8Jv4MJvDpYv/Ppw24dlGPSGGxs1ZlZ9uPGh2ABl
+xMpbv/MMEkOuYgGo1rz0NiVQ0DZBQxEs9rwKXzPJSy40vYAxGj/N8OwS0zHU
+FT9oGaw5mC7ma1yFbUL9GpLqSayTFOkAMEQHXoT+FQaDiGpFeOP4MipEKQh8
+kOl7weoANpmU67Ah+uvr69u99a3tmp1xxVB0wayojI8a/ruQ98uAzbO5tnFf
+bFvGxr1gsI02PgNdhl8Umw7QxcBXntxdN61CcLp2Xro0x54HaoyJH+DFJmdy
+5C/4WsZE3U1n7i8vAjLn2epEfywqGlgX7OfrEmYs8ZAeHgN9nlzk3UPujUAx
+ZyfPYgpSKOSKkEocw8iz27GI8otsii+yf6Cg1oGBjxbhuBS6wRbkL/zRR7xK
+0fuASTd05y1Nyt6IOy8+HB90Baog0JHSnxXBwE5MCdhidB7AOPBnYTFr3SF2
+iLY2N4c9ShDa3t26BTaYj6RnEe3eWQDpo7R0+UqithQa3I58qLuN4SOrSeBD
+0B7F96OY6yBDdZUGK46zK0egzGzwSvd0NZreErMBCbIg4k8W0ccIpMSjDXvm
+B9FDILCwMGSqBmkRlkIct10d9Rw77/F07oXAwLSmQvMBkLOOX3N1Y7DFJlC2
+9ica3g+XkmZWipEv5rNvar83epoNQ+nHIpAc1XuXbV49LeL3TrmiYDN6JcsL
+k+oZ43sh4Hx9dv+bTDwRx+tv8bocf3TOxSQlExU2GBDd2YpE2hhs346Cm45i
+bxZMk4pT7vshGFjzqmT5II7AMkwqjFbnSsHO64P3XZHPgUzRCVZhr2jpbG3t
+3B5N0zhcPCSSHrwXGqUimPujFX0Myteb2A1c74ZUQJScUxw/+V4M5PnH1JOf
+5j5dhvUQmAYf8/5LXomTxRmfcxQhdY7/66SL7Z811ghkkazqYGyt3wb9zpL5
+CGwN3igflgOGTqwg1MrG7/W9suEtEE11CXsoloUyXpWnUEr5vJY5cUviWeFr
+3Tu52ntX9+XyP5BAWDE4VQSi0MRa+RsI5HKaNUS361KgnZcfeEy7ag4tI9n5
+jYnqbfcc/buV6VmX9f2oCFo5ieufDejzS4bWisINyPjzoFqwK5BeRZ4LWGKV
+SeCLfSyuzA9iKVGMNvijKJPJxC9LZWf/+Ki7Wmi/gPl8JGtcyFufYinyzdne
++Zlz2fbCM+h6HXU9RV6Y19n0rub/ghuNvPYzeelfWUftL14vn+XWcP0mqndp
+DcdjUhmNk7m26jj56+HB0mSn79y1KQClhdoc7gFnq2xv8DHy7tivTK9z1bsB
+JaLAOSunaKyg3ZhubTKwKiWiiewrSEZFt3Akv0KKGrlMpwnmOUsrd7oIxka2
+8/bFQYMAVTtkN1umG67TyitVmUh1v6tEdZ+AjL4vhjCibvpFYE25T7B4b978
+zhfPSYK6/0VDdOjeDXVztyyvWOftwe9dolQjRpVm1HSgeKeLo5qJAPkYwdLS
+KIT1cRcu1enLFdcKjx/2KuyxZqpXm2f27fa6w94PgUz8ZHQOIMLyMEU4etjO
+Dx5A7Ip9fDMDWpXDbCuucXqODR8eiK7MV5bRKtEB0cT1PFlVH/6bLad9reED
+Xs4T/vhDkH4Ub5ADX9NVE6KD7Z+7uM4nf6xz0zpjuC99BAvNeMJ6vvs3Xs9l
+vmextP/R+ZsVDYGv6WNWNfR9/H6log+1CPay6kOpIiFXkNWDvPXw6SGZsL8/
+89QhYVATl7odGh69Pv53IGJdEubtEPEHgG41yP7d0tLEY1YNFl2PwvsV4Z+q
+crnfG5kpxgN2EGCyQqjnejR+Q4EbrnbFsQSPRT7I4ybwxsbO89HG7sZub2N3
+WxdmfqZ//yHexdhrMsRTBx/7iRMNJkEo6fu8XK7Grrlmd+27NFpW6be9zH65
+Tu9t/XJNB27+urIPt36zro11zjEte3LrFz6vIBa1XbpbyYLd5brAnGbaTUux
++uQbO3lfkwA1vb1vTgHz62fd/DQmLHRr1fe8nej+uOoWHSqoR2xUW8zba4aK
+oVCYR0Knc+cgtNyBgI5c4VfVNqqxrS1DTc/luNhC1FwPMJahz6HvOBazxcjU
+ak2x1ZBRwnyd7k+vTX/cVGGZSHg6TtMA0VIEy50iu+tjRm2lCSpRQM2O4LyP
+9Muqv+pHKec4MuXY8K0clqJ2+u1ySxj4+IrHpYfpLgjCQLXj3eNGDe6rIx8r
+O4MwpLtzkwyhzLgsdJz4l9hq124Aa9oW8628SDy8aFi74nyrSR4bdYYKg4/F
+hUoDPD9VD9uzvESMzvAe+kTCRugnlB8Jhl0WACeZ6+mdAYiM+6rDk0vLXCvO
+uPUvNjQu4yg6sj/t91wkPfkp665AEUId5pUQw7sBCoceXNRDpAuiK8XNpqFy
+c6PmfRw/Kc3yAra2OUyvdddnEgKkSKSlFzspt52tkpMRMjQ3YiIE+M7ls2Bq
+w+Ru0nx1mDVfRj2mI6e+eAt6AG/w6uFlqOliOuUG7uMFNTmj1qrD4YZ4JzNA
+n2QxSEeLFKfaU6taN3W7z7hNgR5IT8Bzor7vVpdtt6f3InMaVkdSN4TiIakB
+FHymb+zL9Q5NHJsNU59jiqXkuQPwuU2kDnYZ5dsBnm8MNz9/7qrlnsSLBHt9
+0Hr3TGdsba1I4Q0GSBDVDLVHpQ9ZTA14dZ/EM7PcVD2h23zHUaguTWnJgXQL
+VGzqra2W4d/ycPoaP4RyeR6HstRIX4Y2KnSycxaPr9T7oCRFin2l0HRKe4bM
+uHeMK7aLngZWMQx2qsb21MLuTU0zjm9p0rRCGEoyJ60T4AOUHNW7TPHtpsOt
+md261nRZoGZjCwrpKe4aIR1c8eTprkihO6LDSxZVBJFLaSpp0mjSa1pgnT8I
+HDXXI1dE6xFDCtMRfkxMrBv1YgOCLEFhTvqIJLXqnUmJe9AzAPwMNmqZwO6X
+PktDbJ/uwYdeRLh44L9loJ/AKfMjf0o2Hvhy8kLVJKBzRxOnbt5KT4Ng9efj
+CV30wQ3jNalMv3gtSVxn7IfBNHKKvpleWn1q44a74PeoTI4Sj9A8uIgD7G0o
+Q6QFNyOGuYjLOPlY4Bml38zghnAtOIi0GdXjwl7FbQ6DlHdxvNGgqPsM6BEQ
+Dw0JYj1pX4rgLFwqE24UAtrbH9NukhaeNzu85lnu70nNQvn2Km4TSvjwsCtc
+tLCz9KIFMG55W5bjPz+lW/D0dTP7I8xWDuV4Sq5uqk1RfwHmYgKmCS0yGTMk
+Kz44/2DwxgArEz9hR3KQtjfxQryQyRS3src+TP9c/KfEZ7GLXRTQbP9TTibi
+Bx9bgasDgSAhC4rs2yDCJutKGnPF8dUT8C4X7tZLoo097vE3VSpcsil8R4j9
+EO2qK2uX8lPFI/rOFvcuCNxOwBbjBv3ce/Nj4s+wKB5e+P8B2fOO9NtfAgA=
 
 -->
 

--- a/drafts/te-types-update/draft-ietf-teas-rfc8776-update.xml
+++ b/drafts/te-types-update/draft-ietf-teas-rfc8776-update.xml
@@ -60,7 +60,7 @@
       </address>
     </author>
 
-    <date year="2022" month="October" day="21"/>
+    <date year="2022" month="October" day="24"/>
 
     
     <workgroup>TEAS Working Group</workgroup>
@@ -4467,7 +4467,7 @@ revision of the ietf-te-types YANG module.</t>
    <front>
       <title>A YANG Data Model for Traffic Engineering Tunnels, Label Switched Paths and Interfaces</title>
       <author fullname='Tarek Saad' initials='T.' surname='Saad'>
-         <organization>Juniper Networks</organization>
+         <organization>Cisco Systems Inc</organization>
       </author>
       <author fullname='Rakesh Gandhi' initials='R.' surname='Gandhi'>
          <organization>Cisco Systems Inc</organization>
@@ -4484,7 +4484,7 @@ revision of the ietf-te-types YANG module.</t>
       <author fullname='Oscar Gonzalez de Dios' initials='O. G.' surname='de Dios'>
          <organization>Telefonica</organization>
       </author>
-      <date day='11' month='July' year='2022'/>
+      <date day='24' month='October' year='2022'/>
       <abstract>
 	 <t>   This document defines a YANG data model for the provisioning and
    management of Traffic Engineering (TE) tunnels, Label Switched Paths
@@ -4498,8 +4498,8 @@ revision of the ietf-te-types YANG module.</t>
 	 </t>
       </abstract>
    </front>
-   <seriesInfo name='Internet-Draft' value='draft-ietf-teas-yang-te-30'/>
-   <format target='https://www.ietf.org/archive/id/draft-ietf-teas-yang-te-30.txt' type='TXT'/>
+   <seriesInfo name='Internet-Draft' value='draft-ietf-teas-yang-te-31'/>
+   <format target='https://www.ietf.org/archive/id/draft-ietf-teas-yang-te-31.txt' type='TXT'/>
 </reference>
 
 

--- a/drafts/te-types-update/model-diff-spaces.txt
+++ b/drafts/te-types-update/model-diff-spaces.txt
@@ -1,31 +1,55 @@
+    30c30
+    <                <mailto:tsaad@juniper.net>
+    ---
+    >                <mailto:tsaad.net@gmail.com>
     55c55
     <      Copyright (c) 2020 IETF Trust and the persons identified as
     ---
     >      Copyright (c) 2022 IETF Trust and the persons identified as
-    65c65
-    <      This version of this YANG module is part of RFC 8776; see the
+    60c60
+    <      the license terms contained in, the Simplified BSD License set
     ---
-    >      This version of this YANG module is part of RFC XXXX; see the
-    67a68,85
-    >   revision 2022-09-09 {
+    >      the license terms contained in, the Revised BSD License set
+    65,66c65,99
+    <      This version of this YANG module is part of RFC 8776; see the
+    <      RFC itself for full legal notices.";
+    ---
+    >      This version of this YANG module is part of RFC XXXX
+    >      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+    >      for full legal notices.";
+    > 
+    >   revision 2022-10-21 {
     >     description
     >       "Added:
     >       - typedef bandwidth-scientific-notation;
+    >       - base identity lsp-provisioning-error-reason;
     >       - identity association-type-diversity;
     >       - identity tunnel-admin-auto;
     >       - base identity path-computation-error-reason and
     >         its derived identities;
+    >       - base identity tunnel-actions-type and its derived 
+    >         identities;
     >       - base identity protocol-origin-type and
     >         its derived identities;
-    >       - grouping encoding-and-switching-type.";
+    >       - base identity svec-objective-function-type and its derived
+    >         identities;
+    >       - base identity svec-metric-type and its derived identities;
+    >       - grouping encoding-and-switching-type.
+    >       
+    >       Updated:
+    >       - description of the base identity objective-function-type.
+    >       
+    >       Obsoleted:
+    >       - identity of-minimize-agg-bandwidth-consumption
+    >       - identity of-minimize-load-most-loaded-link
+    >       - identity of-minimize-cost-path-set";
     >     reference
     >       "RFC XXXX: Updated Common YANG Data Types for Traffic
     >       Engineering";
     >   }
     >   // RFC Editor: replace XXXX with actual RFC number, update date
     >   // information and remove this note
-    > 
-    545a564,597
+    545a579,612
     >   // NOTE: The typedef bandwidth-scientific-notation below has been
     >   // added in this module revision
     >   // RFC Editor: remove the note above and this note
@@ -60,20 +84,71 @@
     >       Languages - C.";
     >   }
     > 
-    982a1035,1046
+    606a674,681
+    >   // NOTE: The base identity lsp-provisioning-error-reason has been
+    >   // added in this module revision
+    >   // RFC Editor: remove the note above and this note
+    >   identity lsp-provisioning-error-reason {
+    >     description
+    >       "Base identity for LSP provisioning errors.";
+    >   }
+    > 
+    982a1058,1073
     >   // NOTE: The identity association-type-diversity below has been
     >   // added in this module revision
     >   // RFC Editor: remove the note above and this note
     >   identity association-type-diversity {
     >     base association-type;
     >     description
-    >       "Association Type diversity used to associate LSPs whose paths
-    >        are to be diverse from each other.";
+    >       "Association Type diversity used to associate LSPs whose 
+    >       paths are to be diverse from each other.";
     >     reference
     >       "RFC8800";
     >   }
     > 
-    1216a1281,1292
+    >   // NOTE: The description of the base identity 
+    >   // objective-function-type has been updated 
+    >   // in this module revision
+    >   // RFC Editor: remove the note above and this note
+    985c1076
+    <       "Base objective function type.";
+    ---
+    >       "Base identity for path objective function type.";
+    1015a1107,1109
+    >   // NOTE: The identity of-minimize-agg-bandwidth-consumption
+    >   // below has been obsoleted in this module revision
+    >   // RFC Editor: remove the note above and this note
+    1017a1112
+    >     status obsolete;
+    1020c1115
+    <        consumption.";
+    ---
+    >       consumption.";
+    1023c1118
+    <        Computation Element Communication Protocol (PCEP)";
+    ---
+    >       Computation Element Communication Protocol (PCEP)";
+    1025a1121,1123
+    >   // NOTE: The identity of-minimize-load-most-loaded-link
+    >   // below has been obsoleted in this module revision
+    >   // RFC Editor: remove the note above and this note
+    1027a1126
+    >     status obsolete;
+    1030c1129
+    <        is carrying the highest load.";
+    ---
+    >       is carrying the highest load.";
+    1033c1132
+    <        Computation Element Communication Protocol (PCEP)";
+    ---
+    >       Computation Element Communication Protocol (PCEP)";
+    1035a1135,1137
+    >   // NOTE: The identity of-minimize-cost-path-set
+    >   // below has been obsoleted in this module revision
+    >   // RFC Editor: remove the note above and this note
+    1037a1140
+    >     status obsolete;
+    1216a1320,1331
     >   // NOTE: The identity tunnel-admin-auto below has been
     >   // added in this module revision
     >   // RFC Editor: remove the note above and this note
@@ -81,12 +156,12 @@
     >     base tunnel-admin-state-type;
     >     description
     >       "Tunnel administrative auto state. The administrative status
-    >        in state datastore transitions to 'tunnel-admin-up' when the
-    >        tunnel used by the client layer, and to 'tunnel-admin-down'
-    >        when it is not used by the client layer.";
+    >       in state datastore transitions to 'tunnel-admin-up' when the
+    >       tunnel used by the client layer, and to 'tunnel-admin-down'
+    >       when it is not used by the client layer.";
     >   }
     > 
-    2110a2187,2391
+    2110a2226,2569
     >   // NOTE: The base identity path-computation-error-reason and 
     >   // its derived identities below have been
     >   // added in this module revision
@@ -96,156 +171,157 @@
     >       "Base identity for path computation error reasons.";
     >   }
     > 
-    >   identity path-computation-error-no-topology {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because there is no topology
-    >        with the provided topology-identifier.";
-    >   }
+    >     identity path-computation-error-no-topology {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because there is no topology
+    >         with the provided topology-identifier.";
+    >     }
     > 
-    >   identity path-computation-error-no-dependent-server {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because one or more dependent
-    >        path computation servers are unavailable.
-    >        The dependent path computation server could be
-    >        a Backward-Recursive Path Computation (BRPC) downstream
-    >        PCE or a child PCE.";
-    >     reference
-    >       "RFC5441, RFC8685";
-    >   }
+    >     identity path-computation-error-no-dependent-server {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because one or more dependent
+    >         path computation servers are unavailable.
+    >         The dependent path computation server could be
+    >         a Backward-Recursive Path Computation (BRPC) downstream
+    >         PCE or a child PCE.";
+    >       reference
+    >         "RFC5441, RFC8685";
+    >     }
     > 
-    >   identity path-computation-error-pce-unavailable {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because PCE is not available.";
-    >     reference
-    >       "RFC5440";
-    >   }
+    >     identity path-computation-error-pce-unavailable {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because PCE is not available.";
+    >       reference
+    >         "RFC5440";
+    >     }
     > 
-    >   identity path-computation-error-no-inclusion-hop {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because there is no
-    >        node or link provided by one or more inclusion hops.";
-    >     reference
-    >       "RFC8685";
-    >   }
+    >     identity path-computation-error-no-inclusion-hop {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because there is no
+    >         node or link provided by one or more inclusion hops.";
+    >       reference
+    >         "RFC8685";
+    >     }
     > 
-    >   identity path-computation-error-destination-unknown-in-domain {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because the destination node is
-    >        unknown in indicated destination domain.";
-    >     reference
-    >       "RFC8685";
-    >   }
+    >     identity path-computation-error-destination-unknown-in-domain {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because the destination node is
+    >         unknown in indicated destination domain.";
+    >       reference
+    >         "RFC8685";
+    >     }
     > 
-    >   identity path-computation-error-no-resource {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because there is no
-    >        available resource in one or more domains.";
-    >     reference
-    >       "RFC8685";
-    >   }
+    >     identity path-computation-error-no-resource {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because there is no
+    >         available resource in one or more domains.";
+    >       reference
+    >         "RFC8685";
+    >     }
     > 
-    >   identity path-computation-error-child-pce-unresponsive {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because child PCE is not
-    >        responsive.";
-    >     reference
-    >       "RFC8685";
-    >   }
+    >     identity path-computation-error-child-pce-unresponsive {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because child PCE is not
+    >         responsive.";
+    >       reference
+    >         "RFC8685";
+    >     }
     > 
-    >   identity path-computation-error-destination-domain-unknown {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because the destination domain
-    >        was unknown.";
-    >     reference
-    >       "RFC8685";
-    >   }
+    >     identity path-computation-error-destination-domain-unknown {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because the destination domain
+    >         was unknown.";
+    >       reference
+    >         "RFC8685";
+    >     }
     > 
-    >   identity path-computation-error-p2mp {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because of P2MP reachability
-    >        problem.";
-    >     reference
-    >       "RFC8306";
-    >   }
+    >     identity path-computation-error-p2mp {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because of P2MP reachability
+    >         problem.";
+    >       reference
+    >         "RFC8306";
+    >     }
     > 
-    >   identity path-computation-error-no-gco-migration {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because of no Global Concurrent
-    >        Optimization (GCO) migration path found.";
-    >     reference
-    >       "RFC5557";
-    >   }
+    >     identity path-computation-error-no-gco-migration {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because of no Global Concurrent
+    >         Optimization (GCO) migration path found.";
+    >       reference
+    >         "RFC5557";
+    >     }
     > 
-    >   identity path-computation-error-no-gco-solution {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because of no GCO solution
-    >        found.";
-    >     reference
-    >       "RFC5557";
-    >   }
+    >     identity path-computation-error-no-gco-solution {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because of no GCO solution
+    >         found.";
+    >       reference
+    >         "RFC5557";
+    >     }
     > 
-    >   identity path-computation-error-path-not-found {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation no path found error reason.";
-    >     reference
-    >       "RFC5440";
-    >   }
+    >     identity path-computation-error-path-not-found {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation no path found error reason.";
+    >       reference
+    >         "RFC5440";
+    >     }
     > 
-    >   identity path-computation-error-pks-expansion {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because of Path-Key Subobject
-    >        (PKS)  expansion failure.";
-    >     reference
-    >       "RFC5520";
-    >   }
+    >     identity path-computation-error-pks-expansion {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because of Path-Key Subobject
+    >         (PKS)  expansion failure.";
+    >       reference
+    >         "RFC5520";
+    >     }
     > 
-    >   identity path-computation-error-brpc-chain-unavailable {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because PCE BRPC chain
-    >        unavailable.";
-    >     reference
-    >       "RFC5441";
-    >   }
+    >     identity path-computation-error-brpc-chain-unavailable {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because PCE BRPC chain
+    >         unavailable.";
+    >       reference
+    >         "RFC5441";
+    >     }
     > 
-    >   identity path-computation-error-source-unknown {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because source node is unknown.";
-    >     reference
-    >       "RFC5440";
-    >   }
+    >     identity path-computation-error-source-unknown {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because source node is 
+    >         unknown.";
+    >       reference
+    >         "RFC5440";
+    >     }
     > 
-    >   identity path-computation-error-destination-unknown {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because destination node is
-    >        unknown.";
-    >     reference
-    >       "RFC5440";
-    >   }
+    >     identity path-computation-error-destination-unknown {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because destination node is
+    >         unknown.";
+    >       reference
+    >         "RFC5440";
+    >     }
     > 
-    >   identity path-computation-error-no-server {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because path computation
-    >        server is unavailable.";
-    >     reference
-    >       "RFC5440";
-    >   }
+    >     identity path-computation-error-no-server {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because path computation
+    >         server is unavailable.";
+    >       reference
+    >         "RFC5440";
+    >     }
     > 
     >   // NOTE: The base identity tunnel-actions-type and 
     >   // its derived identities below have been
@@ -254,12 +330,6 @@
     >   identity tunnel-actions-type {
     >     description
     >       "TE tunnel actions type.";
-    >   }
-    > 
-    >   identity tunnel-action-reoptimize {
-    >     base tunnel-actions-type;
-    >     description
-    >       "Reoptimize tunnel action type.";
     >   }
     > 
     >   // NOTE: The base identity protocol-origin-type and 
@@ -271,30 +341,175 @@
     >       "Base identity for protocol origin type.";
     >   }
     > 
-    >   identity protocol-origin-api {
-    >     base protocol-origin-type;
-    >     description
-    >       "Protocol origin is via Application Programmable Interface
-    >        (API).";
-    >   }
-    > 
-    >   identity protocol-origin-pcep {
-    >     base protocol-origin-type;
-    >     description
-    >       "Protocol origin is Path Computation Engine Protocol (PCEP).";
-    >     reference "RFC5440";
-    >   }
-    > 
-    >   identity protocol-origin-bgp {
-    >     base protocol-origin-type;
-    >     description
-    >       "Protocol origin is Border Gateway Protocol (BGP).";
-    >     reference "RFC5512";
-    >   }
-    > 
-    3376a3658,3684
+    >     identity protocol-origin-api {
+    >       base protocol-origin-type;
+    >       description
+    >         "Protocol origin is via Application Programmable Interface
+    >         (API).";
     >     }
+    > 
+    >     identity protocol-origin-pcep {
+    >       base protocol-origin-type;
+    >       description
+    >         "Protocol origin is Path Computation Engine Protocol 
+    >         (PCEP).";
+    >       reference "RFC5440";
+    >     }
+    > 
+    >     identity protocol-origin-bgp {
+    >       base protocol-origin-type;
+    >       description
+    >         "Protocol origin is Border Gateway Protocol (BGP).";
+    >       reference "RFC5512";
+    >     }
+    > 
+    >   // NOTE: The base identity svec-objective-function-type and 
+    >   // its derived identities below have been
+    >   // added in this module revision
+    >   // RFC Editor: remove the note above and this note
+    >   identity svec-objective-function-type {
+    >     description
+    >       "Base identity for SVEC objective function type.";
+    >     reference
+    >       "RFC5541: Encoding of Objective Functions in the Path
+    >        Computation Element Communication Protocol (PCEP).";
     >   }
+    > 
+    >     identity svec-of-minimize-agg-bandwidth-consumption {
+    >       base svec-objective-function-type;
+    >       description
+    >         "Objective function for minimizing aggregate bandwidth 
+    >         consumption (MBC).";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    >     identity svec-of-minimize-load-most-loaded-link {
+    >       base svec-objective-function-type;
+    >       description
+    >         "Objective function for minimizing the load on the link that 
+    >         is carrying the highest load (MLL).";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    >     identity svec-of-minimize-cost-path-set {
+    >       base svec-objective-function-type;
+    >       description
+    >         "Objective function for minimizing the cost on a path set 
+    >         (MCC).";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    >     identity svec-of-minimize-common-transit-domain {
+    >       base svec-objective-function-type;
+    >       description
+    >         "Objective function for minimizing the number of common 
+    >         transit domains (MCTD).";
+    >       reference
+    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture.";
+    >     }
+    > 
+    >     identity svec-of-minimize-shared-link {
+    >       base svec-objective-function-type;
+    >       description
+    >         "Objective function for minimizing the number of shared 
+    >         links (MSL).";
+    >       reference
+    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture.";
+    >     }
+    > 
+    >     identity svec-of-minimize-shared-srlg {
+    >       base svec-objective-function-type;
+    >       description
+    >         "Objective function for minimizing the number of shared 
+    >         Shared Risk Link Groups (SRLG) (MSS).";
+    >       reference
+    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture.";
+    >     }
+    > 
+    >     identity svec-of-minimize-shared-nodes {
+    >       base svec-objective-function-type;
+    >       description
+    >         "Objective function for minimizing the number of shared 
+    >         nodes (MSN).";
+    >       reference
+    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture.";
+    >     }
+    > 
+    >   // NOTE: The base identity svec-metric-type and 
+    >   // its derived identities below have been
+    >   // added in this module revision
+    >   // RFC Editor: remove the note above and this note
+    >   identity svec-metric-type {
+    >     description
+    >       "Base identity for SVEC metric type.";
+    >     reference
+    >       "RFC5541: Encoding of Objective Functions in the Path
+    >        Computation Element Communication Protocol (PCEP).";
+    >   }
+    > 
+    >     identity svec-metric-cumul-te {
+    >       base svec-metric-type;
+    >       description
+    >         "Cumulative TE cost.";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    >     identity svec-metric-cumul-igp {
+    >       base svec-metric-type;
+    >       description
+    >         "Cumulative IGP cost.";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    >     identity svec-metric-cumul-hop {
+    >       base svec-metric-type;
+    >       description
+    >         "Cumulative Hop path metric.";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    >     identity svec-metric-aggregate-bandwidth-consumption {
+    >       base svec-metric-type;
+    >       description
+    >         "Aggregate bandwidth consumption.";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    >     identity svec-metric-load-of-the-most-loaded-link {
+    >       base svec-metric-type;
+    >       description
+    >         "Load of the most loaded link.";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    3379c3838,3865
+    < }
+    \ No newline at end of file
+    ---
     > 
     >   // NOTE: The grouping encoding-and-switching-type below has been
     >   // added in this module revision
@@ -320,3 +535,6 @@
     >         "LSP switching type.";
     >       reference
     >         "RFC3945";
+    >     }
+    >   }
+    > }

--- a/drafts/te-types-update/model-diff.txt
+++ b/drafts/te-types-update/model-diff.txt
@@ -1,31 +1,55 @@
+30c30
+<                <mailto:tsaad@juniper.net>
+---
+>                <mailto:tsaad.net@gmail.com>
 55c55
 <      Copyright (c) 2020 IETF Trust and the persons identified as
 ---
 >      Copyright (c) 2022 IETF Trust and the persons identified as
-65c65
-<      This version of this YANG module is part of RFC 8776; see the
+60c60
+<      the license terms contained in, the Simplified BSD License set
 ---
->      This version of this YANG module is part of RFC XXXX; see the
-67a68,85
->   revision 2022-09-09 {
+>      the license terms contained in, the Revised BSD License set
+65,66c65,99
+<      This version of this YANG module is part of RFC 8776; see the
+<      RFC itself for full legal notices.";
+---
+>      This version of this YANG module is part of RFC XXXX
+>      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+>      for full legal notices.";
+> 
+>   revision 2022-10-21 {
 >     description
 >       "Added:
 >       - typedef bandwidth-scientific-notation;
+>       - base identity lsp-provisioning-error-reason;
 >       - identity association-type-diversity;
 >       - identity tunnel-admin-auto;
 >       - base identity path-computation-error-reason and
 >         its derived identities;
+>       - base identity tunnel-actions-type and its derived 
+>         identities;
 >       - base identity protocol-origin-type and
 >         its derived identities;
->       - grouping encoding-and-switching-type.";
+>       - base identity svec-objective-function-type and its derived
+>         identities;
+>       - base identity svec-metric-type and its derived identities;
+>       - grouping encoding-and-switching-type.
+>       
+>       Updated:
+>       - description of the base identity objective-function-type.
+>       
+>       Obsoleted:
+>       - identity of-minimize-agg-bandwidth-consumption
+>       - identity of-minimize-load-most-loaded-link
+>       - identity of-minimize-cost-path-set";
 >     reference
 >       "RFC XXXX: Updated Common YANG Data Types for Traffic
 >       Engineering";
 >   }
 >   // RFC Editor: replace XXXX with actual RFC number, update date
 >   // information and remove this note
-> 
-545a564,597
+545a579,612
 >   // NOTE: The typedef bandwidth-scientific-notation below has been
 >   // added in this module revision
 >   // RFC Editor: remove the note above and this note
@@ -60,20 +84,71 @@
 >       Languages - C.";
 >   }
 > 
-982a1035,1046
+606a674,681
+>   // NOTE: The base identity lsp-provisioning-error-reason has been
+>   // added in this module revision
+>   // RFC Editor: remove the note above and this note
+>   identity lsp-provisioning-error-reason {
+>     description
+>       "Base identity for LSP provisioning errors.";
+>   }
+> 
+982a1058,1073
 >   // NOTE: The identity association-type-diversity below has been
 >   // added in this module revision
 >   // RFC Editor: remove the note above and this note
 >   identity association-type-diversity {
 >     base association-type;
 >     description
->       "Association Type diversity used to associate LSPs whose paths
->        are to be diverse from each other.";
+>       "Association Type diversity used to associate LSPs whose 
+>       paths are to be diverse from each other.";
 >     reference
 >       "RFC8800";
 >   }
 > 
-1216a1281,1292
+>   // NOTE: The description of the base identity 
+>   // objective-function-type has been updated 
+>   // in this module revision
+>   // RFC Editor: remove the note above and this note
+985c1076
+<       "Base objective function type.";
+---
+>       "Base identity for path objective function type.";
+1015a1107,1109
+>   // NOTE: The identity of-minimize-agg-bandwidth-consumption
+>   // below has been obsoleted in this module revision
+>   // RFC Editor: remove the note above and this note
+1017a1112
+>     status obsolete;
+1020c1115
+<        consumption.";
+---
+>       consumption.";
+1023c1118
+<        Computation Element Communication Protocol (PCEP)";
+---
+>       Computation Element Communication Protocol (PCEP)";
+1025a1121,1123
+>   // NOTE: The identity of-minimize-load-most-loaded-link
+>   // below has been obsoleted in this module revision
+>   // RFC Editor: remove the note above and this note
+1027a1126
+>     status obsolete;
+1030c1129
+<        is carrying the highest load.";
+---
+>       is carrying the highest load.";
+1033c1132
+<        Computation Element Communication Protocol (PCEP)";
+---
+>       Computation Element Communication Protocol (PCEP)";
+1035a1135,1137
+>   // NOTE: The identity of-minimize-cost-path-set
+>   // below has been obsoleted in this module revision
+>   // RFC Editor: remove the note above and this note
+1037a1140
+>     status obsolete;
+1216a1320,1331
 >   // NOTE: The identity tunnel-admin-auto below has been
 >   // added in this module revision
 >   // RFC Editor: remove the note above and this note
@@ -81,12 +156,12 @@
 >     base tunnel-admin-state-type;
 >     description
 >       "Tunnel administrative auto state. The administrative status
->        in state datastore transitions to 'tunnel-admin-up' when the
->        tunnel used by the client layer, and to 'tunnel-admin-down'
->        when it is not used by the client layer.";
+>       in state datastore transitions to 'tunnel-admin-up' when the
+>       tunnel used by the client layer, and to 'tunnel-admin-down'
+>       when it is not used by the client layer.";
 >   }
 > 
-2110a2187,2391
+2110a2226,2569
 >   // NOTE: The base identity path-computation-error-reason and 
 >   // its derived identities below have been
 >   // added in this module revision
@@ -96,156 +171,157 @@
 >       "Base identity for path computation error reasons.";
 >   }
 > 
->   identity path-computation-error-no-topology {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because there is no topology
->        with the provided topology-identifier.";
->   }
+>     identity path-computation-error-no-topology {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because there is no topology
+>         with the provided topology-identifier.";
+>     }
 > 
->   identity path-computation-error-no-dependent-server {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because one or more dependent
->        path computation servers are unavailable.
->        The dependent path computation server could be
->        a Backward-Recursive Path Computation (BRPC) downstream
->        PCE or a child PCE.";
->     reference
->       "RFC5441, RFC8685";
->   }
+>     identity path-computation-error-no-dependent-server {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because one or more dependent
+>         path computation servers are unavailable.
+>         The dependent path computation server could be
+>         a Backward-Recursive Path Computation (BRPC) downstream
+>         PCE or a child PCE.";
+>       reference
+>         "RFC5441, RFC8685";
+>     }
 > 
->   identity path-computation-error-pce-unavailable {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because PCE is not available.";
->     reference
->       "RFC5440";
->   }
+>     identity path-computation-error-pce-unavailable {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because PCE is not available.";
+>       reference
+>         "RFC5440";
+>     }
 > 
->   identity path-computation-error-no-inclusion-hop {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because there is no
->        node or link provided by one or more inclusion hops.";
->     reference
->       "RFC8685";
->   }
+>     identity path-computation-error-no-inclusion-hop {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because there is no
+>         node or link provided by one or more inclusion hops.";
+>       reference
+>         "RFC8685";
+>     }
 > 
->   identity path-computation-error-destination-unknown-in-domain {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because the destination node is
->        unknown in indicated destination domain.";
->     reference
->       "RFC8685";
->   }
+>     identity path-computation-error-destination-unknown-in-domain {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because the destination node is
+>         unknown in indicated destination domain.";
+>       reference
+>         "RFC8685";
+>     }
 > 
->   identity path-computation-error-no-resource {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because there is no
->        available resource in one or more domains.";
->     reference
->       "RFC8685";
->   }
+>     identity path-computation-error-no-resource {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because there is no
+>         available resource in one or more domains.";
+>       reference
+>         "RFC8685";
+>     }
 > 
->   identity path-computation-error-child-pce-unresponsive {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because child PCE is not
->        responsive.";
->     reference
->       "RFC8685";
->   }
+>     identity path-computation-error-child-pce-unresponsive {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because child PCE is not
+>         responsive.";
+>       reference
+>         "RFC8685";
+>     }
 > 
->   identity path-computation-error-destination-domain-unknown {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because the destination domain
->        was unknown.";
->     reference
->       "RFC8685";
->   }
+>     identity path-computation-error-destination-domain-unknown {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because the destination domain
+>         was unknown.";
+>       reference
+>         "RFC8685";
+>     }
 > 
->   identity path-computation-error-p2mp {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because of P2MP reachability
->        problem.";
->     reference
->       "RFC8306";
->   }
+>     identity path-computation-error-p2mp {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because of P2MP reachability
+>         problem.";
+>       reference
+>         "RFC8306";
+>     }
 > 
->   identity path-computation-error-no-gco-migration {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because of no Global Concurrent
->        Optimization (GCO) migration path found.";
->     reference
->       "RFC5557";
->   }
+>     identity path-computation-error-no-gco-migration {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because of no Global Concurrent
+>         Optimization (GCO) migration path found.";
+>       reference
+>         "RFC5557";
+>     }
 > 
->   identity path-computation-error-no-gco-solution {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because of no GCO solution
->        found.";
->     reference
->       "RFC5557";
->   }
+>     identity path-computation-error-no-gco-solution {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because of no GCO solution
+>         found.";
+>       reference
+>         "RFC5557";
+>     }
 > 
->   identity path-computation-error-path-not-found {
->     base path-computation-error-reason;
->     description
->       "Path computation no path found error reason.";
->     reference
->       "RFC5440";
->   }
+>     identity path-computation-error-path-not-found {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation no path found error reason.";
+>       reference
+>         "RFC5440";
+>     }
 > 
->   identity path-computation-error-pks-expansion {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because of Path-Key Subobject
->        (PKS)  expansion failure.";
->     reference
->       "RFC5520";
->   }
+>     identity path-computation-error-pks-expansion {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because of Path-Key Subobject
+>         (PKS)  expansion failure.";
+>       reference
+>         "RFC5520";
+>     }
 > 
->   identity path-computation-error-brpc-chain-unavailable {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because PCE BRPC chain
->        unavailable.";
->     reference
->       "RFC5441";
->   }
+>     identity path-computation-error-brpc-chain-unavailable {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because PCE BRPC chain
+>         unavailable.";
+>       reference
+>         "RFC5441";
+>     }
 > 
->   identity path-computation-error-source-unknown {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because source node is unknown.";
->     reference
->       "RFC5440";
->   }
+>     identity path-computation-error-source-unknown {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because source node is 
+>         unknown.";
+>       reference
+>         "RFC5440";
+>     }
 > 
->   identity path-computation-error-destination-unknown {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because destination node is
->        unknown.";
->     reference
->       "RFC5440";
->   }
+>     identity path-computation-error-destination-unknown {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because destination node is
+>         unknown.";
+>       reference
+>         "RFC5440";
+>     }
 > 
->   identity path-computation-error-no-server {
->     base path-computation-error-reason;
->     description
->       "Path computation has failed because path computation
->        server is unavailable.";
->     reference
->       "RFC5440";
->   }
+>     identity path-computation-error-no-server {
+>       base path-computation-error-reason;
+>       description
+>         "Path computation has failed because path computation
+>         server is unavailable.";
+>       reference
+>         "RFC5440";
+>     }
 > 
 >   // NOTE: The base identity tunnel-actions-type and 
 >   // its derived identities below have been
@@ -254,12 +330,6 @@
 >   identity tunnel-actions-type {
 >     description
 >       "TE tunnel actions type.";
->   }
-> 
->   identity tunnel-action-reoptimize {
->     base tunnel-actions-type;
->     description
->       "Reoptimize tunnel action type.";
 >   }
 > 
 >   // NOTE: The base identity protocol-origin-type and 
@@ -271,30 +341,175 @@
 >       "Base identity for protocol origin type.";
 >   }
 > 
->   identity protocol-origin-api {
->     base protocol-origin-type;
->     description
->       "Protocol origin is via Application Programmable Interface
->        (API).";
->   }
-> 
->   identity protocol-origin-pcep {
->     base protocol-origin-type;
->     description
->       "Protocol origin is Path Computation Engine Protocol (PCEP).";
->     reference "RFC5440";
->   }
-> 
->   identity protocol-origin-bgp {
->     base protocol-origin-type;
->     description
->       "Protocol origin is Border Gateway Protocol (BGP).";
->     reference "RFC5512";
->   }
-> 
-3376a3658,3684
+>     identity protocol-origin-api {
+>       base protocol-origin-type;
+>       description
+>         "Protocol origin is via Application Programmable Interface
+>         (API).";
 >     }
+> 
+>     identity protocol-origin-pcep {
+>       base protocol-origin-type;
+>       description
+>         "Protocol origin is Path Computation Engine Protocol 
+>         (PCEP).";
+>       reference "RFC5440";
+>     }
+> 
+>     identity protocol-origin-bgp {
+>       base protocol-origin-type;
+>       description
+>         "Protocol origin is Border Gateway Protocol (BGP).";
+>       reference "RFC5512";
+>     }
+> 
+>   // NOTE: The base identity svec-objective-function-type and 
+>   // its derived identities below have been
+>   // added in this module revision
+>   // RFC Editor: remove the note above and this note
+>   identity svec-objective-function-type {
+>     description
+>       "Base identity for SVEC objective function type.";
+>     reference
+>       "RFC5541: Encoding of Objective Functions in the Path
+>        Computation Element Communication Protocol (PCEP).";
 >   }
+> 
+>     identity svec-of-minimize-agg-bandwidth-consumption {
+>       base svec-objective-function-type;
+>       description
+>         "Objective function for minimizing aggregate bandwidth 
+>         consumption (MBC).";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+>     identity svec-of-minimize-load-most-loaded-link {
+>       base svec-objective-function-type;
+>       description
+>         "Objective function for minimizing the load on the link that 
+>         is carrying the highest load (MLL).";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+>     identity svec-of-minimize-cost-path-set {
+>       base svec-objective-function-type;
+>       description
+>         "Objective function for minimizing the cost on a path set 
+>         (MCC).";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+>     identity svec-of-minimize-common-transit-domain {
+>       base svec-objective-function-type;
+>       description
+>         "Objective function for minimizing the number of common 
+>         transit domains (MCTD).";
+>       reference
+>         "RFC8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture.";
+>     }
+> 
+>     identity svec-of-minimize-shared-link {
+>       base svec-objective-function-type;
+>       description
+>         "Objective function for minimizing the number of shared 
+>         links (MSL).";
+>       reference
+>         "RFC8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture.";
+>     }
+> 
+>     identity svec-of-minimize-shared-srlg {
+>       base svec-objective-function-type;
+>       description
+>         "Objective function for minimizing the number of shared 
+>         Shared Risk Link Groups (SRLG) (MSS).";
+>       reference
+>         "RFC8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture.";
+>     }
+> 
+>     identity svec-of-minimize-shared-nodes {
+>       base svec-objective-function-type;
+>       description
+>         "Objective function for minimizing the number of shared 
+>         nodes (MSN).";
+>       reference
+>         "RFC8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture.";
+>     }
+> 
+>   // NOTE: The base identity svec-metric-type and 
+>   // its derived identities below have been
+>   // added in this module revision
+>   // RFC Editor: remove the note above and this note
+>   identity svec-metric-type {
+>     description
+>       "Base identity for SVEC metric type.";
+>     reference
+>       "RFC5541: Encoding of Objective Functions in the Path
+>        Computation Element Communication Protocol (PCEP).";
+>   }
+> 
+>     identity svec-metric-cumul-te {
+>       base svec-metric-type;
+>       description
+>         "Cumulative TE cost.";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+>     identity svec-metric-cumul-igp {
+>       base svec-metric-type;
+>       description
+>         "Cumulative IGP cost.";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+>     identity svec-metric-cumul-hop {
+>       base svec-metric-type;
+>       description
+>         "Cumulative Hop path metric.";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+>     identity svec-metric-aggregate-bandwidth-consumption {
+>       base svec-metric-type;
+>       description
+>         "Aggregate bandwidth consumption.";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+>     identity svec-metric-load-of-the-most-loaded-link {
+>       base svec-metric-type;
+>       description
+>         "Load of the most loaded link.";
+>       reference
+>         "RFC5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP).";
+>     }
+> 
+3379c3838,3865
+< }
+\ No newline at end of file
+---
 > 
 >   // NOTE: The grouping encoding-and-switching-type below has been
 >   // added in this module revision
@@ -320,3 +535,6 @@
 >         "LSP switching type.";
 >       reference
 >         "RFC3945";
+>     }
+>   }
+> }

--- a/drafts/te-types-update/model-updates.txt
+++ b/drafts/te-types-update/model-updates.txt
@@ -1,31 +1,55 @@
+    30c30
+    <                <mailto:tsaad@juniper.net>
+    ---
+    >                <mailto:tsaad.net@gmail.com>
     55c55
     <      Copyright (c) 2020 IETF Trust and the persons identified as
     ---
     >      Copyright (c) 2022 IETF Trust and the persons identified as
-    65c65
-    <      This version of this YANG module is part of RFC 8776; see the
+    60c60
+    <      the license terms contained in, the Simplified BSD License set
     ---
-    >      This version of this YANG module is part of RFC XXXX; see the
-    67a68,85
-    >   revision 2022-09-09 {
+    >      the license terms contained in, the Revised BSD License set
+    65,66c65,99
+    <      This version of this YANG module is part of RFC 8776; see the
+    <      RFC itself for full legal notices.";
+    ---
+    >      This version of this YANG module is part of RFC XXXX
+    >      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+    >      for full legal notices.";
+    > 
+    >   revision 2022-10-21 {
     >     description
     >       "Added:
     >       - typedef bandwidth-scientific-notation;
+    >       - base identity lsp-provisioning-error-reason;
     >       - identity association-type-diversity;
     >       - identity tunnel-admin-auto;
     >       - base identity path-computation-error-reason and
     >         its derived identities;
+    >       - base identity tunnel-actions-type and its derived 
+    >         identities;
     >       - base identity protocol-origin-type and
     >         its derived identities;
-    >       - grouping encoding-and-switching-type.";
+    >       - base identity svec-objective-function-type and its derived
+    >         identities;
+    >       - base identity svec-metric-type and its derived identities;
+    >       - grouping encoding-and-switching-type.
+    >       
+    >       Updated:
+    >       - description of the base identity objective-function-type.
+    >       
+    >       Obsoleted:
+    >       - identity of-minimize-agg-bandwidth-consumption
+    >       - identity of-minimize-load-most-loaded-link
+    >       - identity of-minimize-cost-path-set";
     >     reference
     >       "RFC XXXX: Updated Common YANG Data Types for Traffic
     >       Engineering";
     >   }
     >   // RFC Editor: replace XXXX with actual RFC number, update date
     >   // information and remove this note
-    > 
-    545a564,597
+    545a579,612
     >   // NOTE: The typedef bandwidth-scientific-notation below has been
     >   // added in this module revision
     >   // RFC Editor: remove the note above and this note
@@ -60,20 +84,71 @@
     >       Languages - C.";
     >   }
     > 
-    982a1035,1046
+    606a674,681
+    >   // NOTE: The base identity lsp-provisioning-error-reason has been
+    >   // added in this module revision
+    >   // RFC Editor: remove the note above and this note
+    >   identity lsp-provisioning-error-reason {
+    >     description
+    >       "Base identity for LSP provisioning errors.";
+    >   }
+    > 
+    982a1058,1073
     >   // NOTE: The identity association-type-diversity below has been
     >   // added in this module revision
     >   // RFC Editor: remove the note above and this note
     >   identity association-type-diversity {
     >     base association-type;
     >     description
-    >       "Association Type diversity used to associate LSPs whose paths
-    >        are to be diverse from each other.";
+    >       "Association Type diversity used to associate LSPs whose 
+    >       paths are to be diverse from each other.";
     >     reference
     >       "RFC8800";
     >   }
     > 
-    1216a1281,1292
+    >   // NOTE: The description of the base identity 
+    >   // objective-function-type has been updated 
+    >   // in this module revision
+    >   // RFC Editor: remove the note above and this note
+    985c1076
+    <       "Base objective function type.";
+    ---
+    >       "Base identity for path objective function type.";
+    1015a1107,1109
+    >   // NOTE: The identity of-minimize-agg-bandwidth-consumption
+    >   // below has been obsoleted in this module revision
+    >   // RFC Editor: remove the note above and this note
+    1017a1112
+    >     status obsolete;
+    1020c1115
+    <        consumption.";
+    ---
+    >       consumption.";
+    1023c1118
+    <        Computation Element Communication Protocol (PCEP)";
+    ---
+    >       Computation Element Communication Protocol (PCEP)";
+    1025a1121,1123
+    >   // NOTE: The identity of-minimize-load-most-loaded-link
+    >   // below has been obsoleted in this module revision
+    >   // RFC Editor: remove the note above and this note
+    1027a1126
+    >     status obsolete;
+    1030c1129
+    <        is carrying the highest load.";
+    ---
+    >       is carrying the highest load.";
+    1033c1132
+    <        Computation Element Communication Protocol (PCEP)";
+    ---
+    >       Computation Element Communication Protocol (PCEP)";
+    1035a1135,1137
+    >   // NOTE: The identity of-minimize-cost-path-set
+    >   // below has been obsoleted in this module revision
+    >   // RFC Editor: remove the note above and this note
+    1037a1140
+    >     status obsolete;
+    1216a1320,1331
     >   // NOTE: The identity tunnel-admin-auto below has been
     >   // added in this module revision
     >   // RFC Editor: remove the note above and this note
@@ -81,12 +156,12 @@
     >     base tunnel-admin-state-type;
     >     description
     >       "Tunnel administrative auto state. The administrative status
-    >        in state datastore transitions to 'tunnel-admin-up' when the
-    >        tunnel used by the client layer, and to 'tunnel-admin-down'
-    >        when it is not used by the client layer.";
+    >       in state datastore transitions to 'tunnel-admin-up' when the
+    >       tunnel used by the client layer, and to 'tunnel-admin-down'
+    >       when it is not used by the client layer.";
     >   }
     > 
-    2110a2187,2391
+    2110a2226,2569
     >   // NOTE: The base identity path-computation-error-reason and 
     >   // its derived identities below have been
     >   // added in this module revision
@@ -96,156 +171,157 @@
     >       "Base identity for path computation error reasons.";
     >   }
     > 
-    >   identity path-computation-error-no-topology {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because there is no topology
-    >        with the provided topology-identifier.";
-    >   }
+    >     identity path-computation-error-no-topology {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because there is no topology
+    >         with the provided topology-identifier.";
+    >     }
     > 
-    >   identity path-computation-error-no-dependent-server {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because one or more dependent
-    >        path computation servers are unavailable.
-    >        The dependent path computation server could be
-    >        a Backward-Recursive Path Computation (BRPC) downstream
-    >        PCE or a child PCE.";
-    >     reference
-    >       "RFC5441, RFC8685";
-    >   }
+    >     identity path-computation-error-no-dependent-server {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because one or more dependent
+    >         path computation servers are unavailable.
+    >         The dependent path computation server could be
+    >         a Backward-Recursive Path Computation (BRPC) downstream
+    >         PCE or a child PCE.";
+    >       reference
+    >         "RFC5441, RFC8685";
+    >     }
     > 
-    >   identity path-computation-error-pce-unavailable {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because PCE is not available.";
-    >     reference
-    >       "RFC5440";
-    >   }
+    >     identity path-computation-error-pce-unavailable {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because PCE is not available.";
+    >       reference
+    >         "RFC5440";
+    >     }
     > 
-    >   identity path-computation-error-no-inclusion-hop {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because there is no
-    >        node or link provided by one or more inclusion hops.";
-    >     reference
-    >       "RFC8685";
-    >   }
+    >     identity path-computation-error-no-inclusion-hop {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because there is no
+    >         node or link provided by one or more inclusion hops.";
+    >       reference
+    >         "RFC8685";
+    >     }
     > 
-    >   identity path-computation-error-destination-unknown-in-domain {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because the destination node is
-    >        unknown in indicated destination domain.";
-    >     reference
-    >       "RFC8685";
-    >   }
+    >     identity path-computation-error-destination-unknown-in-domain {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because the destination node is
+    >         unknown in indicated destination domain.";
+    >       reference
+    >         "RFC8685";
+    >     }
     > 
-    >   identity path-computation-error-no-resource {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because there is no
-    >        available resource in one or more domains.";
-    >     reference
-    >       "RFC8685";
-    >   }
+    >     identity path-computation-error-no-resource {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because there is no
+    >         available resource in one or more domains.";
+    >       reference
+    >         "RFC8685";
+    >     }
     > 
-    >   identity path-computation-error-child-pce-unresponsive {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because child PCE is not
-    >        responsive.";
-    >     reference
-    >       "RFC8685";
-    >   }
+    >     identity path-computation-error-child-pce-unresponsive {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because child PCE is not
+    >         responsive.";
+    >       reference
+    >         "RFC8685";
+    >     }
     > 
-    >   identity path-computation-error-destination-domain-unknown {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because the destination domain
-    >        was unknown.";
-    >     reference
-    >       "RFC8685";
-    >   }
+    >     identity path-computation-error-destination-domain-unknown {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because the destination domain
+    >         was unknown.";
+    >       reference
+    >         "RFC8685";
+    >     }
     > 
-    >   identity path-computation-error-p2mp {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because of P2MP reachability
-    >        problem.";
-    >     reference
-    >       "RFC8306";
-    >   }
+    >     identity path-computation-error-p2mp {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because of P2MP reachability
+    >         problem.";
+    >       reference
+    >         "RFC8306";
+    >     }
     > 
-    >   identity path-computation-error-no-gco-migration {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because of no Global Concurrent
-    >        Optimization (GCO) migration path found.";
-    >     reference
-    >       "RFC5557";
-    >   }
+    >     identity path-computation-error-no-gco-migration {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because of no Global Concurrent
+    >         Optimization (GCO) migration path found.";
+    >       reference
+    >         "RFC5557";
+    >     }
     > 
-    >   identity path-computation-error-no-gco-solution {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because of no GCO solution
-    >        found.";
-    >     reference
-    >       "RFC5557";
-    >   }
+    >     identity path-computation-error-no-gco-solution {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because of no GCO solution
+    >         found.";
+    >       reference
+    >         "RFC5557";
+    >     }
     > 
-    >   identity path-computation-error-path-not-found {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation no path found error reason.";
-    >     reference
-    >       "RFC5440";
-    >   }
+    >     identity path-computation-error-path-not-found {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation no path found error reason.";
+    >       reference
+    >         "RFC5440";
+    >     }
     > 
-    >   identity path-computation-error-pks-expansion {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because of Path-Key Subobject
-    >        (PKS)  expansion failure.";
-    >     reference
-    >       "RFC5520";
-    >   }
+    >     identity path-computation-error-pks-expansion {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because of Path-Key Subobject
+    >         (PKS)  expansion failure.";
+    >       reference
+    >         "RFC5520";
+    >     }
     > 
-    >   identity path-computation-error-brpc-chain-unavailable {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because PCE BRPC chain
-    >        unavailable.";
-    >     reference
-    >       "RFC5441";
-    >   }
+    >     identity path-computation-error-brpc-chain-unavailable {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because PCE BRPC chain
+    >         unavailable.";
+    >       reference
+    >         "RFC5441";
+    >     }
     > 
-    >   identity path-computation-error-source-unknown {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because source node is unknown.";
-    >     reference
-    >       "RFC5440";
-    >   }
+    >     identity path-computation-error-source-unknown {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because source node is 
+    >         unknown.";
+    >       reference
+    >         "RFC5440";
+    >     }
     > 
-    >   identity path-computation-error-destination-unknown {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because destination node is
-    >        unknown.";
-    >     reference
-    >       "RFC5440";
-    >   }
+    >     identity path-computation-error-destination-unknown {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because destination node is
+    >         unknown.";
+    >       reference
+    >         "RFC5440";
+    >     }
     > 
-    >   identity path-computation-error-no-server {
-    >     base path-computation-error-reason;
-    >     description
-    >       "Path computation has failed because path computation
-    >        server is unavailable.";
-    >     reference
-    >       "RFC5440";
-    >   }
+    >     identity path-computation-error-no-server {
+    >       base path-computation-error-reason;
+    >       description
+    >         "Path computation has failed because path computation
+    >         server is unavailable.";
+    >       reference
+    >         "RFC5440";
+    >     }
     > 
     >   // NOTE: The base identity tunnel-actions-type and 
     >   // its derived identities below have been
@@ -254,12 +330,6 @@
     >   identity tunnel-actions-type {
     >     description
     >       "TE tunnel actions type.";
-    >   }
-    > 
-    >   identity tunnel-action-reoptimize {
-    >     base tunnel-actions-type;
-    >     description
-    >       "Reoptimize tunnel action type.";
     >   }
     > 
     >   // NOTE: The base identity protocol-origin-type and 
@@ -271,30 +341,175 @@
     >       "Base identity for protocol origin type.";
     >   }
     > 
-    >   identity protocol-origin-api {
-    >     base protocol-origin-type;
-    >     description
-    >       "Protocol origin is via Application Programmable Interface
-    >        (API).";
-    >   }
-    > 
-    >   identity protocol-origin-pcep {
-    >     base protocol-origin-type;
-    >     description
-    >       "Protocol origin is Path Computation Engine Protocol (PCEP).";
-    >     reference "RFC5440";
-    >   }
-    > 
-    >   identity protocol-origin-bgp {
-    >     base protocol-origin-type;
-    >     description
-    >       "Protocol origin is Border Gateway Protocol (BGP).";
-    >     reference "RFC5512";
-    >   }
-    > 
-    3376a3658,3684
+    >     identity protocol-origin-api {
+    >       base protocol-origin-type;
+    >       description
+    >         "Protocol origin is via Application Programmable Interface
+    >         (API).";
     >     }
+    > 
+    >     identity protocol-origin-pcep {
+    >       base protocol-origin-type;
+    >       description
+    >         "Protocol origin is Path Computation Engine Protocol 
+    >         (PCEP).";
+    >       reference "RFC5440";
+    >     }
+    > 
+    >     identity protocol-origin-bgp {
+    >       base protocol-origin-type;
+    >       description
+    >         "Protocol origin is Border Gateway Protocol (BGP).";
+    >       reference "RFC5512";
+    >     }
+    > 
+    >   // NOTE: The base identity svec-objective-function-type and 
+    >   // its derived identities below have been
+    >   // added in this module revision
+    >   // RFC Editor: remove the note above and this note
+    >   identity svec-objective-function-type {
+    >     description
+    >       "Base identity for SVEC objective function type.";
+    >     reference
+    >       "RFC5541: Encoding of Objective Functions in the Path
+    >        Computation Element Communication Protocol (PCEP).";
     >   }
+    > 
+    >     identity svec-of-minimize-agg-bandwidth-consumption {
+    >       base svec-objective-function-type;
+    >       description
+    >         "Objective function for minimizing aggregate bandwidth 
+    >         consumption (MBC).";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    >     identity svec-of-minimize-load-most-loaded-link {
+    >       base svec-objective-function-type;
+    >       description
+    >         "Objective function for minimizing the load on the link that 
+    >         is carrying the highest load (MLL).";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    >     identity svec-of-minimize-cost-path-set {
+    >       base svec-objective-function-type;
+    >       description
+    >         "Objective function for minimizing the cost on a path set 
+    >         (MCC).";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    >     identity svec-of-minimize-common-transit-domain {
+    >       base svec-objective-function-type;
+    >       description
+    >         "Objective function for minimizing the number of common 
+    >         transit domains (MCTD).";
+    >       reference
+    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture.";
+    >     }
+    > 
+    >     identity svec-of-minimize-shared-link {
+    >       base svec-objective-function-type;
+    >       description
+    >         "Objective function for minimizing the number of shared 
+    >         links (MSL).";
+    >       reference
+    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture.";
+    >     }
+    > 
+    >     identity svec-of-minimize-shared-srlg {
+    >       base svec-objective-function-type;
+    >       description
+    >         "Objective function for minimizing the number of shared 
+    >         Shared Risk Link Groups (SRLG) (MSS).";
+    >       reference
+    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture.";
+    >     }
+    > 
+    >     identity svec-of-minimize-shared-nodes {
+    >       base svec-objective-function-type;
+    >       description
+    >         "Objective function for minimizing the number of shared 
+    >         nodes (MSN).";
+    >       reference
+    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture.";
+    >     }
+    > 
+    >   // NOTE: The base identity svec-metric-type and 
+    >   // its derived identities below have been
+    >   // added in this module revision
+    >   // RFC Editor: remove the note above and this note
+    >   identity svec-metric-type {
+    >     description
+    >       "Base identity for SVEC metric type.";
+    >     reference
+    >       "RFC5541: Encoding of Objective Functions in the Path
+    >        Computation Element Communication Protocol (PCEP).";
+    >   }
+    > 
+    >     identity svec-metric-cumul-te {
+    >       base svec-metric-type;
+    >       description
+    >         "Cumulative TE cost.";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    >     identity svec-metric-cumul-igp {
+    >       base svec-metric-type;
+    >       description
+    >         "Cumulative IGP cost.";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    >     identity svec-metric-cumul-hop {
+    >       base svec-metric-type;
+    >       description
+    >         "Cumulative Hop path metric.";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    >     identity svec-metric-aggregate-bandwidth-consumption {
+    >       base svec-metric-type;
+    >       description
+    >         "Aggregate bandwidth consumption.";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    >     identity svec-metric-load-of-the-most-loaded-link {
+    >       base svec-metric-type;
+    >       description
+    >         "Load of the most loaded link.";
+    >       reference
+    >         "RFC5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP).";
+    >     }
+    > 
+    3379c3838,3865
+    < }
+    \ No newline at end of file
+    ---
     > 
     >   // NOTE: The grouping encoding-and-switching-type below has been
     >   // added in this module revision
@@ -320,3 +535,6 @@
     >         "LSP switching type.";
     >       reference
     >         "RFC3945";
+    >     }
+    >   }
+    > }

--- a/ietf-te-types.yang
+++ b/ietf-te-types.yang
@@ -66,7 +66,7 @@ module ietf-te-types {
      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
      for full legal notices.";
 
-  revision 2022-10-15 {
+  revision 2022-10-21 {
     description
       "Added:
       - typedef bandwidth-scientific-notation;
@@ -667,554 +667,572 @@ module ietf-te-types {
       "Base identity for the RSVP-TE session attributes flags.";
   }
 
-  identity local-protection-desired {
-    base session-attributes-flags;
-    description
-      "Local protection is desired.";
-    reference
-      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
-       Section 4.7.1";
-  }
+    identity local-protection-desired {
+      base session-attributes-flags;
+      description
+        "Local protection is desired.";
+      reference
+        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
+        Section 4.7.1";
+    }
 
-  identity se-style-desired {
-    base session-attributes-flags;
-    description
-      "Shared explicit style, to allow the LSP to be established
-       and share resources with the old LSP.";
-    reference
-      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
-  }
+    identity se-style-desired {
+      base session-attributes-flags;
+      description
+        "Shared explicit style, to allow the LSP to be established
+        and share resources with the old LSP.";
+      reference
+        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
+    }
 
-  identity local-recording-desired {
-    base session-attributes-flags;
-    description
-      "Label recording is desired.";
-    reference
-      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
-       Section 4.7.1";
-  }
+    identity local-recording-desired {
+      base session-attributes-flags;
+      description
+        "Label recording is desired.";
+      reference
+        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
+        Section 4.7.1";
+    }
 
-  identity bandwidth-protection-desired {
-    base session-attributes-flags;
-    description
-      "Requests FRR bandwidth protection on LSRs, if present.";
-    reference
-      "RFC 4090: Fast Reroute Extensions to RSVP-TE for LSP Tunnels";
-  }
+    identity bandwidth-protection-desired {
+      base session-attributes-flags;
+      description
+        "Requests FRR bandwidth protection on LSRs, if present.";
+      reference
+        "RFC 4090: Fast Reroute Extensions to RSVP-TE for LSP 
+        Tunnels";
+    }
 
-  identity node-protection-desired {
-    base session-attributes-flags;
-    description
-      "Requests FRR node protection on LSRs, if present.";
-    reference
-      "RFC 4090: Fast Reroute Extensions to RSVP-TE for LSP Tunnels";
-  }
+    identity node-protection-desired {
+      base session-attributes-flags;
+      description
+        "Requests FRR node protection on LSRs, if present.";
+      reference
+        "RFC 4090: Fast Reroute Extensions to RSVP-TE for LSP 
+        Tunnels";
+    }
 
-  identity path-reevaluation-request {
-    base session-attributes-flags;
-    description
-      "This flag indicates that a path re-evaluation (of the
-       current path in use) is requested.  Note that this does
-       not trigger any LSP reroutes but instead just signals a
-       request to evaluate whether a preferable path exists.";
-    reference
-      "RFC 4736: Reoptimization of Multiprotocol Label Switching
-       (MPLS) Traffic Engineering (TE) Loosely Routed Label Switched
-       Path (LSP)";
-  }
+    identity path-reevaluation-request {
+      base session-attributes-flags;
+      description
+        "This flag indicates that a path re-evaluation (of the
+        current path in use) is requested.  Note that this does
+        not trigger any LSP reroutes but instead just signals a
+        request to evaluate whether a preferable path exists.";
+      reference
+        "RFC 4736: Reoptimization of Multiprotocol Label Switching
+        (MPLS) Traffic Engineering (TE) Loosely Routed Label Switched
+        Path (LSP)";
+    }
 
-  identity soft-preemption-desired {
-    base session-attributes-flags;
-    description
-      "Soft preemption of LSP resources is desired.";
-    reference
-      "RFC 5712: MPLS Traffic Engineering Soft Preemption";
-  }
+    identity soft-preemption-desired {
+      base session-attributes-flags;
+      description
+        "Soft preemption of LSP resources is desired.";
+      reference
+        "RFC 5712: MPLS Traffic Engineering Soft Preemption";
+    }
 
   identity lsp-attributes-flags {
     description
       "Base identity for LSP attributes flags.";
   }
 
-  identity end-to-end-rerouting-desired {
-    base lsp-attributes-flags;
-    description
-      "Indicates end-to-end rerouting behavior for an LSP
-       undergoing establishment.  This MAY also be used to
-       specify the behavior of end-to-end LSP recovery for
-       established LSPs.";
-    reference
-      "RFC 4920: Crankback Signaling Extensions for MPLS and GMPLS
-       RSVP-TE
-       RFC 5420: Encoding of Attributes for MPLS LSP Establishment
-       Using Resource Reservation Protocol Traffic Engineering
-       (RSVP-TE)
-       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-       Route Object (ERO)";
-  }
+    identity end-to-end-rerouting-desired {
+      base lsp-attributes-flags;
+      description
+        "Indicates end-to-end rerouting behavior for an LSP
+        undergoing establishment.  This MAY also be used to
+        specify the behavior of end-to-end LSP recovery for
+        established LSPs.";
+      reference
+        "RFC 4920: Crankback Signaling Extensions for MPLS and GMPLS
+        RSVP-TE
+        RFC 5420: Encoding of Attributes for MPLS LSP Establishment
+        Using Resource Reservation Protocol Traffic Engineering
+        (RSVP-TE)
+        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+        Route Object (ERO)";
+    }
 
-  identity boundary-rerouting-desired {
-    base lsp-attributes-flags;
-    description
-      "Indicates boundary rerouting behavior for an LSP undergoing
-       establishment.  This MAY also be used to specify
-       segment-based LSP recovery through nested crankback for
-       established LSPs.  The boundary Area Border Router (ABR) /
-       Autonomous System Border Router (ASBR) can decide to forward
-       the PathErr message upstream to either an upstream boundary
-       ABR/ASBR or the ingress LSR.  Alternatively, it can try to
-       select another egress boundary LSR.";
-    reference
-      "RFC 4920: Crankback Signaling Extensions for MPLS and GMPLS
-       RSVP-TE
-       RFC 5420: Encoding of Attributes for MPLS LSP Establishment
-       Using Resource Reservation Protocol Traffic Engineering
-       (RSVP-TE)
-       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-       Route Object (ERO)";
-  }
+    identity boundary-rerouting-desired {
+      base lsp-attributes-flags;
+      description
+        "Indicates boundary rerouting behavior for an LSP undergoing
+        establishment.  This MAY also be used to specify
+        segment-based LSP recovery through nested crankback for
+        established LSPs.  The boundary Area Border Router (ABR) /
+        Autonomous System Border Router (ASBR) can decide to forward
+        the PathErr message upstream to either an upstream boundary
+        ABR/ASBR or the ingress LSR.  Alternatively, it can try to
+        select another egress boundary LSR.";
+      reference
+        "RFC 4920: Crankback Signaling Extensions for MPLS and GMPLS
+        RSVP-TE
+        RFC 5420: Encoding of Attributes for MPLS LSP Establishment
+        Using Resource Reservation Protocol Traffic Engineering
+        (RSVP-TE)
+        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+        Route Object (ERO)";
+    }
 
-  identity segment-based-rerouting-desired {
-    base lsp-attributes-flags;
-    description
-      "Indicates segment-based rerouting behavior for an LSP
-       undergoing establishment.  This MAY also be used to specify
-       segment-based LSP recovery for established LSPs.";
-    reference
-      "RFC 4920: Crankback Signaling Extensions for MPLS and GMPLS
-       RSVP-TE
-       RFC 5420: Encoding of Attributes for MPLS LSP Establishment
-       Using Resource Reservation Protocol Traffic Engineering
-       (RSVP-TE)
-       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-       Route Object (ERO)";
-  }
+    identity segment-based-rerouting-desired {
+      base lsp-attributes-flags;
+      description
+        "Indicates segment-based rerouting behavior for an LSP
+        undergoing establishment.  This MAY also be used to specify
+        segment-based LSP recovery for established LSPs.";
+      reference
+        "RFC 4920: Crankback Signaling Extensions for MPLS and GMPLS
+        RSVP-TE
+        RFC 5420: Encoding of Attributes for MPLS LSP Establishment
+        Using Resource Reservation Protocol Traffic Engineering
+        (RSVP-TE)
+        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+        Route Object (ERO)";
+    }
 
-  identity lsp-integrity-required {
-    base lsp-attributes-flags;
-    description
-      "Indicates that LSP integrity is required.";
-    reference
-      "RFC 4875: Extensions to Resource Reservation Protocol -
-       Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
-       Label Switched Paths (LSPs)
-       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-       Route Object (ERO)";
-  }
+    identity lsp-integrity-required {
+      base lsp-attributes-flags;
+      description
+        "Indicates that LSP integrity is required.";
+      reference
+        "RFC 4875: Extensions to Resource Reservation Protocol -
+        Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
+        Label Switched Paths (LSPs)
+        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+        Route Object (ERO)";
+    }
 
-  identity contiguous-lsp-desired {
-    base lsp-attributes-flags;
-    description
-      "Indicates that a contiguous LSP is desired.";
-    reference
-      "RFC 5151: Inter-Domain MPLS and GMPLS Traffic Engineering --
-       Resource Reservation Protocol-Traffic Engineering (RSVP-TE)
-       Extensions
-       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-       Route Object (ERO)";
-  }
+    identity contiguous-lsp-desired {
+      base lsp-attributes-flags;
+      description
+        "Indicates that a contiguous LSP is desired.";
+      reference
+        "RFC 5151: Inter-Domain MPLS and GMPLS Traffic Engineering --
+        Resource Reservation Protocol-Traffic Engineering (RSVP-TE)
+        Extensions
+        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+        Route Object (ERO)";
+    }
 
-  identity lsp-stitching-desired {
-    base lsp-attributes-flags;
-    description
-      "Indicates that LSP stitching is desired.";
-    reference
-      "RFC 5150: Label Switched Path Stitching with Generalized
-       Multiprotocol Label Switching Traffic Engineering (GMPLS TE)
-       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-       Route Object (ERO)";
-  }
+    identity lsp-stitching-desired {
+      base lsp-attributes-flags;
+      description
+        "Indicates that LSP stitching is desired.";
+      reference
+        "RFC 5150: Label Switched Path Stitching with Generalized
+        Multiprotocol Label Switching Traffic Engineering (GMPLS TE)
+        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+        Route Object (ERO)";
+    }
 
-  identity pre-planned-lsp-flag {
-    base lsp-attributes-flags;
-    description
-      "Indicates that the LSP MUST be provisioned in the
-       control plane only.";
-    reference
-      "RFC 6001: Generalized MPLS (GMPLS) Protocol Extensions for
-       Multi-Layer and Multi-Region Networks (MLN/MRN)
-       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-       Route Object (ERO)";
-  }
+    identity pre-planned-lsp-flag {
+      base lsp-attributes-flags;
+      description
+        "Indicates that the LSP MUST be provisioned in the
+        control plane only.";
+      reference
+        "RFC 6001: Generalized MPLS (GMPLS) Protocol Extensions for
+        Multi-Layer and Multi-Region Networks (MLN/MRN)
+        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+        Route Object (ERO)";
+    }
 
-  identity non-php-behavior-flag {
-    base lsp-attributes-flags;
-    description
-      "Indicates that non-PHP (non-Penultimate Hop Popping) behavior
-       for the LSP is desired.";
-    reference
-      "RFC 6511: Non-Penultimate Hop Popping Behavior and Out-of-Band
-       Mapping for RSVP-TE Label Switched Paths
-       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-       Route Object (ERO)";
-  }
+    identity non-php-behavior-flag {
+      base lsp-attributes-flags;
+      description
+        "Indicates that non-PHP (non-Penultimate Hop Popping) 
+        behavior for the LSP is desired.";
+      reference
+        "RFC 6511: Non-Penultimate Hop Popping Behavior and 
+        Out-of-Band Mapping for RSVP-TE Label Switched Paths
+        
+        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+        Route Object (ERO)";
+    }
 
-  identity oob-mapping-flag {
-    base lsp-attributes-flags;
-    description
-      "Indicates that signaling of the egress binding information is
-       out of band (e.g., via the Border Gateway Protocol (BGP)).";
-    reference
-      "RFC 6511: Non-Penultimate Hop Popping Behavior and Out-of-Band
-       Mapping for RSVP-TE Label Switched Paths
-       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-       Route Object (ERO)";
-  }
+    identity oob-mapping-flag {
+      base lsp-attributes-flags;
+      description
+        "Indicates that signaling of the egress binding information 
+        is out of band (e.g., via the Border Gateway Protocol 
+        (BGP)).";
+      reference
+        "RFC 6511: Non-Penultimate Hop Popping Behavior and 
+        Out-of-Band Mapping for RSVP-TE Label Switched Paths
 
-  identity entropy-label-capability {
-    base lsp-attributes-flags;
-    description
-      "Indicates entropy label capability.";
-    reference
-      "RFC 6790: The Use of Entropy Labels in MPLS Forwarding
-       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-       Route Object (ERO)";
-  }
+        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+        Route Object (ERO)";
+    }
 
-  identity oam-mep-entity-desired {
-    base lsp-attributes-flags;
-    description
-      "OAM Maintenance Entity Group End Point (MEP) entities
-       desired.";
-    reference
-      "RFC 7260: GMPLS RSVP-TE Extensions for Operations,
-       Administration, and Maintenance (OAM) Configuration";
-  }
+    identity entropy-label-capability {
+      base lsp-attributes-flags;
+      description
+        "Indicates entropy label capability.";
+      reference
+        "RFC 6790: The Use of Entropy Labels in MPLS Forwarding
+        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+        Route Object (ERO)";
+    }
 
-  identity oam-mip-entity-desired {
-    base lsp-attributes-flags;
-    description
-      "OAM Maintenance Entity Group Intermediate Points (MIP)
-       entities desired.";
-    reference
-      "RFC 7260: GMPLS RSVP-TE Extensions for Operations,
-       Administration, and Maintenance (OAM) Configuration";
-  }
+    identity oam-mep-entity-desired {
+      base lsp-attributes-flags;
+      description
+        "OAM Maintenance Entity Group End Point (MEP) entities
+        desired.";
+      reference
+        "RFC 7260: GMPLS RSVP-TE Extensions for Operations,
+        Administration, and Maintenance (OAM) Configuration";
+    }
 
-  identity srlg-collection-desired {
-    base lsp-attributes-flags;
-    description
-      "SRLG collection desired.";
-    reference
-      "RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-       Route Object (ERO)
-       RFC 8001: RSVP-TE Extensions for Collecting Shared Risk
-       Link Group (SRLG) Information";
-  }
+    identity oam-mip-entity-desired {
+      base lsp-attributes-flags;
+      description
+        "OAM Maintenance Entity Group Intermediate Points (MIP)
+        entities desired.";
+      reference
+        "RFC 7260: GMPLS RSVP-TE Extensions for Operations,
+        Administration, and Maintenance (OAM) Configuration";
+    }
 
-  identity loopback-desired {
-    base lsp-attributes-flags;
-    description
-      "This flag indicates that a particular node on the LSP is
-       required to enter loopback mode.  This can also be
-       used to specify the loopback state of the node.";
-    reference
-      "RFC 7571: GMPLS RSVP-TE Extensions for Lock Instruct and
-       Loopback";
-  }
+    identity srlg-collection-desired {
+      base lsp-attributes-flags;
+      description
+        "SRLG collection desired.";
+      reference
+        "RFC 7570: Label Switched Path (LSP) Attribute in the 
+        Explicit Route Object (ERO)
 
-  identity p2mp-te-tree-eval-request {
-    base lsp-attributes-flags;
-    description
-      "P2MP-TE tree re-evaluation request.";
-    reference
-      "RFC 8149: RSVP Extensions for Reoptimization of Loosely Routed
-       Point-to-Multipoint Traffic Engineering Label Switched Paths
-       (LSPs)";
-  }
+        RFC 8001: RSVP-TE Extensions for Collecting Shared Risk
+        Link Group (SRLG) Information";
+    }
 
-  identity rtm-set-desired {
-    base lsp-attributes-flags;
-    description
-      "Residence Time Measurement (RTM) attribute flag requested.";
-    reference
-      "RFC 8169: Residence Time Measurement in MPLS Networks";
-  }
+    identity loopback-desired {
+      base lsp-attributes-flags;
+      description
+        "This flag indicates that a particular node on the LSP is
+        required to enter loopback mode.  This can also be
+        used to specify the loopback state of the node.";
+      reference
+        "RFC 7571: GMPLS RSVP-TE Extensions for Lock Instruct and
+        Loopback";
+    }
+
+    identity p2mp-te-tree-eval-request {
+      base lsp-attributes-flags;
+      description
+        "P2MP-TE tree re-evaluation request.";
+      reference
+        "RFC 8149: RSVP Extensions for Reoptimization of Loosely 
+        Routed Point-to-Multipoint Traffic Engineering Label 
+        Switched Paths (LSPs)";
+    }
+
+    identity rtm-set-desired {
+      base lsp-attributes-flags;
+      description
+        "Residence Time Measurement (RTM) attribute flag requested.";
+      reference
+        "RFC 8169: Residence Time Measurement in MPLS Networks";
+    }
 
   identity link-protection-type {
     description
       "Base identity for the link protection type.";
   }
 
-  identity link-protection-unprotected {
-    base link-protection-type;
-    description
-      "Unprotected link type.";
-    reference
-      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-  }
+    identity link-protection-unprotected {
+      base link-protection-type;
+      description
+        "Unprotected link type.";
+      reference
+        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+    }
 
-  identity link-protection-extra-traffic {
-    base link-protection-type;
-    description
-      "Extra-Traffic protected link type.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity link-protection-extra-traffic {
+      base link-protection-type;
+      description
+        "Extra-Traffic protected link type.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity link-protection-shared {
-    base link-protection-type;
-    description
-      "Shared protected link type.";
-    reference
-      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-  }
+    identity link-protection-shared {
+      base link-protection-type;
+      description
+        "Shared protected link type.";
+      reference
+        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+    }
 
-  identity link-protection-1-for-1 {
-    base link-protection-type;
-    description
-      "One-for-one (1:1) protected link type.";
-    reference
-      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-  }
+    identity link-protection-1-for-1 {
+      base link-protection-type;
+      description
+        "One-for-one (1:1) protected link type.";
+      reference
+        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+    }
 
-  identity link-protection-1-plus-1 {
-    base link-protection-type;
-    description
-      "One-plus-one (1+1) protected link type.";
-    reference
-      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-  }
+    identity link-protection-1-plus-1 {
+      base link-protection-type;
+      description
+        "One-plus-one (1+1) protected link type.";
+      reference
+        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+    }
 
-  identity link-protection-enhanced {
-    base link-protection-type;
-    description
-      "A compound link protection type derived from the underlay
-       TE tunnel protection configuration supporting the TE link.";
-  }
+    identity link-protection-enhanced {
+      base link-protection-type;
+      description
+        "A compound link protection type derived from the underlay
+        TE tunnel protection configuration supporting the TE link.";
+    }
 
   identity association-type {
     description
       "Base identity for the tunnel association.";
   }
 
-  identity association-type-recovery {
-    base association-type;
-    description
-      "Association type for recovery, used to associate LSPs of the
-       same tunnel for recovery.";
-    reference
-      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-       Generalized Multi-Protocol Label Switching (GMPLS) Recovery
-       RFC 6780: RSVP ASSOCIATION Object Extensions";
-  }
+    identity association-type-recovery {
+      base association-type;
+      description
+        "Association type for recovery, used to associate LSPs of the
+        same tunnel for recovery.";
+      reference
+        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+        Generalized Multi-Protocol Label Switching (GMPLS) Recovery
+        RFC 6780: RSVP ASSOCIATION Object Extensions";
+    }
 
-  identity association-type-resource-sharing {
-    base association-type;
-    description
-      "Association type for resource sharing, used to enable
-       resource sharing during make-before-break.";
-    reference
-      "RFC 4873: GMPLS Segment Recovery
-       RFC 6780: RSVP ASSOCIATION Object Extensions";
-  }
+    identity association-type-resource-sharing {
+      base association-type;
+      description
+        "Association type for resource sharing, used to enable
+        resource sharing during make-before-break.";
+      reference
+        "RFC 4873: GMPLS Segment Recovery
+        RFC 6780: RSVP ASSOCIATION Object Extensions";
+    }
 
-  identity association-type-double-sided-bidir {
-    base association-type;
-    description
-      "Association type for double-sided bidirectional LSPs,
-       used to associate two LSPs of two tunnels that are
-       independently configured on either endpoint.";
-    reference
-      "RFC 7551: RSVP-TE Extensions for Associated Bidirectional
-       Label Switched Paths (LSPs)";
-  }
+    identity association-type-double-sided-bidir {
+      base association-type;
+      description
+        "Association type for double-sided bidirectional LSPs,
+        used to associate two LSPs of two tunnels that are
+        independently configured on either endpoint.";
+      reference
+        "RFC 7551: RSVP-TE Extensions for Associated Bidirectional
+        Label Switched Paths (LSPs)";
+    }
 
-  identity association-type-single-sided-bidir {
-    base association-type;
-    description
-      "Association type for single-sided bidirectional LSPs,
-       used to associate two LSPs of two tunnels, where one
-       tunnel is configured on one side/endpoint and the other
-       tunnel is dynamically created on the other endpoint.";
-    reference
-      "RFC 6780: RSVP ASSOCIATION Object Extensions
-       RFC 7551: RSVP-TE Extensions for Associated Bidirectional
-       Label Switched Paths (LSPs)";
-  }
+    identity association-type-single-sided-bidir {
+      base association-type;
+      description
+        "Association type for single-sided bidirectional LSPs,
+        used to associate two LSPs of two tunnels, where one
+        tunnel is configured on one side/endpoint and the other
+        tunnel is dynamically created on the other endpoint.";
+      reference
+        "RFC 6780: RSVP ASSOCIATION Object Extensions
+        RFC 7551: RSVP-TE Extensions for Associated Bidirectional
+        Label Switched Paths (LSPs)";
+    }
 
-  // NOTE: The identity association-type-diversity below has been
-  // added in this module revision
-  // RFC Editor: remove the note above and this note
-  identity association-type-diversity {
-    base association-type;
-    description
-      "Association Type diversity used to associate LSPs whose paths
-       are to be diverse from each other.";
-    reference
-      "RFC8800";
-  }
+    // NOTE: The identity association-type-diversity below has been
+    // added in this module revision
+    // RFC Editor: remove the note above and this note
+    identity association-type-diversity {
+      base association-type;
+      description
+        "Association Type diversity used to associate LSPs whose 
+        paths are to be diverse from each other.";
+      reference
+        "RFC8800";
+    }
 
   identity objective-function-type {
     description
-      "Base objective function type.";
+      "Base identity for path objective function type.";
   }
 
-  identity of-minimize-cost-path {
-    base objective-function-type;
-    description
-      "Objective function for minimizing path cost.";
-    reference
-      "RFC 5541: Encoding of Objective Functions in the Path
-       Computation Element Communication Protocol (PCEP)";
-  }
+    identity of-minimize-cost-path {
+      base objective-function-type;
+      description
+        "Objective function for minimizing path cost.";
+      reference
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
+    }
 
-  identity of-minimize-load-path {
-    base objective-function-type;
-    description
-      "Objective function for minimizing the load on one or more
-       paths.";
-    reference
-      "RFC 5541: Encoding of Objective Functions in the Path
-       Computation Element Communication Protocol (PCEP)";
-  }
+    identity of-minimize-load-path {
+      base objective-function-type;
+      description
+        "Objective function for minimizing the load on one or more
+        paths.";
+      reference
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
+    }
 
-  identity of-maximize-residual-bandwidth {
-    base objective-function-type;
-    description
-      "Objective function for maximizing residual bandwidth.";
-    reference
-      "RFC 5541: Encoding of Objective Functions in the Path
-       Computation Element Communication Protocol (PCEP)";
-  }
+    identity of-maximize-residual-bandwidth {
+      base objective-function-type;
+      description
+        "Objective function for maximizing residual bandwidth.";
+      reference
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
+    }
 
-  identity of-minimize-agg-bandwidth-consumption {
-    base objective-function-type;
-    description
-      "Objective function for minimizing aggregate bandwidth
-       consumption.";
-    reference
-      "RFC 5541: Encoding of Objective Functions in the Path
-       Computation Element Communication Protocol (PCEP)";
-  }
+    // NOTE: The identity of-minimize-agg-bandwidth-consumption
+    // below has been obsoleted in this module revision
+    // RFC Editor: remove the note above and this note
+    identity of-minimize-agg-bandwidth-consumption {
+      base objective-function-type;
+      status obsolete;
+      description
+        "Objective function for minimizing aggregate bandwidth
+        consumption.";
+      reference
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
+    }
 
-  identity of-minimize-load-most-loaded-link {
-    base objective-function-type;
-    description
-      "Objective function for minimizing the load on the link that
-       is carrying the highest load.";
-    reference
-      "RFC 5541: Encoding of Objective Functions in the Path
-       Computation Element Communication Protocol (PCEP)";
-  }
+    // NOTE: The identity of-minimize-load-most-loaded-link
+    // below has been obsoleted in this module revision
+    // RFC Editor: remove the note above and this note
+    identity of-minimize-load-most-loaded-link {
+      base objective-function-type;
+      status obsolete;
+      description
+        "Objective function for minimizing the load on the link that
+        is carrying the highest load.";
+      reference
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
+    }
 
-  identity of-minimize-cost-path-set {
-    base objective-function-type;
-    description
-      "Objective function for minimizing the cost on a path set.";
-    reference
-      "RFC 5541: Encoding of Objective Functions in the Path
-       Computation Element Communication Protocol (PCEP)";
-  }
+    // NOTE: The identity of-minimize-cost-path-set
+    // below has been obsoleted in this module revision
+    // RFC Editor: remove the note above and this note
+    identity of-minimize-cost-path-set {
+      base objective-function-type;
+      status obsolete;
+      description
+        "Objective function for minimizing the cost on a path set.";
+      reference
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
+    }
 
   identity path-computation-method {
     description
       "Base identity for supported path computation mechanisms.";
   }
 
-  identity path-locally-computed {
-    base path-computation-method;
-    description
-      "Indicates a constrained-path LSP in which the
-       path is computed by the local LER.";
-    reference
-      "RFC 3272: Overview and Principles of Internet Traffic
-       Engineering, Section 5.4";
-  }
+    identity path-locally-computed {
+      base path-computation-method;
+      description
+        "Indicates a constrained-path LSP in which the
+        path is computed by the local LER.";
+      reference
+        "RFC 3272: Overview and Principles of Internet Traffic
+        Engineering, Section 5.4";
+    }
 
-  identity path-externally-queried {
-    base path-computation-method;
-    description
-      "Constrained-path LSP in which the path is obtained by
-       querying an external source, such as a PCE server.
-       In the case that an LSP is defined to be externally queried,
-       it may also have associated explicit definitions (provided
-       to the external source to aid computation).  The path that is
-       returned by the external source may require further local
-       computation on the device.";
-    reference
-      "RFC 3272: Overview and Principles of Internet Traffic
-       Engineering
-       RFC 4657: Path Computation Element (PCE) Communication
-       Protocol Generic Requirements";
-  }
+    identity path-externally-queried {
+      base path-computation-method;
+      description
+        "Constrained-path LSP in which the path is obtained by
+        querying an external source, such as a PCE server.
+        In the case that an LSP is defined to be externally queried,
+        it may also have associated explicit definitions (provided
+        to the external source to aid computation).  The path that is
+        returned by the external source may require further local
+        computation on the device.";
+      reference
+        "RFC 3272: Overview and Principles of Internet Traffic
+        Engineering
+        RFC 4657: Path Computation Element (PCE) Communication
+        Protocol Generic Requirements";
+    }
 
-  identity path-explicitly-defined {
-    base path-computation-method;
-    description
-      "Constrained-path LSP in which the path is
-       explicitly specified as a collection of strict and/or loose
-       hops.";
-    reference
-      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels
-       RFC 3272: Overview and Principles of Internet Traffic
-       Engineering";
-  }
+    identity path-explicitly-defined {
+      base path-computation-method;
+      description
+        "Constrained-path LSP in which the path is
+        explicitly specified as a collection of strict and/or loose
+        hops.";
+      reference
+        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels
+        RFC 3272: Overview and Principles of Internet Traffic
+        Engineering";
+    }
 
   identity lsp-metric-type {
     description
       "Base identity for the LSP metric specification types.";
   }
 
-  identity lsp-metric-relative {
-    base lsp-metric-type;
-    description
-      "The metric specified for the LSPs to which this identity
-       refers is specified as a value relative to the IGP metric
-       cost to the LSP's tail end.";
-    reference
-      "RFC 4657: Path Computation Element (PCE) Communication
-       Protocol Generic Requirements";
-  }
+    identity lsp-metric-relative {
+      base lsp-metric-type;
+      description
+        "The metric specified for the LSPs to which this identity
+        refers is specified as a value relative to the IGP metric
+        cost to the LSP's tail end.";
+      reference
+        "RFC 4657: Path Computation Element (PCE) Communication
+        Protocol Generic Requirements";
+    }
 
-  identity lsp-metric-absolute {
-    base lsp-metric-type;
-    description
-      "The metric specified for the LSPs to which this identity
-       refers is specified as an absolute value.";
-    reference
-      "RFC 4657: Path Computation Element (PCE) Communication
-       Protocol Generic Requirements";
-  }
+    identity lsp-metric-absolute {
+      base lsp-metric-type;
+      description
+        "The metric specified for the LSPs to which this identity
+        refers is specified as an absolute value.";
+      reference
+        "RFC 4657: Path Computation Element (PCE) Communication
+        Protocol Generic Requirements";
+    }
 
-  identity lsp-metric-inherited {
-    base lsp-metric-type;
-    description
-      "The metric for the LSPs to which this identity refers is
-       not specified explicitly; rather, it is directly inherited
-       from the IGP cost.";
-    reference
-      "RFC 4657: Path Computation Element (PCE) Communication
-       Protocol Generic Requirements";
-  }
+    identity lsp-metric-inherited {
+      base lsp-metric-type;
+      description
+        "The metric for the LSPs to which this identity refers is
+        not specified explicitly; rather, it is directly inherited
+        from the IGP cost.";
+      reference
+        "RFC 4657: Path Computation Element (PCE) Communication
+        Protocol Generic Requirements";
+    }
 
   identity te-tunnel-type {
     description
       "Base identity from which specific tunnel types are derived.";
   }
 
-  identity te-tunnel-p2p {
-    base te-tunnel-type;
-    description
-      "TE Point-to-Point (P2P) tunnel type.";
-    reference
-      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
-  }
+    identity te-tunnel-p2p {
+      base te-tunnel-type;
+      description
+        "TE Point-to-Point (P2P) tunnel type.";
+      reference
+        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
+    }
 
-  identity te-tunnel-p2mp {
-    base te-tunnel-type;
-    description
-      "TE P2MP tunnel type.";
-    reference
-      "RFC 4875: Extensions to Resource Reservation Protocol -
-       Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
-       Label Switched Paths (LSPs)";
-  }
+    identity te-tunnel-p2mp {
+      base te-tunnel-type;
+      description
+        "TE P2MP tunnel type.";
+      reference
+        "RFC 4875: Extensions to Resource Reservation Protocol -
+        Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
+        Label Switched Paths (LSPs)";
+    }
 
   identity tunnel-action-type {
     description
@@ -1222,26 +1240,26 @@ module ietf-te-types {
        are derived.";
   }
 
-  identity tunnel-action-resetup {
-    base tunnel-action-type;
-    description
-      "TE tunnel action that tears down the tunnel's current LSP
-       (if any) and attempts to re-establish a new LSP.";
-  }
+    identity tunnel-action-resetup {
+      base tunnel-action-type;
+      description
+        "TE tunnel action that tears down the tunnel's current LSP
+        (if any) and attempts to re-establish a new LSP.";
+    }
 
-  identity tunnel-action-reoptimize {
-    base tunnel-action-type;
-    description
-      "TE tunnel action that reoptimizes the placement of the
-       tunnel LSP(s).";
-  }
+    identity tunnel-action-reoptimize {
+      base tunnel-action-type;
+      description
+        "TE tunnel action that reoptimizes the placement of the
+        tunnel LSP(s).";
+    }
 
-  identity tunnel-action-switchpath {
-    base tunnel-action-type;
-    description
-      "TE tunnel action that switches the tunnel's LSP to use the
-       specified path.";
-  }
+    identity tunnel-action-switchpath {
+      base tunnel-action-type;
+      description
+        "TE tunnel action that switches the tunnel's LSP to use the
+        specified path.";
+    }
 
   identity te-action-result {
     description
@@ -1249,202 +1267,202 @@ module ietf-te-types {
        are derived.";
   }
 
-  identity te-action-success {
-    base te-action-result;
-    description
-      "TE action was successful.";
-  }
+    identity te-action-success {
+      base te-action-result;
+      description
+        "TE action was successful.";
+    }
 
-  identity te-action-fail {
-    base te-action-result;
-    description
-      "TE action failed.";
-  }
+    identity te-action-fail {
+      base te-action-result;
+      description
+        "TE action failed.";
+    }
 
-  identity tunnel-action-inprogress {
-    base te-action-result;
-    description
-      "TE action is in progress.";
-  }
+    identity tunnel-action-inprogress {
+      base te-action-result;
+      description
+        "TE action is in progress.";
+    }
 
   identity tunnel-admin-state-type {
     description
       "Base identity for TE tunnel administrative states.";
   }
 
-  identity tunnel-admin-state-up {
-    base tunnel-admin-state-type;
-    description
-      "Tunnel's administrative state is up.";
-  }
+    identity tunnel-admin-state-up {
+      base tunnel-admin-state-type;
+      description
+        "Tunnel's administrative state is up.";
+    }
 
-  identity tunnel-admin-state-down {
-    base tunnel-admin-state-type;
-    description
-      "Tunnel's administrative state is down.";
-  }
+    identity tunnel-admin-state-down {
+      base tunnel-admin-state-type;
+      description
+        "Tunnel's administrative state is down.";
+    }
 
-  // NOTE: The identity tunnel-admin-auto below has been
-  // added in this module revision
-  // RFC Editor: remove the note above and this note
-  identity tunnel-admin-auto {
-    base tunnel-admin-state-type;
-    description
-      "Tunnel administrative auto state. The administrative status
-       in state datastore transitions to 'tunnel-admin-up' when the
-       tunnel used by the client layer, and to 'tunnel-admin-down'
-       when it is not used by the client layer.";
-  }
+    // NOTE: The identity tunnel-admin-auto below has been
+    // added in this module revision
+    // RFC Editor: remove the note above and this note
+    identity tunnel-admin-auto {
+      base tunnel-admin-state-type;
+      description
+        "Tunnel administrative auto state. The administrative status
+        in state datastore transitions to 'tunnel-admin-up' when the
+        tunnel used by the client layer, and to 'tunnel-admin-down'
+        when it is not used by the client layer.";
+    }
 
   identity tunnel-state-type {
     description
       "Base identity for TE tunnel states.";
   }
 
-  identity tunnel-state-up {
-    base tunnel-state-type;
-    description
-      "Tunnel's state is up.";
-  }
+    identity tunnel-state-up {
+      base tunnel-state-type;
+      description
+        "Tunnel's state is up.";
+    }
 
-  identity tunnel-state-down {
-    base tunnel-state-type;
-    description
-      "Tunnel's state is down.";
-  }
+    identity tunnel-state-down {
+      base tunnel-state-type;
+      description
+        "Tunnel's state is down.";
+    }
 
   identity lsp-state-type {
     description
       "Base identity for TE LSP states.";
   }
 
-  identity lsp-path-computing {
-    base lsp-state-type;
-    description
-      "State path computation is in progress.";
-  }
+    identity lsp-path-computing {
+      base lsp-state-type;
+      description
+        "State path computation is in progress.";
+    }
 
-  identity lsp-path-computation-ok {
-    base lsp-state-type;
-    description
-      "State path computation was successful.";
-  }
+    identity lsp-path-computation-ok {
+      base lsp-state-type;
+      description
+        "State path computation was successful.";
+    }
 
-  identity lsp-path-computation-failed {
-    base lsp-state-type;
-    description
-      "State path computation failed.";
-  }
+    identity lsp-path-computation-failed {
+      base lsp-state-type;
+      description
+        "State path computation failed.";
+    }
 
-  identity lsp-state-setting-up {
-    base lsp-state-type;
-    description
-      "State is being set up.";
-  }
+    identity lsp-state-setting-up {
+      base lsp-state-type;
+      description
+        "State is being set up.";
+    }
 
-  identity lsp-state-setup-ok {
-    base lsp-state-type;
-    description
-      "State setup was successful.";
-  }
+    identity lsp-state-setup-ok {
+      base lsp-state-type;
+      description
+        "State setup was successful.";
+    }
 
-  identity lsp-state-setup-failed {
-    base lsp-state-type;
-    description
-      "State setup failed.";
-  }
+    identity lsp-state-setup-failed {
+      base lsp-state-type;
+      description
+        "State setup failed.";
+    }
 
-  identity lsp-state-up {
-    base lsp-state-type;
-    description
-      "State is up.";
-  }
+    identity lsp-state-up {
+      base lsp-state-type;
+      description
+        "State is up.";
+    }
 
-  identity lsp-state-tearing-down {
-    base lsp-state-type;
-    description
-      "State is being torn down.";
-  }
+    identity lsp-state-tearing-down {
+      base lsp-state-type;
+      description
+        "State is being torn down.";
+    }
 
-  identity lsp-state-down {
-    base lsp-state-type;
-    description
-      "State is down.";
-  }
+    identity lsp-state-down {
+      base lsp-state-type;
+      description
+        "State is down.";
+    }
 
   identity path-invalidation-action-type {
     description
       "Base identity for TE path invalidation action types.";
   }
 
-  identity path-invalidation-action-drop {
-    base path-invalidation-action-type;
-    description
-      "Upon invalidation of the TE tunnel path, the tunnel remains
-       valid, but any packet mapped over the tunnel is dropped.";
-    reference
-      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
-       Section 2.5";
-  }
+    identity path-invalidation-action-drop {
+      base path-invalidation-action-type;
+      description
+        "Upon invalidation of the TE tunnel path, the tunnel remains
+        valid, but any packet mapped over the tunnel is dropped.";
+      reference
+        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
+        Section 2.5";
+    }
 
-  identity path-invalidation-action-teardown {
-    base path-invalidation-action-type;
-    description
-      "TE path invalidation action teardown.";
-    reference
-      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
-       Section 2.5";
-  }
+    identity path-invalidation-action-teardown {
+      base path-invalidation-action-type;
+      description
+        "TE path invalidation action teardown.";
+      reference
+        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
+        Section 2.5";
+    }
 
   identity lsp-restoration-type {
     description
       "Base identity from which LSP restoration types are derived.";
   }
 
-  identity lsp-restoration-restore-any {
-    base lsp-restoration-type;
-    description
-      "Any LSP affected by a failure is restored.";
-  }
+    identity lsp-restoration-restore-any {
+      base lsp-restoration-type;
+      description
+        "Any LSP affected by a failure is restored.";
+    }
 
-  identity lsp-restoration-restore-all {
-    base lsp-restoration-type;
-    description
-      "Affected LSPs are restored after all LSPs of the tunnel are
-       broken.";
-  }
+    identity lsp-restoration-restore-all {
+      base lsp-restoration-type;
+      description
+        "Affected LSPs are restored after all LSPs of the tunnel are
+        broken.";
+    }
 
   identity restoration-scheme-type {
     description
       "Base identity for LSP restoration schemes.";
   }
 
-  identity restoration-scheme-preconfigured {
-    base restoration-scheme-type;
-    description
-      "Restoration LSP is preconfigured prior to the failure.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity restoration-scheme-preconfigured {
+      base restoration-scheme-type;
+      description
+        "Restoration LSP is preconfigured prior to the failure.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity restoration-scheme-precomputed {
-    base restoration-scheme-type;
-    description
-      "Restoration LSP is precomputed prior to the failure.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity restoration-scheme-precomputed {
+      base restoration-scheme-type;
+      description
+        "Restoration LSP is precomputed prior to the failure.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity restoration-scheme-presignaled {
-    base restoration-scheme-type;
-    description
-      "Restoration LSP is presignaled prior to the failure.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity restoration-scheme-presignaled {
+      base restoration-scheme-type;
+      description
+        "Restoration LSP is presignaled prior to the failure.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
   identity lsp-protection-type {
     description
@@ -1454,175 +1472,175 @@ module ietf-te-types {
        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
   }
 
-  identity lsp-protection-unprotected {
-    base lsp-protection-type;
-    description
-      "'Unprotected' LSP protection type.";
-    reference
-      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-  }
+    identity lsp-protection-unprotected {
+      base lsp-protection-type;
+      description
+        "'Unprotected' LSP protection type.";
+      reference
+        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+    }
 
-  identity lsp-protection-reroute-extra {
-    base lsp-protection-type;
-    description
-      "'(Full) Rerouting' LSP protection type.";
-    reference
-      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-  }
+    identity lsp-protection-reroute-extra {
+      base lsp-protection-type;
+      description
+        "'(Full) Rerouting' LSP protection type.";
+      reference
+        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+    }
 
-  identity lsp-protection-reroute {
-    base lsp-protection-type;
-    description
-      "'Rerouting without Extra-Traffic' LSP protection type.";
-    reference
-      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-  }
+    identity lsp-protection-reroute {
+      base lsp-protection-type;
+      description
+        "'Rerouting without Extra-Traffic' LSP protection type.";
+      reference
+        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+    }
 
-  identity lsp-protection-1-for-n {
-    base lsp-protection-type;
-    description
-      "'1:N Protection with Extra-Traffic' LSP protection type.";
-    reference
-      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-  }
+    identity lsp-protection-1-for-n {
+      base lsp-protection-type;
+      description
+        "'1:N Protection with Extra-Traffic' LSP protection type.";
+      reference
+        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+    }
 
-  identity lsp-protection-1-for-1 {
-    base lsp-protection-type;
-    description
-      "LSP protection '1:1 Protection Type'.";
-    reference
-      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-  }
+    identity lsp-protection-1-for-1 {
+      base lsp-protection-type;
+      description
+        "LSP protection '1:1 Protection Type'.";
+      reference
+        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+    }
 
-  identity lsp-protection-unidir-1-plus-1 {
-    base lsp-protection-type;
-    description
-      "'1+1 Unidirectional Protection' LSP protection type.";
-    reference
-      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-  }
+    identity lsp-protection-unidir-1-plus-1 {
+      base lsp-protection-type;
+      description
+        "'1+1 Unidirectional Protection' LSP protection type.";
+      reference
+        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+    }
 
-  identity lsp-protection-bidir-1-plus-1 {
-    base lsp-protection-type;
-    description
-      "'1+1 Bidirectional Protection' LSP protection type.";
-    reference
-      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-  }
+    identity lsp-protection-bidir-1-plus-1 {
+      base lsp-protection-type;
+      description
+        "'1+1 Bidirectional Protection' LSP protection type.";
+      reference
+        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+    }
 
-  identity lsp-protection-extra-traffic {
-    base lsp-protection-type;
-    description
-      "Extra-Traffic LSP protection type.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity lsp-protection-extra-traffic {
+      base lsp-protection-type;
+      description
+        "Extra-Traffic LSP protection type.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
   identity lsp-protection-state {
     description
       "Base identity of protection states for reporting purposes.";
   }
 
-  identity normal {
-    base lsp-protection-state;
-    description
-      "Normal state.";
-  }
+    identity normal {
+      base lsp-protection-state;
+      description
+        "Normal state.";
+    }
 
-  identity signal-fail-of-protection {
-    base lsp-protection-state;
-    description
-      "The protection transport entity has a signal fail condition
-       that is of higher priority than the forced switchover
-       command.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity signal-fail-of-protection {
+      base lsp-protection-state;
+      description
+        "The protection transport entity has a signal fail condition
+        that is of higher priority than the forced switchover
+        command.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity lockout-of-protection {
-    base lsp-protection-state;
-    description
-      "A Loss of Protection (LoP) command is active.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity lockout-of-protection {
+      base lsp-protection-state;
+      description
+        "A Loss of Protection (LoP) command is active.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity forced-switch {
-    base lsp-protection-state;
-    description
-      "A forced switchover command is active.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity forced-switch {
+      base lsp-protection-state;
+      description
+        "A forced switchover command is active.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity signal-fail {
-    base lsp-protection-state;
-    description
-      "There is a signal fail condition on either the working path
-       or the protection path.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity signal-fail {
+      base lsp-protection-state;
+      description
+        "There is a signal fail condition on either the working path
+        or the protection path.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity signal-degrade {
-    base lsp-protection-state;
-    description
-      "There is a signal degrade condition on either the working
-       path or the protection path.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity signal-degrade {
+      base lsp-protection-state;
+      description
+        "There is a signal degrade condition on either the working
+        path or the protection path.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity manual-switch {
-    base lsp-protection-state;
-    description
-      "A manual switchover command is active.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity manual-switch {
+      base lsp-protection-state;
+      description
+        "A manual switchover command is active.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity wait-to-restore {
-    base lsp-protection-state;
-    description
-      "A WTR timer is running.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity wait-to-restore {
+      base lsp-protection-state;
+      description
+        "A WTR timer is running.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity do-not-revert {
-    base lsp-protection-state;
-    description
-      "A Do Not Revert (DNR) condition is active because of
-       non-revertive behavior.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity do-not-revert {
+      base lsp-protection-state;
+      description
+        "A Do Not Revert (DNR) condition is active because of
+        non-revertive behavior.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity failure-of-protocol {
-    base lsp-protection-state;
-    description
-      "LSP protection is not working because of a protocol failure
-       condition.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity failure-of-protocol {
+      base lsp-protection-state;
+      description
+        "LSP protection is not working because of a protocol failure
+        condition.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
   identity protection-external-commands {
     description
@@ -1630,105 +1648,107 @@ module ietf-te-types {
        used for troubleshooting purposes are derived.";
   }
 
-  identity action-freeze {
-    base protection-external-commands;
-    description
-      "A temporary configuration action initiated by an operator
-       command that prevents any switchover action from being taken
-       and, as such, freezes the current state.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity action-freeze {
+      base protection-external-commands;
+      description
+        "A temporary configuration action initiated by an operator
+        command that prevents any switchover action from being taken
+        and, as such, freezes the current state.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity clear-freeze {
-    base protection-external-commands;
-    description
-      "An action that clears the active freeze state.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity clear-freeze {
+      base protection-external-commands;
+      description
+        "An action that clears the active freeze state.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity action-lockout-of-normal {
-    base protection-external-commands;
-    description
-      "A temporary configuration action initiated by an operator
-       command to ensure that the normal traffic is not allowed
-       to use the protection transport entity.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity action-lockout-of-normal {
+      base protection-external-commands;
+      description
+        "A temporary configuration action initiated by an operator
+        command to ensure that the normal traffic is not allowed
+        to use the protection transport entity.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity clear-lockout-of-normal {
-    base protection-external-commands;
-    description
-      "An action that clears the active lockout of the
-       normal state.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity clear-lockout-of-normal {
+      base protection-external-commands;
+      description
+        "An action that clears the active lockout of the
+        normal state.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity action-lockout-of-protection {
-    base protection-external-commands;
-    description
-      "A temporary configuration action initiated by an operator
-       command to ensure that the protection transport entity is
-       temporarily not available to transport a traffic signal
-       (either normal or Extra-Traffic).";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity action-lockout-of-protection {
+      base protection-external-commands;
+      description
+        "A temporary configuration action initiated by an operator
+        command to ensure that the protection transport entity is
+        temporarily not available to transport a traffic signal
+        (either normal or Extra-Traffic).";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity action-forced-switch {
-    base protection-external-commands;
-    description
-      "A switchover action initiated by an operator command to switch
-       the Extra-Traffic signal, the normal traffic signal, or the
-       null signal to the protection transport entity, unless a
-       switchover command of equal or higher priority is in effect.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity action-forced-switch {
+      base protection-external-commands;
+      description
+        "A switchover action initiated by an operator command to 
+        switch the Extra-Traffic signal, the normal traffic signal, 
+        or the null signal to the protection transport entity, 
+        unless a switchover command of equal or higher priority is 
+        in effect.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity action-manual-switch {
-    base protection-external-commands;
-    description
-      "A switchover action initiated by an operator command to switch
-       the Extra-Traffic signal, the normal traffic signal, or
-       the null signal to the protection transport entity, unless
-       a fault condition exists on other transport entities or a
-       switchover command of equal or higher priority is in effect.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity action-manual-switch {
+      base protection-external-commands;
+      description
+        "A switchover action initiated by an operator command to 
+        switch the Extra-Traffic signal, the normal traffic signal, 
+        or the null signal to the protection transport entity, 
+        unless a fault condition exists on other transport entities 
+        or a switchover command of equal or higher priority is 
+        in effect.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity action-exercise {
-    base protection-external-commands;
-    description
-      "An action that starts testing whether or not APS communication
-       is operating correctly.  It is of lower priority than any
-       other state or command.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity action-exercise {
+      base protection-external-commands;
+      description
+        "An action that starts testing whether or not APS 
+        communication is operating correctly.  It is of lower 
+        priority than any other state or command.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
-  identity clear {
-    base protection-external-commands;
-    description
-      "An action that clears the active near-end lockout of a
-       protection, forced switchover, manual switchover, WTR state,
-       or exercise command.";
-    reference
-      "RFC 4427: Recovery (Protection and Restoration) Terminology
-       for Generalized Multi-Protocol Label Switching (GMPLS)";
-  }
+    identity clear {
+      base protection-external-commands;
+      description
+        "An action that clears the active near-end lockout of a
+        protection, forced switchover, manual switchover, WTR state,
+        or exercise command.";
+      reference
+        "RFC 4427: Recovery (Protection and Restoration) Terminology
+        for Generalized Multi-Protocol Label Switching (GMPLS)";
+    }
 
   identity switching-capabilities {
     description
@@ -1738,77 +1758,77 @@ module ietf-te-types {
        Signaling Functional Description";
   }
 
-  identity switching-psc1 {
-    base switching-capabilities;
-    description
-      "Packet-Switch Capable-1 (PSC-1).";
-    reference
-      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Functional Description";
-  }
+    identity switching-psc1 {
+      base switching-capabilities;
+      description
+        "Packet-Switch Capable-1 (PSC-1).";
+      reference
+        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Functional Description";
+    }
 
-  identity switching-evpl {
-    base switching-capabilities;
-    description
-      "Ethernet Virtual Private Line (EVPL).";
-    reference
-      "RFC 6004: Generalized MPLS (GMPLS) Support for Metro Ethernet
-       Forum and G.8011 Ethernet Service Switching";
-  }
+    identity switching-evpl {
+      base switching-capabilities;
+      description
+        "Ethernet Virtual Private Line (EVPL).";
+      reference
+        "RFC 6004: Generalized MPLS (GMPLS) Support for Metro 
+        Ethernet Forum and G.8011 Ethernet Service Switching";
+    }
 
-  identity switching-l2sc {
-    base switching-capabilities;
-    description
-      "Layer-2 Switch Capable (L2SC).";
-    reference
-      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Functional Description";
-  }
+    identity switching-l2sc {
+      base switching-capabilities;
+      description
+        "Layer-2 Switch Capable (L2SC).";
+      reference
+        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Functional Description";
+    }
 
-  identity switching-tdm {
-    base switching-capabilities;
-    description
-      "Time-Division-Multiplex Capable (TDM).";
-    reference
-      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Functional Description";
-  }
+    identity switching-tdm {
+      base switching-capabilities;
+      description
+        "Time-Division-Multiplex Capable (TDM).";
+      reference
+        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Functional Description";
+    }
 
-  identity switching-otn {
-    base switching-capabilities;
-    description
-      "OTN-TDM capable.";
-    reference
-      "RFC 7138: Traffic Engineering Extensions to OSPF for GMPLS
-       Control of Evolving G.709 Optical Transport Networks";
-  }
+    identity switching-otn {
+      base switching-capabilities;
+      description
+        "OTN-TDM capable.";
+      reference
+        "RFC 7138: Traffic Engineering Extensions to OSPF for GMPLS
+        Control of Evolving G.709 Optical Transport Networks";
+    }
 
-  identity switching-dcsc {
-    base switching-capabilities;
-    description
-      "Data Channel Switching Capable (DCSC).";
-    reference
-      "RFC 6002: Generalized MPLS (GMPLS) Data Channel
-       Switching Capable (DCSC) and Channel Set Label Extensions";
-  }
+    identity switching-dcsc {
+      base switching-capabilities;
+      description
+        "Data Channel Switching Capable (DCSC).";
+      reference
+        "RFC 6002: Generalized MPLS (GMPLS) Data Channel
+        Switching Capable (DCSC) and Channel Set Label Extensions";
+    }
 
-  identity switching-lsc {
-    base switching-capabilities;
-    description
-      "Lambda-Switch Capable (LSC).";
-    reference
-      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Functional Description";
-  }
+    identity switching-lsc {
+      base switching-capabilities;
+      description
+        "Lambda-Switch Capable (LSC).";
+      reference
+        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Functional Description";
+    }
 
-  identity switching-fsc {
-    base switching-capabilities;
-    description
-      "Fiber-Switch Capable (FSC).";
-    reference
-      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Functional Description";
-  }
+    identity switching-fsc {
+      base switching-capabilities;
+      description
+        "Fiber-Switch Capable (FSC).";
+      reference
+        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Functional Description";
+    }
 
   identity lsp-encoding-types {
     description
@@ -1818,106 +1838,106 @@ module ietf-te-types {
        Signaling Functional Description";
   }
 
-  identity lsp-encoding-packet {
-    base lsp-encoding-types;
-    description
-      "Packet LSP encoding.";
-    reference
-      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Functional Description";
-  }
+    identity lsp-encoding-packet {
+      base lsp-encoding-types;
+      description
+        "Packet LSP encoding.";
+      reference
+        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Functional Description";
+    }
 
-  identity lsp-encoding-ethernet {
-    base lsp-encoding-types;
-    description
-      "Ethernet LSP encoding.";
-    reference
-      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Functional Description";
-  }
+    identity lsp-encoding-ethernet {
+      base lsp-encoding-types;
+      description
+        "Ethernet LSP encoding.";
+      reference
+        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Functional Description";
+    }
 
-  identity lsp-encoding-pdh {
-    base lsp-encoding-types;
-    description
-      "ANSI/ETSI PDH LSP encoding.";
-    reference
-      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Functional Description";
-  }
+    identity lsp-encoding-pdh {
+      base lsp-encoding-types;
+      description
+        "ANSI/ETSI PDH LSP encoding.";
+      reference
+        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Functional Description";
+    }
 
-  identity lsp-encoding-sdh {
-    base lsp-encoding-types;
-    description
-      "SDH ITU-T G.707 / SONET ANSI T1.105 LSP encoding.";
-    reference
-      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Functional Description";
-  }
+    identity lsp-encoding-sdh {
+      base lsp-encoding-types;
+      description
+        "SDH ITU-T G.707 / SONET ANSI T1.105 LSP encoding.";
+      reference
+        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Functional Description";
+    }
 
-  identity lsp-encoding-digital-wrapper {
-    base lsp-encoding-types;
-    description
-      "Digital Wrapper LSP encoding.";
-    reference
-      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Functional Description";
-  }
+    identity lsp-encoding-digital-wrapper {
+      base lsp-encoding-types;
+      description
+        "Digital Wrapper LSP encoding.";
+      reference
+        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Functional Description";
+    }
 
-  identity lsp-encoding-lambda {
-    base lsp-encoding-types;
-    description
-      "Lambda (photonic) LSP encoding.";
-    reference
-      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Functional Description";
-  }
+    identity lsp-encoding-lambda {
+      base lsp-encoding-types;
+      description
+        "Lambda (photonic) LSP encoding.";
+      reference
+        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Functional Description";
+    }
 
-  identity lsp-encoding-fiber {
-    base lsp-encoding-types;
-    description
-      "Fiber LSP encoding.";
-    reference
-      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Functional Description";
-  }
+    identity lsp-encoding-fiber {
+      base lsp-encoding-types;
+      description
+        "Fiber LSP encoding.";
+      reference
+        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Functional Description";
+    }
 
-  identity lsp-encoding-fiber-channel {
-    base lsp-encoding-types;
-    description
-      "FiberChannel LSP encoding.";
-    reference
-      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Functional Description";
-  }
+    identity lsp-encoding-fiber-channel {
+      base lsp-encoding-types;
+      description
+        "FiberChannel LSP encoding.";
+      reference
+        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Functional Description";
+    }
 
-  identity lsp-encoding-oduk {
-    base lsp-encoding-types;
-    description
-      "G.709 ODUk (Digital Path) LSP encoding.";
-    reference
-      "RFC 4328: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Extensions for G.709 Optical Transport Networks
-       Control";
-  }
+    identity lsp-encoding-oduk {
+      base lsp-encoding-types;
+      description
+        "G.709 ODUk (Digital Path) LSP encoding.";
+      reference
+        "RFC 4328: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Extensions for G.709 Optical Transport Networks
+        Control";
+    }
 
-  identity lsp-encoding-optical-channel {
-    base lsp-encoding-types;
-    description
-      "G.709 Optical Channel LSP encoding.";
-    reference
-      "RFC 4328: Generalized Multi-Protocol Label Switching (GMPLS)
-       Signaling Extensions for G.709 Optical Transport Networks
-       Control";
-  }
+    identity lsp-encoding-optical-channel {
+      base lsp-encoding-types;
+      description
+        "G.709 Optical Channel LSP encoding.";
+      reference
+        "RFC 4328: Generalized Multi-Protocol Label Switching (GMPLS)
+        Signaling Extensions for G.709 Optical Transport Networks
+        Control";
+    }
 
-  identity lsp-encoding-line {
-    base lsp-encoding-types;
-    description
-      "Line (e.g., 8B/10B) LSP encoding.";
-    reference
-      "RFC 6004: Generalized MPLS (GMPLS) Support for Metro
-       Ethernet Forum and G.8011 Ethernet Service Switching";
-  }
+    identity lsp-encoding-line {
+      base lsp-encoding-types;
+      description
+        "Line (e.g., 8B/10B) LSP encoding.";
+      reference
+        "RFC 6004: Generalized MPLS (GMPLS) Support for Metro
+        Ethernet Forum and G.8011 Ethernet Service Switching";
+    }
 
   identity path-signaling-type {
     description
@@ -1925,25 +1945,25 @@ module ietf-te-types {
        are derived.";
   }
 
-  identity path-setup-static {
-    base path-signaling-type;
-    description
-      "Static LSP provisioning path setup.";
-  }
+    identity path-setup-static {
+      base path-signaling-type;
+      description
+        "Static LSP provisioning path setup.";
+    }
 
-  identity path-setup-rsvp {
-    base path-signaling-type;
-    description
-      "RSVP-TE signaling path setup.";
-    reference
-      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
-  }
+    identity path-setup-rsvp {
+      base path-signaling-type;
+      description
+        "RSVP-TE signaling path setup.";
+      reference
+        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
+    }
 
-  identity path-setup-sr {
-    base path-signaling-type;
-    description
-      "Segment-routing path setup.";
-  }
+    identity path-setup-sr {
+      base path-signaling-type;
+      description
+        "Segment-routing path setup.";
+    }
 
   identity path-scope-type {
     description
@@ -1951,144 +1971,144 @@ module ietf-te-types {
        derived.";
   }
 
-  identity path-scope-segment {
-    base path-scope-type;
-    description
-      "Path scope segment.";
-    reference
-      "RFC 4873: GMPLS Segment Recovery";
-  }
+    identity path-scope-segment {
+      base path-scope-type;
+      description
+        "Path scope segment.";
+      reference
+        "RFC 4873: GMPLS Segment Recovery";
+    }
 
-  identity path-scope-end-to-end {
-    base path-scope-type;
-    description
-      "Path scope end to end.";
-    reference
-      "RFC 4873: GMPLS Segment Recovery";
-  }
+    identity path-scope-end-to-end {
+      base path-scope-type;
+      description
+        "Path scope end to end.";
+      reference
+        "RFC 4873: GMPLS Segment Recovery";
+    }
 
   identity route-usage-type {
     description
       "Base identity for route usage.";
   }
 
-  identity route-include-object {
-    base route-usage-type;
-    description
-      "'Include route' object.";
-  }
+    identity route-include-object {
+      base route-usage-type;
+      description
+        "'Include route' object.";
+    }
 
-  identity route-exclude-object {
-    base route-usage-type;
-    description
-      "'Exclude route' object.";
-    reference
-      "RFC 4874: Exclude Routes - Extension to Resource ReserVation
-       Protocol-Traffic Engineering (RSVP-TE)";
-  }
+    identity route-exclude-object {
+      base route-usage-type;
+      description
+        "'Exclude route' object.";
+      reference
+        "RFC 4874: Exclude Routes - Extension to Resource ReserVation
+        Protocol-Traffic Engineering (RSVP-TE)";
+    }
 
-  identity route-exclude-srlg {
-    base route-usage-type;
-    description
-      "Excludes SRLGs.";
-    reference
-      "RFC 4874: Exclude Routes - Extension to Resource ReserVation
-       Protocol-Traffic Engineering (RSVP-TE)";
-  }
+    identity route-exclude-srlg {
+      base route-usage-type;
+      description
+        "Excludes SRLGs.";
+      reference
+        "RFC 4874: Exclude Routes - Extension to Resource ReserVation
+        Protocol-Traffic Engineering (RSVP-TE)";
+    }
 
   identity path-metric-type {
     description
       "Base identity for the path metric type.";
   }
 
-  identity path-metric-te {
-    base path-metric-type;
-    description
-      "TE path metric.";
-    reference
-      "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
-       second MPLS Traffic Engineering (TE) Metric";
-  }
+    identity path-metric-te {
+      base path-metric-type;
+      description
+        "TE path metric.";
+      reference
+        "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+        second MPLS Traffic Engineering (TE) Metric";
+    }
 
-  identity path-metric-igp {
-    base path-metric-type;
-    description
-      "IGP path metric.";
-    reference
-      "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
-       second MPLS Traffic Engineering (TE) Metric";
-  }
+    identity path-metric-igp {
+      base path-metric-type;
+      description
+        "IGP path metric.";
+      reference
+        "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+        second MPLS Traffic Engineering (TE) Metric";
+    }
 
-  identity path-metric-hop {
-    base path-metric-type;
-    description
-      "Hop path metric.";
-  }
+    identity path-metric-hop {
+      base path-metric-type;
+      description
+        "Hop path metric.";
+    }
 
-  identity path-metric-delay-average {
-    base path-metric-type;
-    description
-      "Average unidirectional link delay.";
-    reference
-      "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-  }
+    identity path-metric-delay-average {
+      base path-metric-type;
+      description
+        "Average unidirectional link delay.";
+      reference
+        "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+    }
 
-  identity path-metric-delay-minimum {
-    base path-metric-type;
-    description
-      "Minimum unidirectional link delay.";
-    reference
-      "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-  }
+    identity path-metric-delay-minimum {
+      base path-metric-type;
+      description
+        "Minimum unidirectional link delay.";
+      reference
+        "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+    }
 
-  identity path-metric-residual-bandwidth {
-    base path-metric-type;
-    description
-      "Unidirectional Residual Bandwidth, which is defined to be
-       Maximum Bandwidth (RFC 3630) minus the bandwidth currently
-       allocated to LSPs.";
-    reference
-      "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
-       Version 2
-       RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-  }
+    identity path-metric-residual-bandwidth {
+      base path-metric-type;
+      description
+        "Unidirectional Residual Bandwidth, which is defined to be
+        Maximum Bandwidth (RFC 3630) minus the bandwidth currently
+        allocated to LSPs.";
+      reference
+        "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+        Version 2
+        RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+    }
 
-  identity path-metric-optimize-includes {
-    base path-metric-type;
-    description
-      "A metric that optimizes the number of included resources
-       specified in a set.";
-  }
+    identity path-metric-optimize-includes {
+      base path-metric-type;
+      description
+        "A metric that optimizes the number of included resources
+        specified in a set.";
+    }
 
-  identity path-metric-optimize-excludes {
-    base path-metric-type;
-    description
-      "A metric that optimizes to a maximum the number of excluded
-       resources specified in a set.";
-  }
+    identity path-metric-optimize-excludes {
+      base path-metric-type;
+      description
+        "A metric that optimizes to a maximum the number of excluded
+        resources specified in a set.";
+    }
 
   identity path-tiebreaker-type {
     description
       "Base identity for the path tiebreaker type.";
   }
 
-  identity path-tiebreaker-minfill {
-    base path-tiebreaker-type;
-    description
-      "Min-Fill LSP path placement.";
-  }
+    identity path-tiebreaker-minfill {
+      base path-tiebreaker-type;
+      description
+        "Min-Fill LSP path placement.";
+    }
 
-  identity path-tiebreaker-maxfill {
-    base path-tiebreaker-type;
-    description
-      "Max-Fill LSP path placement.";
-  }
+    identity path-tiebreaker-maxfill {
+      base path-tiebreaker-type;
+      description
+        "Max-Fill LSP path placement.";
+    }
 
-  identity path-tiebreaker-random {
-    base path-tiebreaker-type;
-    description
-      "Random LSP path placement.";
-  }
+    identity path-tiebreaker-random {
+      base path-tiebreaker-type;
+      description
+        "Random LSP path placement.";
+    }
 
   identity resource-affinities-type {
     description
@@ -2097,37 +2117,37 @@ module ietf-te-types {
       "RFC 2702: Requirements for Traffic Engineering Over MPLS";
   }
 
-  identity resource-aff-include-all {
-    base resource-affinities-type;
-    description
-      "The set of attribute filters associated with a
-       tunnel, all of which must be present for a link
-       to be acceptable.";
-    reference
-      "RFC 2702: Requirements for Traffic Engineering Over MPLS
-       RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
-  }
+    identity resource-aff-include-all {
+      base resource-affinities-type;
+      description
+        "The set of attribute filters associated with a
+        tunnel, all of which must be present for a link
+        to be acceptable.";
+      reference
+        "RFC 2702: Requirements for Traffic Engineering Over MPLS
+        RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
+    }
 
-  identity resource-aff-include-any {
-    base resource-affinities-type;
-    description
-      "The set of attribute filters associated with a
-       tunnel, any of which must be present for a link
-       to be acceptable.";
-    reference
-      "RFC 2702: Requirements for Traffic Engineering Over MPLS
-       RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
-  }
+    identity resource-aff-include-any {
+      base resource-affinities-type;
+      description
+        "The set of attribute filters associated with a
+        tunnel, any of which must be present for a link
+        to be acceptable.";
+      reference
+        "RFC 2702: Requirements for Traffic Engineering Over MPLS
+        RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
+    }
 
-  identity resource-aff-exclude-any {
-    base resource-affinities-type;
-    description
-      "The set of attribute filters associated with a
-       tunnel, any of which renders a link unacceptable.";
-    reference
-      "RFC 2702: Requirements for Traffic Engineering Over MPLS
-       RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
-  }
+    identity resource-aff-exclude-any {
+      base resource-affinities-type;
+      description
+        "The set of attribute filters associated with a
+        tunnel, any of which renders a link unacceptable.";
+      reference
+        "RFC 2702: Requirements for Traffic Engineering Over MPLS
+        RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
+    }
 
   identity te-optimization-criterion {
     description
@@ -2137,58 +2157,58 @@ module ietf-te-types {
        Engineering";
   }
 
-  identity not-optimized {
-    base te-optimization-criterion;
-    description
-      "Optimization is not applied.";
-  }
+    identity not-optimized {
+      base te-optimization-criterion;
+      description
+        "Optimization is not applied.";
+    }
 
-  identity cost {
-    base te-optimization-criterion;
-    description
-      "Optimized on cost.";
-    reference
-      "RFC 5541: Encoding of Objective Functions in the Path
-       Computation Element Communication Protocol (PCEP)";
-  }
+    identity cost {
+      base te-optimization-criterion;
+      description
+        "Optimized on cost.";
+      reference
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
+    }
 
-  identity delay {
-    base te-optimization-criterion;
-    description
-      "Optimized on delay.";
-    reference
-      "RFC 5541: Encoding of Objective Functions in the Path
-       Computation Element Communication Protocol (PCEP)";
-  }
+    identity delay {
+      base te-optimization-criterion;
+      description
+        "Optimized on delay.";
+      reference
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
+    }
 
   identity path-computation-srlg-type {
     description
       "Base identity for SRLG path computation.";
   }
 
-  identity srlg-ignore {
-    base path-computation-srlg-type;
-    description
-      "Ignores SRLGs in the path computation.";
-  }
+    identity srlg-ignore {
+      base path-computation-srlg-type;
+      description
+        "Ignores SRLGs in the path computation.";
+    }
 
-  identity srlg-strict {
-    base path-computation-srlg-type;
-    description
-      "Includes a strict SRLG check in the path computation.";
-  }
+    identity srlg-strict {
+      base path-computation-srlg-type;
+      description
+        "Includes a strict SRLG check in the path computation.";
+    }
 
-  identity srlg-preferred {
-    base path-computation-srlg-type;
-    description
-      "Includes a preferred SRLG check in the path computation.";
-  }
+    identity srlg-preferred {
+      base path-computation-srlg-type;
+      description
+        "Includes a preferred SRLG check in the path computation.";
+    }
 
-  identity srlg-weighted {
-    base path-computation-srlg-type;
-    description
-      "Includes a weighted SRLG check in the path computation.";
-  }
+    identity srlg-weighted {
+      base path-computation-srlg-type;
+      description
+        "Includes a weighted SRLG check in the path computation.";
+    }
 
   // NOTE: The base identity path-computation-error-reason and 
   // its derived identities below have been
@@ -2199,156 +2219,157 @@ module ietf-te-types {
       "Base identity for path computation error reasons.";
   }
 
-  identity path-computation-error-no-topology {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because there is no topology
-       with the provided topology-identifier.";
-  }
+    identity path-computation-error-no-topology {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because there is no topology
+        with the provided topology-identifier.";
+    }
 
-  identity path-computation-error-no-dependent-server {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because one or more dependent
-       path computation servers are unavailable.
-       The dependent path computation server could be
-       a Backward-Recursive Path Computation (BRPC) downstream
-       PCE or a child PCE.";
-    reference
-      "RFC5441, RFC8685";
-  }
+    identity path-computation-error-no-dependent-server {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because one or more dependent
+        path computation servers are unavailable.
+        The dependent path computation server could be
+        a Backward-Recursive Path Computation (BRPC) downstream
+        PCE or a child PCE.";
+      reference
+        "RFC5441, RFC8685";
+    }
 
-  identity path-computation-error-pce-unavailable {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because PCE is not available.";
-    reference
-      "RFC5440";
-  }
+    identity path-computation-error-pce-unavailable {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because PCE is not available.";
+      reference
+        "RFC5440";
+    }
 
-  identity path-computation-error-no-inclusion-hop {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because there is no
-       node or link provided by one or more inclusion hops.";
-    reference
-      "RFC8685";
-  }
+    identity path-computation-error-no-inclusion-hop {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because there is no
+        node or link provided by one or more inclusion hops.";
+      reference
+        "RFC8685";
+    }
 
-  identity path-computation-error-destination-unknown-in-domain {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because the destination node is
-       unknown in indicated destination domain.";
-    reference
-      "RFC8685";
-  }
+    identity path-computation-error-destination-unknown-in-domain {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because the destination node is
+        unknown in indicated destination domain.";
+      reference
+        "RFC8685";
+    }
 
-  identity path-computation-error-no-resource {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because there is no
-       available resource in one or more domains.";
-    reference
-      "RFC8685";
-  }
+    identity path-computation-error-no-resource {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because there is no
+        available resource in one or more domains.";
+      reference
+        "RFC8685";
+    }
 
-  identity path-computation-error-child-pce-unresponsive {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because child PCE is not
-       responsive.";
-    reference
-      "RFC8685";
-  }
+    identity path-computation-error-child-pce-unresponsive {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because child PCE is not
+        responsive.";
+      reference
+        "RFC8685";
+    }
 
-  identity path-computation-error-destination-domain-unknown {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because the destination domain
-       was unknown.";
-    reference
-      "RFC8685";
-  }
+    identity path-computation-error-destination-domain-unknown {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because the destination domain
+        was unknown.";
+      reference
+        "RFC8685";
+    }
 
-  identity path-computation-error-p2mp {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because of P2MP reachability
-       problem.";
-    reference
-      "RFC8306";
-  }
+    identity path-computation-error-p2mp {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because of P2MP reachability
+        problem.";
+      reference
+        "RFC8306";
+    }
 
-  identity path-computation-error-no-gco-migration {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because of no Global Concurrent
-       Optimization (GCO) migration path found.";
-    reference
-      "RFC5557";
-  }
+    identity path-computation-error-no-gco-migration {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because of no Global Concurrent
+        Optimization (GCO) migration path found.";
+      reference
+        "RFC5557";
+    }
 
-  identity path-computation-error-no-gco-solution {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because of no GCO solution
-       found.";
-    reference
-      "RFC5557";
-  }
+    identity path-computation-error-no-gco-solution {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because of no GCO solution
+        found.";
+      reference
+        "RFC5557";
+    }
 
-  identity path-computation-error-path-not-found {
-    base path-computation-error-reason;
-    description
-      "Path computation no path found error reason.";
-    reference
-      "RFC5440";
-  }
+    identity path-computation-error-path-not-found {
+      base path-computation-error-reason;
+      description
+        "Path computation no path found error reason.";
+      reference
+        "RFC5440";
+    }
 
-  identity path-computation-error-pks-expansion {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because of Path-Key Subobject
-       (PKS)  expansion failure.";
-    reference
-      "RFC5520";
-  }
+    identity path-computation-error-pks-expansion {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because of Path-Key Subobject
+        (PKS)  expansion failure.";
+      reference
+        "RFC5520";
+    }
 
-  identity path-computation-error-brpc-chain-unavailable {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because PCE BRPC chain
-       unavailable.";
-    reference
-      "RFC5441";
-  }
+    identity path-computation-error-brpc-chain-unavailable {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because PCE BRPC chain
+        unavailable.";
+      reference
+        "RFC5441";
+    }
 
-  identity path-computation-error-source-unknown {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because source node is unknown.";
-    reference
-      "RFC5440";
-  }
+    identity path-computation-error-source-unknown {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because source node is 
+        unknown.";
+      reference
+        "RFC5440";
+    }
 
-  identity path-computation-error-destination-unknown {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because destination node is
-       unknown.";
-    reference
-      "RFC5440";
-  }
+    identity path-computation-error-destination-unknown {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because destination node is
+        unknown.";
+      reference
+        "RFC5440";
+    }
 
-  identity path-computation-error-no-server {
-    base path-computation-error-reason;
-    description
-      "Path computation has failed because path computation
-       server is unavailable.";
-    reference
-      "RFC5440";
-  }
+    identity path-computation-error-no-server {
+      base path-computation-error-reason;
+      description
+        "Path computation has failed because path computation
+        server is unavailable.";
+      reference
+        "RFC5440";
+    }
 
   // NOTE: The base identity tunnel-actions-type and 
   // its derived identities below have been
@@ -2368,26 +2389,170 @@ module ietf-te-types {
       "Base identity for protocol origin type.";
   }
 
-  identity protocol-origin-api {
-    base protocol-origin-type;
+    identity protocol-origin-api {
+      base protocol-origin-type;
+      description
+        "Protocol origin is via Application Programmable Interface
+        (API).";
+    }
+
+    identity protocol-origin-pcep {
+      base protocol-origin-type;
+      description
+        "Protocol origin is Path Computation Engine Protocol 
+        (PCEP).";
+      reference "RFC5440";
+    }
+
+    identity protocol-origin-bgp {
+      base protocol-origin-type;
+      description
+        "Protocol origin is Border Gateway Protocol (BGP).";
+      reference "RFC5512";
+    }
+
+  // NOTE: The base identity svec-objective-function-type and 
+  // its derived identities below have been
+  // added in this module revision
+  // RFC Editor: remove the note above and this note
+  identity svec-objective-function-type {
     description
-      "Protocol origin is via Application Programmable Interface
-       (API).";
+      "Base identity for SVEC objective function type.";
+    reference
+      "RFC5541: Encoding of Objective Functions in the Path
+       Computation Element Communication Protocol (PCEP).";
   }
 
-  identity protocol-origin-pcep {
-    base protocol-origin-type;
+    identity svec-of-minimize-agg-bandwidth-consumption {
+      base svec-objective-function-type;
+      description
+        "Objective function for minimizing aggregate bandwidth 
+        consumption (MBC).";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
+
+    identity svec-of-minimize-load-most-loaded-link {
+      base svec-objective-function-type;
+      description
+        "Objective function for minimizing the load on the link that 
+        is carrying the highest load (MLL).";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
+
+    identity svec-of-minimize-cost-path-set {
+      base svec-objective-function-type;
+      description
+        "Objective function for minimizing the cost on a path set 
+        (MCC).";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
+
+    identity svec-of-minimize-common-transit-domain {
+      base svec-objective-function-type;
+      description
+        "Objective function for minimizing the number of common 
+        transit domains (MCTD).";
+      reference
+        "RFC8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture.";
+    }
+
+    identity svec-of-minimize-shared-link {
+      base svec-objective-function-type;
+      description
+        "Objective function for minimizing the number of shared 
+        links (MSL).";
+      reference
+        "RFC8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture.";
+    }
+
+    identity svec-of-minimize-shared-srlg {
+      base svec-objective-function-type;
+      description
+        "Objective function for minimizing the number of shared 
+        Shared Risk Link Groups (SRLG) (MSS).";
+      reference
+        "RFC8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture.";
+    }
+
+    identity svec-of-minimize-shared-nodes {
+      base svec-objective-function-type;
+      description
+        "Objective function for minimizing the number of shared 
+        nodes (MSN).";
+      reference
+        "RFC8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture.";
+    }
+
+  // NOTE: The base identity svec-metric-type and 
+  // its derived identities below have been
+  // added in this module revision
+  // RFC Editor: remove the note above and this note
+  identity svec-metric-type {
     description
-      "Protocol origin is Path Computation Engine Protocol (PCEP).";
-    reference "RFC5440";
+      "Base identity for SVEC metric type.";
+    reference
+      "RFC5541: Encoding of Objective Functions in the Path
+       Computation Element Communication Protocol (PCEP).";
   }
 
-  identity protocol-origin-bgp {
-    base protocol-origin-type;
-    description
-      "Protocol origin is Border Gateway Protocol (BGP).";
-    reference "RFC5512";
-  }
+    identity svec-metric-cumul-te {
+      base svec-metric-type;
+      description
+        "Cumulative TE cost.";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
+
+    identity svec-metric-cumul-igp {
+      base svec-metric-type;
+      description
+        "Cumulative IGP cost.";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
+
+    identity svec-metric-cumul-hop {
+      base svec-metric-type;
+      description
+        "Cumulative Hop path metric.";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
+
+    identity svec-metric-aggregate-bandwidth-consumption {
+      base svec-metric-type;
+      description
+        "Aggregate bandwidth consumption.";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
+
+    identity svec-metric-load-of-the-most-loaded-link {
+      base svec-metric-type;
+      description
+        "Load of the most loaded link.";
+      reference
+        "RFC5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP).";
+    }
 
   /**
    * TE bandwidth groupings

--- a/ietf-te-types.yang
+++ b/ietf-te-types.yang
@@ -70,13 +70,27 @@ module ietf-te-types {
     description
       "Added:
       - typedef bandwidth-scientific-notation;
+      - base identity lsp-provisioning-error-reason;
       - identity association-type-diversity;
       - identity tunnel-admin-auto;
       - base identity path-computation-error-reason and
         its derived identities;
+      - base identity tunnel-actions-type and its derived 
+        identities;
       - base identity protocol-origin-type and
         its derived identities;
-      - grouping encoding-and-switching-type.";
+      - base identity svec-objective-function-type and its derived
+        identities;
+      - base identity svec-metric-type and its derived identities;
+      - grouping encoding-and-switching-type.
+      
+      Updated:
+      - description of the base identity objective-function-type.
+      
+      Obsoleted:
+      - identity of-minimize-agg-bandwidth-consumption
+      - identity of-minimize-load-most-loaded-link
+      - identity of-minimize-cost-path-set";
     reference
       "RFC XXXX: Updated Common YANG Data Types for Traffic
       Engineering";
@@ -657,6 +671,9 @@ module ietf-te-types {
    * Identities
    */
 
+  // NOTE: The base identity lsp-provisioning-error-reason has been
+  // added in this module revision
+  // RFC Editor: remove the note above and this note
   identity lsp-provisioning-error-reason {
     description
       "Base identity for LSP provisioning errors.";
@@ -667,572 +684,572 @@ module ietf-te-types {
       "Base identity for the RSVP-TE session attributes flags.";
   }
 
-    identity local-protection-desired {
-      base session-attributes-flags;
-      description
-        "Local protection is desired.";
-      reference
-        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
-        Section 4.7.1";
-    }
+  identity local-protection-desired {
+    base session-attributes-flags;
+    description
+      "Local protection is desired.";
+    reference
+      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
+       Section 4.7.1";
+  }
 
-    identity se-style-desired {
-      base session-attributes-flags;
-      description
-        "Shared explicit style, to allow the LSP to be established
-        and share resources with the old LSP.";
-      reference
-        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
-    }
+  identity se-style-desired {
+    base session-attributes-flags;
+    description
+      "Shared explicit style, to allow the LSP to be established
+       and share resources with the old LSP.";
+    reference
+      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
+  }
 
-    identity local-recording-desired {
-      base session-attributes-flags;
-      description
-        "Label recording is desired.";
-      reference
-        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
-        Section 4.7.1";
-    }
+  identity local-recording-desired {
+    base session-attributes-flags;
+    description
+      "Label recording is desired.";
+    reference
+      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
+       Section 4.7.1";
+  }
 
-    identity bandwidth-protection-desired {
-      base session-attributes-flags;
-      description
-        "Requests FRR bandwidth protection on LSRs, if present.";
-      reference
-        "RFC 4090: Fast Reroute Extensions to RSVP-TE for LSP 
-        Tunnels";
-    }
+  identity bandwidth-protection-desired {
+    base session-attributes-flags;
+    description
+      "Requests FRR bandwidth protection on LSRs, if present.";
+    reference
+      "RFC 4090: Fast Reroute Extensions to RSVP-TE for LSP Tunnels";
+  }
 
-    identity node-protection-desired {
-      base session-attributes-flags;
-      description
-        "Requests FRR node protection on LSRs, if present.";
-      reference
-        "RFC 4090: Fast Reroute Extensions to RSVP-TE for LSP 
-        Tunnels";
-    }
+  identity node-protection-desired {
+    base session-attributes-flags;
+    description
+      "Requests FRR node protection on LSRs, if present.";
+    reference
+      "RFC 4090: Fast Reroute Extensions to RSVP-TE for LSP Tunnels";
+  }
 
-    identity path-reevaluation-request {
-      base session-attributes-flags;
-      description
-        "This flag indicates that a path re-evaluation (of the
-        current path in use) is requested.  Note that this does
-        not trigger any LSP reroutes but instead just signals a
-        request to evaluate whether a preferable path exists.";
-      reference
-        "RFC 4736: Reoptimization of Multiprotocol Label Switching
-        (MPLS) Traffic Engineering (TE) Loosely Routed Label Switched
-        Path (LSP)";
-    }
+  identity path-reevaluation-request {
+    base session-attributes-flags;
+    description
+      "This flag indicates that a path re-evaluation (of the
+       current path in use) is requested.  Note that this does
+       not trigger any LSP reroutes but instead just signals a
+       request to evaluate whether a preferable path exists.";
+    reference
+      "RFC 4736: Reoptimization of Multiprotocol Label Switching
+       (MPLS) Traffic Engineering (TE) Loosely Routed Label Switched
+       Path (LSP)";
+  }
 
-    identity soft-preemption-desired {
-      base session-attributes-flags;
-      description
-        "Soft preemption of LSP resources is desired.";
-      reference
-        "RFC 5712: MPLS Traffic Engineering Soft Preemption";
-    }
+  identity soft-preemption-desired {
+    base session-attributes-flags;
+    description
+      "Soft preemption of LSP resources is desired.";
+    reference
+      "RFC 5712: MPLS Traffic Engineering Soft Preemption";
+  }
 
   identity lsp-attributes-flags {
     description
       "Base identity for LSP attributes flags.";
   }
 
-    identity end-to-end-rerouting-desired {
-      base lsp-attributes-flags;
-      description
-        "Indicates end-to-end rerouting behavior for an LSP
-        undergoing establishment.  This MAY also be used to
-        specify the behavior of end-to-end LSP recovery for
-        established LSPs.";
-      reference
-        "RFC 4920: Crankback Signaling Extensions for MPLS and GMPLS
-        RSVP-TE
-        RFC 5420: Encoding of Attributes for MPLS LSP Establishment
-        Using Resource Reservation Protocol Traffic Engineering
-        (RSVP-TE)
-        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-        Route Object (ERO)";
-    }
+  identity end-to-end-rerouting-desired {
+    base lsp-attributes-flags;
+    description
+      "Indicates end-to-end rerouting behavior for an LSP
+       undergoing establishment.  This MAY also be used to
+       specify the behavior of end-to-end LSP recovery for
+       established LSPs.";
+    reference
+      "RFC 4920: Crankback Signaling Extensions for MPLS and GMPLS
+       RSVP-TE
+       RFC 5420: Encoding of Attributes for MPLS LSP Establishment
+       Using Resource Reservation Protocol Traffic Engineering
+       (RSVP-TE)
+       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+       Route Object (ERO)";
+  }
 
-    identity boundary-rerouting-desired {
-      base lsp-attributes-flags;
-      description
-        "Indicates boundary rerouting behavior for an LSP undergoing
-        establishment.  This MAY also be used to specify
-        segment-based LSP recovery through nested crankback for
-        established LSPs.  The boundary Area Border Router (ABR) /
-        Autonomous System Border Router (ASBR) can decide to forward
-        the PathErr message upstream to either an upstream boundary
-        ABR/ASBR or the ingress LSR.  Alternatively, it can try to
-        select another egress boundary LSR.";
-      reference
-        "RFC 4920: Crankback Signaling Extensions for MPLS and GMPLS
-        RSVP-TE
-        RFC 5420: Encoding of Attributes for MPLS LSP Establishment
-        Using Resource Reservation Protocol Traffic Engineering
-        (RSVP-TE)
-        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-        Route Object (ERO)";
-    }
+  identity boundary-rerouting-desired {
+    base lsp-attributes-flags;
+    description
+      "Indicates boundary rerouting behavior for an LSP undergoing
+       establishment.  This MAY also be used to specify
+       segment-based LSP recovery through nested crankback for
+       established LSPs.  The boundary Area Border Router (ABR) /
+       Autonomous System Border Router (ASBR) can decide to forward
+       the PathErr message upstream to either an upstream boundary
+       ABR/ASBR or the ingress LSR.  Alternatively, it can try to
+       select another egress boundary LSR.";
+    reference
+      "RFC 4920: Crankback Signaling Extensions for MPLS and GMPLS
+       RSVP-TE
+       RFC 5420: Encoding of Attributes for MPLS LSP Establishment
+       Using Resource Reservation Protocol Traffic Engineering
+       (RSVP-TE)
+       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+       Route Object (ERO)";
+  }
 
-    identity segment-based-rerouting-desired {
-      base lsp-attributes-flags;
-      description
-        "Indicates segment-based rerouting behavior for an LSP
-        undergoing establishment.  This MAY also be used to specify
-        segment-based LSP recovery for established LSPs.";
-      reference
-        "RFC 4920: Crankback Signaling Extensions for MPLS and GMPLS
-        RSVP-TE
-        RFC 5420: Encoding of Attributes for MPLS LSP Establishment
-        Using Resource Reservation Protocol Traffic Engineering
-        (RSVP-TE)
-        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-        Route Object (ERO)";
-    }
+  identity segment-based-rerouting-desired {
+    base lsp-attributes-flags;
+    description
+      "Indicates segment-based rerouting behavior for an LSP
+       undergoing establishment.  This MAY also be used to specify
+       segment-based LSP recovery for established LSPs.";
+    reference
+      "RFC 4920: Crankback Signaling Extensions for MPLS and GMPLS
+       RSVP-TE
+       RFC 5420: Encoding of Attributes for MPLS LSP Establishment
+       Using Resource Reservation Protocol Traffic Engineering
+       (RSVP-TE)
+       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+       Route Object (ERO)";
+  }
 
-    identity lsp-integrity-required {
-      base lsp-attributes-flags;
-      description
-        "Indicates that LSP integrity is required.";
-      reference
-        "RFC 4875: Extensions to Resource Reservation Protocol -
-        Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
-        Label Switched Paths (LSPs)
-        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-        Route Object (ERO)";
-    }
+  identity lsp-integrity-required {
+    base lsp-attributes-flags;
+    description
+      "Indicates that LSP integrity is required.";
+    reference
+      "RFC 4875: Extensions to Resource Reservation Protocol -
+       Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
+       Label Switched Paths (LSPs)
+       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+       Route Object (ERO)";
+  }
 
-    identity contiguous-lsp-desired {
-      base lsp-attributes-flags;
-      description
-        "Indicates that a contiguous LSP is desired.";
-      reference
-        "RFC 5151: Inter-Domain MPLS and GMPLS Traffic Engineering --
-        Resource Reservation Protocol-Traffic Engineering (RSVP-TE)
-        Extensions
-        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-        Route Object (ERO)";
-    }
+  identity contiguous-lsp-desired {
+    base lsp-attributes-flags;
+    description
+      "Indicates that a contiguous LSP is desired.";
+    reference
+      "RFC 5151: Inter-Domain MPLS and GMPLS Traffic Engineering --
+       Resource Reservation Protocol-Traffic Engineering (RSVP-TE)
+       Extensions
+       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+       Route Object (ERO)";
+  }
 
-    identity lsp-stitching-desired {
-      base lsp-attributes-flags;
-      description
-        "Indicates that LSP stitching is desired.";
-      reference
-        "RFC 5150: Label Switched Path Stitching with Generalized
-        Multiprotocol Label Switching Traffic Engineering (GMPLS TE)
-        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-        Route Object (ERO)";
-    }
+  identity lsp-stitching-desired {
+    base lsp-attributes-flags;
+    description
+      "Indicates that LSP stitching is desired.";
+    reference
+      "RFC 5150: Label Switched Path Stitching with Generalized
+       Multiprotocol Label Switching Traffic Engineering (GMPLS TE)
+       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+       Route Object (ERO)";
+  }
 
-    identity pre-planned-lsp-flag {
-      base lsp-attributes-flags;
-      description
-        "Indicates that the LSP MUST be provisioned in the
-        control plane only.";
-      reference
-        "RFC 6001: Generalized MPLS (GMPLS) Protocol Extensions for
-        Multi-Layer and Multi-Region Networks (MLN/MRN)
-        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-        Route Object (ERO)";
-    }
+  identity pre-planned-lsp-flag {
+    base lsp-attributes-flags;
+    description
+      "Indicates that the LSP MUST be provisioned in the
+       control plane only.";
+    reference
+      "RFC 6001: Generalized MPLS (GMPLS) Protocol Extensions for
+       Multi-Layer and Multi-Region Networks (MLN/MRN)
+       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+       Route Object (ERO)";
+  }
 
-    identity non-php-behavior-flag {
-      base lsp-attributes-flags;
-      description
-        "Indicates that non-PHP (non-Penultimate Hop Popping) 
-        behavior for the LSP is desired.";
-      reference
-        "RFC 6511: Non-Penultimate Hop Popping Behavior and 
-        Out-of-Band Mapping for RSVP-TE Label Switched Paths
-        
-        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-        Route Object (ERO)";
-    }
+  identity non-php-behavior-flag {
+    base lsp-attributes-flags;
+    description
+      "Indicates that non-PHP (non-Penultimate Hop Popping) behavior
+       for the LSP is desired.";
+    reference
+      "RFC 6511: Non-Penultimate Hop Popping Behavior and Out-of-Band
+       Mapping for RSVP-TE Label Switched Paths
+       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+       Route Object (ERO)";
+  }
 
-    identity oob-mapping-flag {
-      base lsp-attributes-flags;
-      description
-        "Indicates that signaling of the egress binding information 
-        is out of band (e.g., via the Border Gateway Protocol 
-        (BGP)).";
-      reference
-        "RFC 6511: Non-Penultimate Hop Popping Behavior and 
-        Out-of-Band Mapping for RSVP-TE Label Switched Paths
+  identity oob-mapping-flag {
+    base lsp-attributes-flags;
+    description
+      "Indicates that signaling of the egress binding information is
+       out of band (e.g., via the Border Gateway Protocol (BGP)).";
+    reference
+      "RFC 6511: Non-Penultimate Hop Popping Behavior and Out-of-Band
+       Mapping for RSVP-TE Label Switched Paths
+       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+       Route Object (ERO)";
+  }
 
-        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-        Route Object (ERO)";
-    }
+  identity entropy-label-capability {
+    base lsp-attributes-flags;
+    description
+      "Indicates entropy label capability.";
+    reference
+      "RFC 6790: The Use of Entropy Labels in MPLS Forwarding
+       RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+       Route Object (ERO)";
+  }
 
-    identity entropy-label-capability {
-      base lsp-attributes-flags;
-      description
-        "Indicates entropy label capability.";
-      reference
-        "RFC 6790: The Use of Entropy Labels in MPLS Forwarding
-        RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
-        Route Object (ERO)";
-    }
+  identity oam-mep-entity-desired {
+    base lsp-attributes-flags;
+    description
+      "OAM Maintenance Entity Group End Point (MEP) entities
+       desired.";
+    reference
+      "RFC 7260: GMPLS RSVP-TE Extensions for Operations,
+       Administration, and Maintenance (OAM) Configuration";
+  }
 
-    identity oam-mep-entity-desired {
-      base lsp-attributes-flags;
-      description
-        "OAM Maintenance Entity Group End Point (MEP) entities
-        desired.";
-      reference
-        "RFC 7260: GMPLS RSVP-TE Extensions for Operations,
-        Administration, and Maintenance (OAM) Configuration";
-    }
+  identity oam-mip-entity-desired {
+    base lsp-attributes-flags;
+    description
+      "OAM Maintenance Entity Group Intermediate Points (MIP)
+       entities desired.";
+    reference
+      "RFC 7260: GMPLS RSVP-TE Extensions for Operations,
+       Administration, and Maintenance (OAM) Configuration";
+  }
 
-    identity oam-mip-entity-desired {
-      base lsp-attributes-flags;
-      description
-        "OAM Maintenance Entity Group Intermediate Points (MIP)
-        entities desired.";
-      reference
-        "RFC 7260: GMPLS RSVP-TE Extensions for Operations,
-        Administration, and Maintenance (OAM) Configuration";
-    }
+  identity srlg-collection-desired {
+    base lsp-attributes-flags;
+    description
+      "SRLG collection desired.";
+    reference
+      "RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
+       Route Object (ERO)
+       RFC 8001: RSVP-TE Extensions for Collecting Shared Risk
+       Link Group (SRLG) Information";
+  }
 
-    identity srlg-collection-desired {
-      base lsp-attributes-flags;
-      description
-        "SRLG collection desired.";
-      reference
-        "RFC 7570: Label Switched Path (LSP) Attribute in the 
-        Explicit Route Object (ERO)
+  identity loopback-desired {
+    base lsp-attributes-flags;
+    description
+      "This flag indicates that a particular node on the LSP is
+       required to enter loopback mode.  This can also be
+       used to specify the loopback state of the node.";
+    reference
+      "RFC 7571: GMPLS RSVP-TE Extensions for Lock Instruct and
+       Loopback";
+  }
 
-        RFC 8001: RSVP-TE Extensions for Collecting Shared Risk
-        Link Group (SRLG) Information";
-    }
+  identity p2mp-te-tree-eval-request {
+    base lsp-attributes-flags;
+    description
+      "P2MP-TE tree re-evaluation request.";
+    reference
+      "RFC 8149: RSVP Extensions for Reoptimization of Loosely Routed
+       Point-to-Multipoint Traffic Engineering Label Switched Paths
+       (LSPs)";
+  }
 
-    identity loopback-desired {
-      base lsp-attributes-flags;
-      description
-        "This flag indicates that a particular node on the LSP is
-        required to enter loopback mode.  This can also be
-        used to specify the loopback state of the node.";
-      reference
-        "RFC 7571: GMPLS RSVP-TE Extensions for Lock Instruct and
-        Loopback";
-    }
-
-    identity p2mp-te-tree-eval-request {
-      base lsp-attributes-flags;
-      description
-        "P2MP-TE tree re-evaluation request.";
-      reference
-        "RFC 8149: RSVP Extensions for Reoptimization of Loosely 
-        Routed Point-to-Multipoint Traffic Engineering Label 
-        Switched Paths (LSPs)";
-    }
-
-    identity rtm-set-desired {
-      base lsp-attributes-flags;
-      description
-        "Residence Time Measurement (RTM) attribute flag requested.";
-      reference
-        "RFC 8169: Residence Time Measurement in MPLS Networks";
-    }
+  identity rtm-set-desired {
+    base lsp-attributes-flags;
+    description
+      "Residence Time Measurement (RTM) attribute flag requested.";
+    reference
+      "RFC 8169: Residence Time Measurement in MPLS Networks";
+  }
 
   identity link-protection-type {
     description
       "Base identity for the link protection type.";
   }
 
-    identity link-protection-unprotected {
-      base link-protection-type;
-      description
-        "Unprotected link type.";
-      reference
-        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-    }
+  identity link-protection-unprotected {
+    base link-protection-type;
+    description
+      "Unprotected link type.";
+    reference
+      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+  }
 
-    identity link-protection-extra-traffic {
-      base link-protection-type;
-      description
-        "Extra-Traffic protected link type.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity link-protection-extra-traffic {
+    base link-protection-type;
+    description
+      "Extra-Traffic protected link type.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity link-protection-shared {
-      base link-protection-type;
-      description
-        "Shared protected link type.";
-      reference
-        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-    }
+  identity link-protection-shared {
+    base link-protection-type;
+    description
+      "Shared protected link type.";
+    reference
+      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+  }
 
-    identity link-protection-1-for-1 {
-      base link-protection-type;
-      description
-        "One-for-one (1:1) protected link type.";
-      reference
-        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-    }
+  identity link-protection-1-for-1 {
+    base link-protection-type;
+    description
+      "One-for-one (1:1) protected link type.";
+    reference
+      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+  }
 
-    identity link-protection-1-plus-1 {
-      base link-protection-type;
-      description
-        "One-plus-one (1+1) protected link type.";
-      reference
-        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-    }
+  identity link-protection-1-plus-1 {
+    base link-protection-type;
+    description
+      "One-plus-one (1+1) protected link type.";
+    reference
+      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+  }
 
-    identity link-protection-enhanced {
-      base link-protection-type;
-      description
-        "A compound link protection type derived from the underlay
-        TE tunnel protection configuration supporting the TE link.";
-    }
+  identity link-protection-enhanced {
+    base link-protection-type;
+    description
+      "A compound link protection type derived from the underlay
+       TE tunnel protection configuration supporting the TE link.";
+  }
 
   identity association-type {
     description
       "Base identity for the tunnel association.";
   }
 
-    identity association-type-recovery {
-      base association-type;
-      description
-        "Association type for recovery, used to associate LSPs of the
-        same tunnel for recovery.";
-      reference
-        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-        Generalized Multi-Protocol Label Switching (GMPLS) Recovery
-        RFC 6780: RSVP ASSOCIATION Object Extensions";
-    }
+  identity association-type-recovery {
+    base association-type;
+    description
+      "Association type for recovery, used to associate LSPs of the
+       same tunnel for recovery.";
+    reference
+      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+       Generalized Multi-Protocol Label Switching (GMPLS) Recovery
+       RFC 6780: RSVP ASSOCIATION Object Extensions";
+  }
 
-    identity association-type-resource-sharing {
-      base association-type;
-      description
-        "Association type for resource sharing, used to enable
-        resource sharing during make-before-break.";
-      reference
-        "RFC 4873: GMPLS Segment Recovery
-        RFC 6780: RSVP ASSOCIATION Object Extensions";
-    }
+  identity association-type-resource-sharing {
+    base association-type;
+    description
+      "Association type for resource sharing, used to enable
+       resource sharing during make-before-break.";
+    reference
+      "RFC 4873: GMPLS Segment Recovery
+       RFC 6780: RSVP ASSOCIATION Object Extensions";
+  }
 
-    identity association-type-double-sided-bidir {
-      base association-type;
-      description
-        "Association type for double-sided bidirectional LSPs,
-        used to associate two LSPs of two tunnels that are
-        independently configured on either endpoint.";
-      reference
-        "RFC 7551: RSVP-TE Extensions for Associated Bidirectional
-        Label Switched Paths (LSPs)";
-    }
+  identity association-type-double-sided-bidir {
+    base association-type;
+    description
+      "Association type for double-sided bidirectional LSPs,
+       used to associate two LSPs of two tunnels that are
+       independently configured on either endpoint.";
+    reference
+      "RFC 7551: RSVP-TE Extensions for Associated Bidirectional
+       Label Switched Paths (LSPs)";
+  }
 
-    identity association-type-single-sided-bidir {
-      base association-type;
-      description
-        "Association type for single-sided bidirectional LSPs,
-        used to associate two LSPs of two tunnels, where one
-        tunnel is configured on one side/endpoint and the other
-        tunnel is dynamically created on the other endpoint.";
-      reference
-        "RFC 6780: RSVP ASSOCIATION Object Extensions
-        RFC 7551: RSVP-TE Extensions for Associated Bidirectional
-        Label Switched Paths (LSPs)";
-    }
+  identity association-type-single-sided-bidir {
+    base association-type;
+    description
+      "Association type for single-sided bidirectional LSPs,
+       used to associate two LSPs of two tunnels, where one
+       tunnel is configured on one side/endpoint and the other
+       tunnel is dynamically created on the other endpoint.";
+    reference
+      "RFC 6780: RSVP ASSOCIATION Object Extensions
+       RFC 7551: RSVP-TE Extensions for Associated Bidirectional
+       Label Switched Paths (LSPs)";
+  }
 
-    // NOTE: The identity association-type-diversity below has been
-    // added in this module revision
-    // RFC Editor: remove the note above and this note
-    identity association-type-diversity {
-      base association-type;
-      description
-        "Association Type diversity used to associate LSPs whose 
-        paths are to be diverse from each other.";
-      reference
-        "RFC8800";
-    }
+  // NOTE: The identity association-type-diversity below has been
+  // added in this module revision
+  // RFC Editor: remove the note above and this note
+  identity association-type-diversity {
+    base association-type;
+    description
+      "Association Type diversity used to associate LSPs whose 
+      paths are to be diverse from each other.";
+    reference
+      "RFC8800: Path Computation Element Communication Protocol 
+      (PCEP) Extension for Label Switched Path (LSP) Diversity 
+      Constraint Signaling";
+  }
 
+  // NOTE: The description of the base identity 
+  // objective-function-type has been updated 
+  // in this module revision
+  // RFC Editor: remove the note above and this note
   identity objective-function-type {
     description
       "Base identity for path objective function type.";
   }
 
-    identity of-minimize-cost-path {
-      base objective-function-type;
-      description
-        "Objective function for minimizing path cost.";
-      reference
-        "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP)";
-    }
+  identity of-minimize-cost-path {
+    base objective-function-type;
+    description
+      "Objective function for minimizing path cost.";
+    reference
+      "RFC 5541: Encoding of Objective Functions in the Path
+       Computation Element Communication Protocol (PCEP)";
+  }
 
-    identity of-minimize-load-path {
-      base objective-function-type;
-      description
-        "Objective function for minimizing the load on one or more
-        paths.";
-      reference
-        "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP)";
-    }
+  identity of-minimize-load-path {
+    base objective-function-type;
+    description
+      "Objective function for minimizing the load on one or more
+       paths.";
+    reference
+      "RFC 5541: Encoding of Objective Functions in the Path
+       Computation Element Communication Protocol (PCEP)";
+  }
 
-    identity of-maximize-residual-bandwidth {
-      base objective-function-type;
-      description
-        "Objective function for maximizing residual bandwidth.";
-      reference
-        "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP)";
-    }
+  identity of-maximize-residual-bandwidth {
+    base objective-function-type;
+    description
+      "Objective function for maximizing residual bandwidth.";
+    reference
+      "RFC 5541: Encoding of Objective Functions in the Path
+       Computation Element Communication Protocol (PCEP)";
+  }
 
-    // NOTE: The identity of-minimize-agg-bandwidth-consumption
-    // below has been obsoleted in this module revision
-    // RFC Editor: remove the note above and this note
-    identity of-minimize-agg-bandwidth-consumption {
-      base objective-function-type;
-      status obsolete;
-      description
-        "Objective function for minimizing aggregate bandwidth
-        consumption.";
-      reference
-        "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP)";
-    }
+  // NOTE: The identity of-minimize-agg-bandwidth-consumption
+  // below has been obsoleted in this module revision
+  // RFC Editor: remove the note above and this note
+  identity of-minimize-agg-bandwidth-consumption {
+    base objective-function-type;
+    status obsolete;
+    description
+      "Objective function for minimizing aggregate bandwidth
+      consumption.";
+    reference
+      "RFC 5541: Encoding of Objective Functions in the Path
+      Computation Element Communication Protocol (PCEP)";
+  }
 
-    // NOTE: The identity of-minimize-load-most-loaded-link
-    // below has been obsoleted in this module revision
-    // RFC Editor: remove the note above and this note
-    identity of-minimize-load-most-loaded-link {
-      base objective-function-type;
-      status obsolete;
-      description
-        "Objective function for minimizing the load on the link that
-        is carrying the highest load.";
-      reference
-        "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP)";
-    }
+  // NOTE: The identity of-minimize-load-most-loaded-link
+  // below has been obsoleted in this module revision
+  // RFC Editor: remove the note above and this note
+  identity of-minimize-load-most-loaded-link {
+    base objective-function-type;
+    status obsolete;
+    description
+      "Objective function for minimizing the load on the link that
+      is carrying the highest load.";
+    reference
+      "RFC 5541: Encoding of Objective Functions in the Path
+      Computation Element Communication Protocol (PCEP)";
+  }
 
-    // NOTE: The identity of-minimize-cost-path-set
-    // below has been obsoleted in this module revision
-    // RFC Editor: remove the note above and this note
-    identity of-minimize-cost-path-set {
-      base objective-function-type;
-      status obsolete;
-      description
-        "Objective function for minimizing the cost on a path set.";
-      reference
-        "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP)";
-    }
+  // NOTE: The identity of-minimize-cost-path-set
+  // below has been obsoleted in this module revision
+  // RFC Editor: remove the note above and this note
+  identity of-minimize-cost-path-set {
+    base objective-function-type;
+    status obsolete;
+    description
+      "Objective function for minimizing the cost on a path set.";
+    reference
+      "RFC 5541: Encoding of Objective Functions in the Path
+       Computation Element Communication Protocol (PCEP)";
+  }
 
   identity path-computation-method {
     description
       "Base identity for supported path computation mechanisms.";
   }
 
-    identity path-locally-computed {
-      base path-computation-method;
-      description
-        "Indicates a constrained-path LSP in which the
-        path is computed by the local LER.";
-      reference
-        "RFC 3272: Overview and Principles of Internet Traffic
-        Engineering, Section 5.4";
-    }
+  identity path-locally-computed {
+    base path-computation-method;
+    description
+      "Indicates a constrained-path LSP in which the
+       path is computed by the local LER.";
+    reference
+      "RFC 3272: Overview and Principles of Internet Traffic
+       Engineering, Section 5.4";
+  }
 
-    identity path-externally-queried {
-      base path-computation-method;
-      description
-        "Constrained-path LSP in which the path is obtained by
-        querying an external source, such as a PCE server.
-        In the case that an LSP is defined to be externally queried,
-        it may also have associated explicit definitions (provided
-        to the external source to aid computation).  The path that is
-        returned by the external source may require further local
-        computation on the device.";
-      reference
-        "RFC 3272: Overview and Principles of Internet Traffic
-        Engineering
-        RFC 4657: Path Computation Element (PCE) Communication
-        Protocol Generic Requirements";
-    }
+  identity path-externally-queried {
+    base path-computation-method;
+    description
+      "Constrained-path LSP in which the path is obtained by
+       querying an external source, such as a PCE server.
+       In the case that an LSP is defined to be externally queried,
+       it may also have associated explicit definitions (provided
+       to the external source to aid computation).  The path that is
+       returned by the external source may require further local
+       computation on the device.";
+    reference
+      "RFC 3272: Overview and Principles of Internet Traffic
+       Engineering
+       RFC 4657: Path Computation Element (PCE) Communication
+       Protocol Generic Requirements";
+  }
 
-    identity path-explicitly-defined {
-      base path-computation-method;
-      description
-        "Constrained-path LSP in which the path is
-        explicitly specified as a collection of strict and/or loose
-        hops.";
-      reference
-        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels
-        RFC 3272: Overview and Principles of Internet Traffic
-        Engineering";
-    }
+  identity path-explicitly-defined {
+    base path-computation-method;
+    description
+      "Constrained-path LSP in which the path is
+       explicitly specified as a collection of strict and/or loose
+       hops.";
+    reference
+      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels
+       RFC 3272: Overview and Principles of Internet Traffic
+       Engineering";
+  }
 
   identity lsp-metric-type {
     description
       "Base identity for the LSP metric specification types.";
   }
 
-    identity lsp-metric-relative {
-      base lsp-metric-type;
-      description
-        "The metric specified for the LSPs to which this identity
-        refers is specified as a value relative to the IGP metric
-        cost to the LSP's tail end.";
-      reference
-        "RFC 4657: Path Computation Element (PCE) Communication
-        Protocol Generic Requirements";
-    }
+  identity lsp-metric-relative {
+    base lsp-metric-type;
+    description
+      "The metric specified for the LSPs to which this identity
+       refers is specified as a value relative to the IGP metric
+       cost to the LSP's tail end.";
+    reference
+      "RFC 4657: Path Computation Element (PCE) Communication
+       Protocol Generic Requirements";
+  }
 
-    identity lsp-metric-absolute {
-      base lsp-metric-type;
-      description
-        "The metric specified for the LSPs to which this identity
-        refers is specified as an absolute value.";
-      reference
-        "RFC 4657: Path Computation Element (PCE) Communication
-        Protocol Generic Requirements";
-    }
+  identity lsp-metric-absolute {
+    base lsp-metric-type;
+    description
+      "The metric specified for the LSPs to which this identity
+       refers is specified as an absolute value.";
+    reference
+      "RFC 4657: Path Computation Element (PCE) Communication
+       Protocol Generic Requirements";
+  }
 
-    identity lsp-metric-inherited {
-      base lsp-metric-type;
-      description
-        "The metric for the LSPs to which this identity refers is
-        not specified explicitly; rather, it is directly inherited
-        from the IGP cost.";
-      reference
-        "RFC 4657: Path Computation Element (PCE) Communication
-        Protocol Generic Requirements";
-    }
+  identity lsp-metric-inherited {
+    base lsp-metric-type;
+    description
+      "The metric for the LSPs to which this identity refers is
+       not specified explicitly; rather, it is directly inherited
+       from the IGP cost.";
+    reference
+      "RFC 4657: Path Computation Element (PCE) Communication
+       Protocol Generic Requirements";
+  }
 
   identity te-tunnel-type {
     description
       "Base identity from which specific tunnel types are derived.";
   }
 
-    identity te-tunnel-p2p {
-      base te-tunnel-type;
-      description
-        "TE Point-to-Point (P2P) tunnel type.";
-      reference
-        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
-    }
+  identity te-tunnel-p2p {
+    base te-tunnel-type;
+    description
+      "TE Point-to-Point (P2P) tunnel type.";
+    reference
+      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
+  }
 
-    identity te-tunnel-p2mp {
-      base te-tunnel-type;
-      description
-        "TE P2MP tunnel type.";
-      reference
-        "RFC 4875: Extensions to Resource Reservation Protocol -
-        Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
-        Label Switched Paths (LSPs)";
-    }
+  identity te-tunnel-p2mp {
+    base te-tunnel-type;
+    description
+      "TE P2MP tunnel type.";
+    reference
+      "RFC 4875: Extensions to Resource Reservation Protocol -
+       Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
+       Label Switched Paths (LSPs)";
+  }
 
   identity tunnel-action-type {
     description
@@ -1240,26 +1257,26 @@ module ietf-te-types {
        are derived.";
   }
 
-    identity tunnel-action-resetup {
-      base tunnel-action-type;
-      description
-        "TE tunnel action that tears down the tunnel's current LSP
-        (if any) and attempts to re-establish a new LSP.";
-    }
+  identity tunnel-action-resetup {
+    base tunnel-action-type;
+    description
+      "TE tunnel action that tears down the tunnel's current LSP
+       (if any) and attempts to re-establish a new LSP.";
+  }
 
-    identity tunnel-action-reoptimize {
-      base tunnel-action-type;
-      description
-        "TE tunnel action that reoptimizes the placement of the
-        tunnel LSP(s).";
-    }
+  identity tunnel-action-reoptimize {
+    base tunnel-action-type;
+    description
+      "TE tunnel action that reoptimizes the placement of the
+       tunnel LSP(s).";
+  }
 
-    identity tunnel-action-switchpath {
-      base tunnel-action-type;
-      description
-        "TE tunnel action that switches the tunnel's LSP to use the
-        specified path.";
-    }
+  identity tunnel-action-switchpath {
+    base tunnel-action-type;
+    description
+      "TE tunnel action that switches the tunnel's LSP to use the
+       specified path.";
+  }
 
   identity te-action-result {
     description
@@ -1267,202 +1284,202 @@ module ietf-te-types {
        are derived.";
   }
 
-    identity te-action-success {
-      base te-action-result;
-      description
-        "TE action was successful.";
-    }
+  identity te-action-success {
+    base te-action-result;
+    description
+      "TE action was successful.";
+  }
 
-    identity te-action-fail {
-      base te-action-result;
-      description
-        "TE action failed.";
-    }
+  identity te-action-fail {
+    base te-action-result;
+    description
+      "TE action failed.";
+  }
 
-    identity tunnel-action-inprogress {
-      base te-action-result;
-      description
-        "TE action is in progress.";
-    }
+  identity tunnel-action-inprogress {
+    base te-action-result;
+    description
+      "TE action is in progress.";
+  }
 
   identity tunnel-admin-state-type {
     description
       "Base identity for TE tunnel administrative states.";
   }
 
-    identity tunnel-admin-state-up {
-      base tunnel-admin-state-type;
-      description
-        "Tunnel's administrative state is up.";
-    }
+  identity tunnel-admin-state-up {
+    base tunnel-admin-state-type;
+    description
+      "Tunnel's administrative state is up.";
+  }
 
-    identity tunnel-admin-state-down {
-      base tunnel-admin-state-type;
-      description
-        "Tunnel's administrative state is down.";
-    }
+  identity tunnel-admin-state-down {
+    base tunnel-admin-state-type;
+    description
+      "Tunnel's administrative state is down.";
+  }
 
-    // NOTE: The identity tunnel-admin-auto below has been
-    // added in this module revision
-    // RFC Editor: remove the note above and this note
-    identity tunnel-admin-auto {
-      base tunnel-admin-state-type;
-      description
-        "Tunnel administrative auto state. The administrative status
-        in state datastore transitions to 'tunnel-admin-up' when the
-        tunnel used by the client layer, and to 'tunnel-admin-down'
-        when it is not used by the client layer.";
-    }
+  // NOTE: The identity tunnel-admin-auto below has been
+  // added in this module revision
+  // RFC Editor: remove the note above and this note
+  identity tunnel-admin-auto {
+    base tunnel-admin-state-type;
+    description
+      "Tunnel administrative auto state. The administrative status
+      in state datastore transitions to 'tunnel-admin-up' when the
+      tunnel used by the client layer, and to 'tunnel-admin-down'
+      when it is not used by the client layer.";
+  }
 
   identity tunnel-state-type {
     description
       "Base identity for TE tunnel states.";
   }
 
-    identity tunnel-state-up {
-      base tunnel-state-type;
-      description
-        "Tunnel's state is up.";
-    }
+  identity tunnel-state-up {
+    base tunnel-state-type;
+    description
+      "Tunnel's state is up.";
+  }
 
-    identity tunnel-state-down {
-      base tunnel-state-type;
-      description
-        "Tunnel's state is down.";
-    }
+  identity tunnel-state-down {
+    base tunnel-state-type;
+    description
+      "Tunnel's state is down.";
+  }
 
   identity lsp-state-type {
     description
       "Base identity for TE LSP states.";
   }
 
-    identity lsp-path-computing {
-      base lsp-state-type;
-      description
-        "State path computation is in progress.";
-    }
+  identity lsp-path-computing {
+    base lsp-state-type;
+    description
+      "State path computation is in progress.";
+  }
 
-    identity lsp-path-computation-ok {
-      base lsp-state-type;
-      description
-        "State path computation was successful.";
-    }
+  identity lsp-path-computation-ok {
+    base lsp-state-type;
+    description
+      "State path computation was successful.";
+  }
 
-    identity lsp-path-computation-failed {
-      base lsp-state-type;
-      description
-        "State path computation failed.";
-    }
+  identity lsp-path-computation-failed {
+    base lsp-state-type;
+    description
+      "State path computation failed.";
+  }
 
-    identity lsp-state-setting-up {
-      base lsp-state-type;
-      description
-        "State is being set up.";
-    }
+  identity lsp-state-setting-up {
+    base lsp-state-type;
+    description
+      "State is being set up.";
+  }
 
-    identity lsp-state-setup-ok {
-      base lsp-state-type;
-      description
-        "State setup was successful.";
-    }
+  identity lsp-state-setup-ok {
+    base lsp-state-type;
+    description
+      "State setup was successful.";
+  }
 
-    identity lsp-state-setup-failed {
-      base lsp-state-type;
-      description
-        "State setup failed.";
-    }
+  identity lsp-state-setup-failed {
+    base lsp-state-type;
+    description
+      "State setup failed.";
+  }
 
-    identity lsp-state-up {
-      base lsp-state-type;
-      description
-        "State is up.";
-    }
+  identity lsp-state-up {
+    base lsp-state-type;
+    description
+      "State is up.";
+  }
 
-    identity lsp-state-tearing-down {
-      base lsp-state-type;
-      description
-        "State is being torn down.";
-    }
+  identity lsp-state-tearing-down {
+    base lsp-state-type;
+    description
+      "State is being torn down.";
+  }
 
-    identity lsp-state-down {
-      base lsp-state-type;
-      description
-        "State is down.";
-    }
+  identity lsp-state-down {
+    base lsp-state-type;
+    description
+      "State is down.";
+  }
 
   identity path-invalidation-action-type {
     description
       "Base identity for TE path invalidation action types.";
   }
 
-    identity path-invalidation-action-drop {
-      base path-invalidation-action-type;
-      description
-        "Upon invalidation of the TE tunnel path, the tunnel remains
-        valid, but any packet mapped over the tunnel is dropped.";
-      reference
-        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
-        Section 2.5";
-    }
+  identity path-invalidation-action-drop {
+    base path-invalidation-action-type;
+    description
+      "Upon invalidation of the TE tunnel path, the tunnel remains
+       valid, but any packet mapped over the tunnel is dropped.";
+    reference
+      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
+       Section 2.5";
+  }
 
-    identity path-invalidation-action-teardown {
-      base path-invalidation-action-type;
-      description
-        "TE path invalidation action teardown.";
-      reference
-        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
-        Section 2.5";
-    }
+  identity path-invalidation-action-teardown {
+    base path-invalidation-action-type;
+    description
+      "TE path invalidation action teardown.";
+    reference
+      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
+       Section 2.5";
+  }
 
   identity lsp-restoration-type {
     description
       "Base identity from which LSP restoration types are derived.";
   }
 
-    identity lsp-restoration-restore-any {
-      base lsp-restoration-type;
-      description
-        "Any LSP affected by a failure is restored.";
-    }
+  identity lsp-restoration-restore-any {
+    base lsp-restoration-type;
+    description
+      "Any LSP affected by a failure is restored.";
+  }
 
-    identity lsp-restoration-restore-all {
-      base lsp-restoration-type;
-      description
-        "Affected LSPs are restored after all LSPs of the tunnel are
-        broken.";
-    }
+  identity lsp-restoration-restore-all {
+    base lsp-restoration-type;
+    description
+      "Affected LSPs are restored after all LSPs of the tunnel are
+       broken.";
+  }
 
   identity restoration-scheme-type {
     description
       "Base identity for LSP restoration schemes.";
   }
 
-    identity restoration-scheme-preconfigured {
-      base restoration-scheme-type;
-      description
-        "Restoration LSP is preconfigured prior to the failure.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity restoration-scheme-preconfigured {
+    base restoration-scheme-type;
+    description
+      "Restoration LSP is preconfigured prior to the failure.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity restoration-scheme-precomputed {
-      base restoration-scheme-type;
-      description
-        "Restoration LSP is precomputed prior to the failure.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity restoration-scheme-precomputed {
+    base restoration-scheme-type;
+    description
+      "Restoration LSP is precomputed prior to the failure.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity restoration-scheme-presignaled {
-      base restoration-scheme-type;
-      description
-        "Restoration LSP is presignaled prior to the failure.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity restoration-scheme-presignaled {
+    base restoration-scheme-type;
+    description
+      "Restoration LSP is presignaled prior to the failure.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
   identity lsp-protection-type {
     description
@@ -1472,175 +1489,175 @@ module ietf-te-types {
        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
   }
 
-    identity lsp-protection-unprotected {
-      base lsp-protection-type;
-      description
-        "'Unprotected' LSP protection type.";
-      reference
-        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-    }
+  identity lsp-protection-unprotected {
+    base lsp-protection-type;
+    description
+      "'Unprotected' LSP protection type.";
+    reference
+      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+  }
 
-    identity lsp-protection-reroute-extra {
-      base lsp-protection-type;
-      description
-        "'(Full) Rerouting' LSP protection type.";
-      reference
-        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-    }
+  identity lsp-protection-reroute-extra {
+    base lsp-protection-type;
+    description
+      "'(Full) Rerouting' LSP protection type.";
+    reference
+      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+  }
 
-    identity lsp-protection-reroute {
-      base lsp-protection-type;
-      description
-        "'Rerouting without Extra-Traffic' LSP protection type.";
-      reference
-        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-    }
+  identity lsp-protection-reroute {
+    base lsp-protection-type;
+    description
+      "'Rerouting without Extra-Traffic' LSP protection type.";
+    reference
+      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+  }
 
-    identity lsp-protection-1-for-n {
-      base lsp-protection-type;
-      description
-        "'1:N Protection with Extra-Traffic' LSP protection type.";
-      reference
-        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-    }
+  identity lsp-protection-1-for-n {
+    base lsp-protection-type;
+    description
+      "'1:N Protection with Extra-Traffic' LSP protection type.";
+    reference
+      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+  }
 
-    identity lsp-protection-1-for-1 {
-      base lsp-protection-type;
-      description
-        "LSP protection '1:1 Protection Type'.";
-      reference
-        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-    }
+  identity lsp-protection-1-for-1 {
+    base lsp-protection-type;
+    description
+      "LSP protection '1:1 Protection Type'.";
+    reference
+      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+  }
 
-    identity lsp-protection-unidir-1-plus-1 {
-      base lsp-protection-type;
-      description
-        "'1+1 Unidirectional Protection' LSP protection type.";
-      reference
-        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-    }
+  identity lsp-protection-unidir-1-plus-1 {
+    base lsp-protection-type;
+    description
+      "'1+1 Unidirectional Protection' LSP protection type.";
+    reference
+      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+  }
 
-    identity lsp-protection-bidir-1-plus-1 {
-      base lsp-protection-type;
-      description
-        "'1+1 Bidirectional Protection' LSP protection type.";
-      reference
-        "RFC 4872: RSVP-TE Extensions in Support of End-to-End
-        Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
-    }
+  identity lsp-protection-bidir-1-plus-1 {
+    base lsp-protection-type;
+    description
+      "'1+1 Bidirectional Protection' LSP protection type.";
+    reference
+      "RFC 4872: RSVP-TE Extensions in Support of End-to-End
+       Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
+  }
 
-    identity lsp-protection-extra-traffic {
-      base lsp-protection-type;
-      description
-        "Extra-Traffic LSP protection type.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity lsp-protection-extra-traffic {
+    base lsp-protection-type;
+    description
+      "Extra-Traffic LSP protection type.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
   identity lsp-protection-state {
     description
       "Base identity of protection states for reporting purposes.";
   }
 
-    identity normal {
-      base lsp-protection-state;
-      description
-        "Normal state.";
-    }
+  identity normal {
+    base lsp-protection-state;
+    description
+      "Normal state.";
+  }
 
-    identity signal-fail-of-protection {
-      base lsp-protection-state;
-      description
-        "The protection transport entity has a signal fail condition
-        that is of higher priority than the forced switchover
-        command.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity signal-fail-of-protection {
+    base lsp-protection-state;
+    description
+      "The protection transport entity has a signal fail condition
+       that is of higher priority than the forced switchover
+       command.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity lockout-of-protection {
-      base lsp-protection-state;
-      description
-        "A Loss of Protection (LoP) command is active.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity lockout-of-protection {
+    base lsp-protection-state;
+    description
+      "A Loss of Protection (LoP) command is active.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity forced-switch {
-      base lsp-protection-state;
-      description
-        "A forced switchover command is active.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity forced-switch {
+    base lsp-protection-state;
+    description
+      "A forced switchover command is active.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity signal-fail {
-      base lsp-protection-state;
-      description
-        "There is a signal fail condition on either the working path
-        or the protection path.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity signal-fail {
+    base lsp-protection-state;
+    description
+      "There is a signal fail condition on either the working path
+       or the protection path.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity signal-degrade {
-      base lsp-protection-state;
-      description
-        "There is a signal degrade condition on either the working
-        path or the protection path.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity signal-degrade {
+    base lsp-protection-state;
+    description
+      "There is a signal degrade condition on either the working
+       path or the protection path.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity manual-switch {
-      base lsp-protection-state;
-      description
-        "A manual switchover command is active.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity manual-switch {
+    base lsp-protection-state;
+    description
+      "A manual switchover command is active.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity wait-to-restore {
-      base lsp-protection-state;
-      description
-        "A WTR timer is running.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity wait-to-restore {
+    base lsp-protection-state;
+    description
+      "A WTR timer is running.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity do-not-revert {
-      base lsp-protection-state;
-      description
-        "A Do Not Revert (DNR) condition is active because of
-        non-revertive behavior.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity do-not-revert {
+    base lsp-protection-state;
+    description
+      "A Do Not Revert (DNR) condition is active because of
+       non-revertive behavior.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity failure-of-protocol {
-      base lsp-protection-state;
-      description
-        "LSP protection is not working because of a protocol failure
-        condition.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity failure-of-protocol {
+    base lsp-protection-state;
+    description
+      "LSP protection is not working because of a protocol failure
+       condition.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
   identity protection-external-commands {
     description
@@ -1648,107 +1665,105 @@ module ietf-te-types {
        used for troubleshooting purposes are derived.";
   }
 
-    identity action-freeze {
-      base protection-external-commands;
-      description
-        "A temporary configuration action initiated by an operator
-        command that prevents any switchover action from being taken
-        and, as such, freezes the current state.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity action-freeze {
+    base protection-external-commands;
+    description
+      "A temporary configuration action initiated by an operator
+       command that prevents any switchover action from being taken
+       and, as such, freezes the current state.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity clear-freeze {
-      base protection-external-commands;
-      description
-        "An action that clears the active freeze state.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity clear-freeze {
+    base protection-external-commands;
+    description
+      "An action that clears the active freeze state.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity action-lockout-of-normal {
-      base protection-external-commands;
-      description
-        "A temporary configuration action initiated by an operator
-        command to ensure that the normal traffic is not allowed
-        to use the protection transport entity.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity action-lockout-of-normal {
+    base protection-external-commands;
+    description
+      "A temporary configuration action initiated by an operator
+       command to ensure that the normal traffic is not allowed
+       to use the protection transport entity.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity clear-lockout-of-normal {
-      base protection-external-commands;
-      description
-        "An action that clears the active lockout of the
-        normal state.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity clear-lockout-of-normal {
+    base protection-external-commands;
+    description
+      "An action that clears the active lockout of the
+       normal state.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity action-lockout-of-protection {
-      base protection-external-commands;
-      description
-        "A temporary configuration action initiated by an operator
-        command to ensure that the protection transport entity is
-        temporarily not available to transport a traffic signal
-        (either normal or Extra-Traffic).";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity action-lockout-of-protection {
+    base protection-external-commands;
+    description
+      "A temporary configuration action initiated by an operator
+       command to ensure that the protection transport entity is
+       temporarily not available to transport a traffic signal
+       (either normal or Extra-Traffic).";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity action-forced-switch {
-      base protection-external-commands;
-      description
-        "A switchover action initiated by an operator command to 
-        switch the Extra-Traffic signal, the normal traffic signal, 
-        or the null signal to the protection transport entity, 
-        unless a switchover command of equal or higher priority is 
-        in effect.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity action-forced-switch {
+    base protection-external-commands;
+    description
+      "A switchover action initiated by an operator command to switch
+       the Extra-Traffic signal, the normal traffic signal, or the
+       null signal to the protection transport entity, unless a
+       switchover command of equal or higher priority is in effect.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity action-manual-switch {
-      base protection-external-commands;
-      description
-        "A switchover action initiated by an operator command to 
-        switch the Extra-Traffic signal, the normal traffic signal, 
-        or the null signal to the protection transport entity, 
-        unless a fault condition exists on other transport entities 
-        or a switchover command of equal or higher priority is 
-        in effect.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity action-manual-switch {
+    base protection-external-commands;
+    description
+      "A switchover action initiated by an operator command to switch
+       the Extra-Traffic signal, the normal traffic signal, or
+       the null signal to the protection transport entity, unless
+       a fault condition exists on other transport entities or a
+       switchover command of equal or higher priority is in effect.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity action-exercise {
-      base protection-external-commands;
-      description
-        "An action that starts testing whether or not APS 
-        communication is operating correctly.  It is of lower 
-        priority than any other state or command.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity action-exercise {
+    base protection-external-commands;
+    description
+      "An action that starts testing whether or not APS communication
+       is operating correctly.  It is of lower priority than any
+       other state or command.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
-    identity clear {
-      base protection-external-commands;
-      description
-        "An action that clears the active near-end lockout of a
-        protection, forced switchover, manual switchover, WTR state,
-        or exercise command.";
-      reference
-        "RFC 4427: Recovery (Protection and Restoration) Terminology
-        for Generalized Multi-Protocol Label Switching (GMPLS)";
-    }
+  identity clear {
+    base protection-external-commands;
+    description
+      "An action that clears the active near-end lockout of a
+       protection, forced switchover, manual switchover, WTR state,
+       or exercise command.";
+    reference
+      "RFC 4427: Recovery (Protection and Restoration) Terminology
+       for Generalized Multi-Protocol Label Switching (GMPLS)";
+  }
 
   identity switching-capabilities {
     description
@@ -1758,77 +1773,77 @@ module ietf-te-types {
        Signaling Functional Description";
   }
 
-    identity switching-psc1 {
-      base switching-capabilities;
-      description
-        "Packet-Switch Capable-1 (PSC-1).";
-      reference
-        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Functional Description";
-    }
+  identity switching-psc1 {
+    base switching-capabilities;
+    description
+      "Packet-Switch Capable-1 (PSC-1).";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description";
+  }
 
-    identity switching-evpl {
-      base switching-capabilities;
-      description
-        "Ethernet Virtual Private Line (EVPL).";
-      reference
-        "RFC 6004: Generalized MPLS (GMPLS) Support for Metro 
-        Ethernet Forum and G.8011 Ethernet Service Switching";
-    }
+  identity switching-evpl {
+    base switching-capabilities;
+    description
+      "Ethernet Virtual Private Line (EVPL).";
+    reference
+      "RFC 6004: Generalized MPLS (GMPLS) Support for Metro Ethernet
+       Forum and G.8011 Ethernet Service Switching";
+  }
 
-    identity switching-l2sc {
-      base switching-capabilities;
-      description
-        "Layer-2 Switch Capable (L2SC).";
-      reference
-        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Functional Description";
-    }
+  identity switching-l2sc {
+    base switching-capabilities;
+    description
+      "Layer-2 Switch Capable (L2SC).";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description";
+  }
 
-    identity switching-tdm {
-      base switching-capabilities;
-      description
-        "Time-Division-Multiplex Capable (TDM).";
-      reference
-        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Functional Description";
-    }
+  identity switching-tdm {
+    base switching-capabilities;
+    description
+      "Time-Division-Multiplex Capable (TDM).";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description";
+  }
 
-    identity switching-otn {
-      base switching-capabilities;
-      description
-        "OTN-TDM capable.";
-      reference
-        "RFC 7138: Traffic Engineering Extensions to OSPF for GMPLS
-        Control of Evolving G.709 Optical Transport Networks";
-    }
+  identity switching-otn {
+    base switching-capabilities;
+    description
+      "OTN-TDM capable.";
+    reference
+      "RFC 7138: Traffic Engineering Extensions to OSPF for GMPLS
+       Control of Evolving G.709 Optical Transport Networks";
+  }
 
-    identity switching-dcsc {
-      base switching-capabilities;
-      description
-        "Data Channel Switching Capable (DCSC).";
-      reference
-        "RFC 6002: Generalized MPLS (GMPLS) Data Channel
-        Switching Capable (DCSC) and Channel Set Label Extensions";
-    }
+  identity switching-dcsc {
+    base switching-capabilities;
+    description
+      "Data Channel Switching Capable (DCSC).";
+    reference
+      "RFC 6002: Generalized MPLS (GMPLS) Data Channel
+       Switching Capable (DCSC) and Channel Set Label Extensions";
+  }
 
-    identity switching-lsc {
-      base switching-capabilities;
-      description
-        "Lambda-Switch Capable (LSC).";
-      reference
-        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Functional Description";
-    }
+  identity switching-lsc {
+    base switching-capabilities;
+    description
+      "Lambda-Switch Capable (LSC).";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description";
+  }
 
-    identity switching-fsc {
-      base switching-capabilities;
-      description
-        "Fiber-Switch Capable (FSC).";
-      reference
-        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Functional Description";
-    }
+  identity switching-fsc {
+    base switching-capabilities;
+    description
+      "Fiber-Switch Capable (FSC).";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description";
+  }
 
   identity lsp-encoding-types {
     description
@@ -1838,106 +1853,106 @@ module ietf-te-types {
        Signaling Functional Description";
   }
 
-    identity lsp-encoding-packet {
-      base lsp-encoding-types;
-      description
-        "Packet LSP encoding.";
-      reference
-        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Functional Description";
-    }
+  identity lsp-encoding-packet {
+    base lsp-encoding-types;
+    description
+      "Packet LSP encoding.";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description";
+  }
 
-    identity lsp-encoding-ethernet {
-      base lsp-encoding-types;
-      description
-        "Ethernet LSP encoding.";
-      reference
-        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Functional Description";
-    }
+  identity lsp-encoding-ethernet {
+    base lsp-encoding-types;
+    description
+      "Ethernet LSP encoding.";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description";
+  }
 
-    identity lsp-encoding-pdh {
-      base lsp-encoding-types;
-      description
-        "ANSI/ETSI PDH LSP encoding.";
-      reference
-        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Functional Description";
-    }
+  identity lsp-encoding-pdh {
+    base lsp-encoding-types;
+    description
+      "ANSI/ETSI PDH LSP encoding.";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description";
+  }
 
-    identity lsp-encoding-sdh {
-      base lsp-encoding-types;
-      description
-        "SDH ITU-T G.707 / SONET ANSI T1.105 LSP encoding.";
-      reference
-        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Functional Description";
-    }
+  identity lsp-encoding-sdh {
+    base lsp-encoding-types;
+    description
+      "SDH ITU-T G.707 / SONET ANSI T1.105 LSP encoding.";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description";
+  }
 
-    identity lsp-encoding-digital-wrapper {
-      base lsp-encoding-types;
-      description
-        "Digital Wrapper LSP encoding.";
-      reference
-        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Functional Description";
-    }
+  identity lsp-encoding-digital-wrapper {
+    base lsp-encoding-types;
+    description
+      "Digital Wrapper LSP encoding.";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description";
+  }
 
-    identity lsp-encoding-lambda {
-      base lsp-encoding-types;
-      description
-        "Lambda (photonic) LSP encoding.";
-      reference
-        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Functional Description";
-    }
+  identity lsp-encoding-lambda {
+    base lsp-encoding-types;
+    description
+      "Lambda (photonic) LSP encoding.";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description";
+  }
 
-    identity lsp-encoding-fiber {
-      base lsp-encoding-types;
-      description
-        "Fiber LSP encoding.";
-      reference
-        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Functional Description";
-    }
+  identity lsp-encoding-fiber {
+    base lsp-encoding-types;
+    description
+      "Fiber LSP encoding.";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description";
+  }
 
-    identity lsp-encoding-fiber-channel {
-      base lsp-encoding-types;
-      description
-        "FiberChannel LSP encoding.";
-      reference
-        "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Functional Description";
-    }
+  identity lsp-encoding-fiber-channel {
+    base lsp-encoding-types;
+    description
+      "FiberChannel LSP encoding.";
+    reference
+      "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Functional Description";
+  }
 
-    identity lsp-encoding-oduk {
-      base lsp-encoding-types;
-      description
-        "G.709 ODUk (Digital Path) LSP encoding.";
-      reference
-        "RFC 4328: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Extensions for G.709 Optical Transport Networks
-        Control";
-    }
+  identity lsp-encoding-oduk {
+    base lsp-encoding-types;
+    description
+      "G.709 ODUk (Digital Path) LSP encoding.";
+    reference
+      "RFC 4328: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Extensions for G.709 Optical Transport Networks
+       Control";
+  }
 
-    identity lsp-encoding-optical-channel {
-      base lsp-encoding-types;
-      description
-        "G.709 Optical Channel LSP encoding.";
-      reference
-        "RFC 4328: Generalized Multi-Protocol Label Switching (GMPLS)
-        Signaling Extensions for G.709 Optical Transport Networks
-        Control";
-    }
+  identity lsp-encoding-optical-channel {
+    base lsp-encoding-types;
+    description
+      "G.709 Optical Channel LSP encoding.";
+    reference
+      "RFC 4328: Generalized Multi-Protocol Label Switching (GMPLS)
+       Signaling Extensions for G.709 Optical Transport Networks
+       Control";
+  }
 
-    identity lsp-encoding-line {
-      base lsp-encoding-types;
-      description
-        "Line (e.g., 8B/10B) LSP encoding.";
-      reference
-        "RFC 6004: Generalized MPLS (GMPLS) Support for Metro
-        Ethernet Forum and G.8011 Ethernet Service Switching";
-    }
+  identity lsp-encoding-line {
+    base lsp-encoding-types;
+    description
+      "Line (e.g., 8B/10B) LSP encoding.";
+    reference
+      "RFC 6004: Generalized MPLS (GMPLS) Support for Metro
+       Ethernet Forum and G.8011 Ethernet Service Switching";
+  }
 
   identity path-signaling-type {
     description
@@ -1945,25 +1960,25 @@ module ietf-te-types {
        are derived.";
   }
 
-    identity path-setup-static {
-      base path-signaling-type;
-      description
-        "Static LSP provisioning path setup.";
-    }
+  identity path-setup-static {
+    base path-signaling-type;
+    description
+      "Static LSP provisioning path setup.";
+  }
 
-    identity path-setup-rsvp {
-      base path-signaling-type;
-      description
-        "RSVP-TE signaling path setup.";
-      reference
-        "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
-    }
+  identity path-setup-rsvp {
+    base path-signaling-type;
+    description
+      "RSVP-TE signaling path setup.";
+    reference
+      "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
+  }
 
-    identity path-setup-sr {
-      base path-signaling-type;
-      description
-        "Segment-routing path setup.";
-    }
+  identity path-setup-sr {
+    base path-signaling-type;
+    description
+      "Segment-routing path setup.";
+  }
 
   identity path-scope-type {
     description
@@ -1971,144 +1986,144 @@ module ietf-te-types {
        derived.";
   }
 
-    identity path-scope-segment {
-      base path-scope-type;
-      description
-        "Path scope segment.";
-      reference
-        "RFC 4873: GMPLS Segment Recovery";
-    }
+  identity path-scope-segment {
+    base path-scope-type;
+    description
+      "Path scope segment.";
+    reference
+      "RFC 4873: GMPLS Segment Recovery";
+  }
 
-    identity path-scope-end-to-end {
-      base path-scope-type;
-      description
-        "Path scope end to end.";
-      reference
-        "RFC 4873: GMPLS Segment Recovery";
-    }
+  identity path-scope-end-to-end {
+    base path-scope-type;
+    description
+      "Path scope end to end.";
+    reference
+      "RFC 4873: GMPLS Segment Recovery";
+  }
 
   identity route-usage-type {
     description
       "Base identity for route usage.";
   }
 
-    identity route-include-object {
-      base route-usage-type;
-      description
-        "'Include route' object.";
-    }
+  identity route-include-object {
+    base route-usage-type;
+    description
+      "'Include route' object.";
+  }
 
-    identity route-exclude-object {
-      base route-usage-type;
-      description
-        "'Exclude route' object.";
-      reference
-        "RFC 4874: Exclude Routes - Extension to Resource ReserVation
-        Protocol-Traffic Engineering (RSVP-TE)";
-    }
+  identity route-exclude-object {
+    base route-usage-type;
+    description
+      "'Exclude route' object.";
+    reference
+      "RFC 4874: Exclude Routes - Extension to Resource ReserVation
+       Protocol-Traffic Engineering (RSVP-TE)";
+  }
 
-    identity route-exclude-srlg {
-      base route-usage-type;
-      description
-        "Excludes SRLGs.";
-      reference
-        "RFC 4874: Exclude Routes - Extension to Resource ReserVation
-        Protocol-Traffic Engineering (RSVP-TE)";
-    }
+  identity route-exclude-srlg {
+    base route-usage-type;
+    description
+      "Excludes SRLGs.";
+    reference
+      "RFC 4874: Exclude Routes - Extension to Resource ReserVation
+       Protocol-Traffic Engineering (RSVP-TE)";
+  }
 
   identity path-metric-type {
     description
       "Base identity for the path metric type.";
   }
 
-    identity path-metric-te {
-      base path-metric-type;
-      description
-        "TE path metric.";
-      reference
-        "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
-        second MPLS Traffic Engineering (TE) Metric";
-    }
+  identity path-metric-te {
+    base path-metric-type;
+    description
+      "TE path metric.";
+    reference
+      "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+       second MPLS Traffic Engineering (TE) Metric";
+  }
 
-    identity path-metric-igp {
-      base path-metric-type;
-      description
-        "IGP path metric.";
-      reference
-        "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
-        second MPLS Traffic Engineering (TE) Metric";
-    }
+  identity path-metric-igp {
+    base path-metric-type;
+    description
+      "IGP path metric.";
+    reference
+      "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+       second MPLS Traffic Engineering (TE) Metric";
+  }
 
-    identity path-metric-hop {
-      base path-metric-type;
-      description
-        "Hop path metric.";
-    }
+  identity path-metric-hop {
+    base path-metric-type;
+    description
+      "Hop path metric.";
+  }
 
-    identity path-metric-delay-average {
-      base path-metric-type;
-      description
-        "Average unidirectional link delay.";
-      reference
-        "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-    }
+  identity path-metric-delay-average {
+    base path-metric-type;
+    description
+      "Average unidirectional link delay.";
+    reference
+      "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+  }
 
-    identity path-metric-delay-minimum {
-      base path-metric-type;
-      description
-        "Minimum unidirectional link delay.";
-      reference
-        "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-    }
+  identity path-metric-delay-minimum {
+    base path-metric-type;
+    description
+      "Minimum unidirectional link delay.";
+    reference
+      "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+  }
 
-    identity path-metric-residual-bandwidth {
-      base path-metric-type;
-      description
-        "Unidirectional Residual Bandwidth, which is defined to be
-        Maximum Bandwidth (RFC 3630) minus the bandwidth currently
-        allocated to LSPs.";
-      reference
-        "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
-        Version 2
-        RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-    }
+  identity path-metric-residual-bandwidth {
+    base path-metric-type;
+    description
+      "Unidirectional Residual Bandwidth, which is defined to be
+       Maximum Bandwidth (RFC 3630) minus the bandwidth currently
+       allocated to LSPs.";
+    reference
+      "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+       Version 2
+       RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+  }
 
-    identity path-metric-optimize-includes {
-      base path-metric-type;
-      description
-        "A metric that optimizes the number of included resources
-        specified in a set.";
-    }
+  identity path-metric-optimize-includes {
+    base path-metric-type;
+    description
+      "A metric that optimizes the number of included resources
+       specified in a set.";
+  }
 
-    identity path-metric-optimize-excludes {
-      base path-metric-type;
-      description
-        "A metric that optimizes to a maximum the number of excluded
-        resources specified in a set.";
-    }
+  identity path-metric-optimize-excludes {
+    base path-metric-type;
+    description
+      "A metric that optimizes to a maximum the number of excluded
+       resources specified in a set.";
+  }
 
   identity path-tiebreaker-type {
     description
       "Base identity for the path tiebreaker type.";
   }
 
-    identity path-tiebreaker-minfill {
-      base path-tiebreaker-type;
-      description
-        "Min-Fill LSP path placement.";
-    }
+  identity path-tiebreaker-minfill {
+    base path-tiebreaker-type;
+    description
+      "Min-Fill LSP path placement.";
+  }
 
-    identity path-tiebreaker-maxfill {
-      base path-tiebreaker-type;
-      description
-        "Max-Fill LSP path placement.";
-    }
+  identity path-tiebreaker-maxfill {
+    base path-tiebreaker-type;
+    description
+      "Max-Fill LSP path placement.";
+  }
 
-    identity path-tiebreaker-random {
-      base path-tiebreaker-type;
-      description
-        "Random LSP path placement.";
-    }
+  identity path-tiebreaker-random {
+    base path-tiebreaker-type;
+    description
+      "Random LSP path placement.";
+  }
 
   identity resource-affinities-type {
     description
@@ -2117,37 +2132,37 @@ module ietf-te-types {
       "RFC 2702: Requirements for Traffic Engineering Over MPLS";
   }
 
-    identity resource-aff-include-all {
-      base resource-affinities-type;
-      description
-        "The set of attribute filters associated with a
-        tunnel, all of which must be present for a link
-        to be acceptable.";
-      reference
-        "RFC 2702: Requirements for Traffic Engineering Over MPLS
-        RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
-    }
+  identity resource-aff-include-all {
+    base resource-affinities-type;
+    description
+      "The set of attribute filters associated with a
+       tunnel, all of which must be present for a link
+       to be acceptable.";
+    reference
+      "RFC 2702: Requirements for Traffic Engineering Over MPLS
+       RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
+  }
 
-    identity resource-aff-include-any {
-      base resource-affinities-type;
-      description
-        "The set of attribute filters associated with a
-        tunnel, any of which must be present for a link
-        to be acceptable.";
-      reference
-        "RFC 2702: Requirements for Traffic Engineering Over MPLS
-        RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
-    }
+  identity resource-aff-include-any {
+    base resource-affinities-type;
+    description
+      "The set of attribute filters associated with a
+       tunnel, any of which must be present for a link
+       to be acceptable.";
+    reference
+      "RFC 2702: Requirements for Traffic Engineering Over MPLS
+       RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
+  }
 
-    identity resource-aff-exclude-any {
-      base resource-affinities-type;
-      description
-        "The set of attribute filters associated with a
-        tunnel, any of which renders a link unacceptable.";
-      reference
-        "RFC 2702: Requirements for Traffic Engineering Over MPLS
-        RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
-    }
+  identity resource-aff-exclude-any {
+    base resource-affinities-type;
+    description
+      "The set of attribute filters associated with a
+       tunnel, any of which renders a link unacceptable.";
+    reference
+      "RFC 2702: Requirements for Traffic Engineering Over MPLS
+       RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
+  }
 
   identity te-optimization-criterion {
     description
@@ -2157,58 +2172,58 @@ module ietf-te-types {
        Engineering";
   }
 
-    identity not-optimized {
-      base te-optimization-criterion;
-      description
-        "Optimization is not applied.";
-    }
+  identity not-optimized {
+    base te-optimization-criterion;
+    description
+      "Optimization is not applied.";
+  }
 
-    identity cost {
-      base te-optimization-criterion;
-      description
-        "Optimized on cost.";
-      reference
-        "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP)";
-    }
+  identity cost {
+    base te-optimization-criterion;
+    description
+      "Optimized on cost.";
+    reference
+      "RFC 5541: Encoding of Objective Functions in the Path
+       Computation Element Communication Protocol (PCEP)";
+  }
 
-    identity delay {
-      base te-optimization-criterion;
-      description
-        "Optimized on delay.";
-      reference
-        "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP)";
-    }
+  identity delay {
+    base te-optimization-criterion;
+    description
+      "Optimized on delay.";
+    reference
+      "RFC 5541: Encoding of Objective Functions in the Path
+       Computation Element Communication Protocol (PCEP)";
+  }
 
   identity path-computation-srlg-type {
     description
       "Base identity for SRLG path computation.";
   }
 
-    identity srlg-ignore {
-      base path-computation-srlg-type;
-      description
-        "Ignores SRLGs in the path computation.";
-    }
+  identity srlg-ignore {
+    base path-computation-srlg-type;
+    description
+      "Ignores SRLGs in the path computation.";
+  }
 
-    identity srlg-strict {
-      base path-computation-srlg-type;
-      description
-        "Includes a strict SRLG check in the path computation.";
-    }
+  identity srlg-strict {
+    base path-computation-srlg-type;
+    description
+      "Includes a strict SRLG check in the path computation.";
+  }
 
-    identity srlg-preferred {
-      base path-computation-srlg-type;
-      description
-        "Includes a preferred SRLG check in the path computation.";
-    }
+  identity srlg-preferred {
+    base path-computation-srlg-type;
+    description
+      "Includes a preferred SRLG check in the path computation.";
+  }
 
-    identity srlg-weighted {
-      base path-computation-srlg-type;
-      description
-        "Includes a weighted SRLG check in the path computation.";
-    }
+  identity srlg-weighted {
+    base path-computation-srlg-type;
+    description
+      "Includes a weighted SRLG check in the path computation.";
+  }
 
   // NOTE: The base identity path-computation-error-reason and 
   // its derived identities below have been


### PR DESCRIPTION
Updated as proposed in https://mailarchive.ietf.org/arch/msg/teas/LM9Ax6HFC4_-BUJDNqpvtOck2t8/:
- Added svec-objective-function-type;
- Moved svec-metric-type from path-comutation YANG;
- Obsoleted of-minimize-agg-bandwidth-consumption (MBC), of-minimize-load-most-loaded-link (MLL) and of-minimize-cost-path-set (MCC) path objective functions

Added description of the changes done to RFC8776

Fix #193 
