### PR TITLE
Preparation for v10 of RFC8776-bis

### DIFF
--- a/drafts/te-types-update/diffs/te-pkt-types/model-diff-spaces.txt
+++ b/drafts/te-types-update/diffs/te-pkt-types/model-diff-spaces.txt
@@ -33,31 +33,33 @@
     <      the license terms contained in, the Simplified BSD License set
     ---
     >      the license terms contained in, the Revised BSD License set
-    51,52c61,80
+    51,52c61,82
     <      This version of this YANG module is part of RFC 8776; see the
     <      RFC itself for full legal notices.";
     ---
     >      This version of this YANG module is part of RFC XXXX
     >      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
     >      for full legal notices.";
-    >   revision 2024-01-25 {
+    >   revision 2024-02-16 {
     >     description
-    >       "Added common TE packet identities:
+    >       "This revision adds the following new identities:
     >        - bandwidth-profile-type;
-    >        - path-metric-loss;
-    >        - path-metric-delay-variation.
+    >        - link-metric-delay-variation;
+    >        - link-metric-loss;
+    >        - path-metric-delay-variation;
+    >        - path-metric-loss.
     > 
-    >        Added common TE packet groupings:
+    >       This revision adds the following new groupings:
     >        - te-packet-path-bandwidth;
     >        - te-packet-link-bandwidth.
     >        
-    >        Updated module description.";
+    >       This revision provides also few editorial changes.";
     >     reference
     >       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
     >   }
     >   // RFC Editor: replace XXXX with actual RFC number, update date
     >   // information and remove this note
-    61c89,187
+    61c91,196
     <   /**
     ---
     >   /*
@@ -106,65 +108,72 @@
     >         Marker with Efficient Handling of in-Profile Traffic";
     >     }
     > 
-    >   // CHANGE NOTE: The identity path-metric-loss below has 
-    >   // been added in this module revision
-    >   // RFC Editor: remove the note above and this note
-    >   identity path-metric-loss {
-    >     base te-types:path-metric-type;
-    >     description
-    >       "The path loss (as a packet percentage) metric type
-    >       encodes a function of the unidirectional loss metrics of all
-    >       links traversed by a P2P path.
-    >        
-    >       The basic unit is 0.000003%,
-    >       where (2^24 - 2) or 50.331642% is the maximum value of the
-    >       path loss percentage that can be expressed.
-    >       
-    >       Values that are larger than the maximum value SHOULD be
-    >       encoded as the maximum value.";
-    >     reference
-    >       "RFC8233: Extensions to the Path Computation Element
-    >       Communication Protocol (PCEP) to Compute Service-Aware Label
-    >       Switched Paths (LSPs);
+    >     // CHANGE NOTE: The identity link-metric-delay-variation
+    >     // below has been added in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity link-metric-delay-variation {
+    >       base te-types:link-metric-type;
+    >       description
+    >         "The Unidirectional Delay Variation Metric,
+    >         measured in units of microseconds.";
+    >       reference
+    >         "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+    >         section 4.3
     > 
-    >       RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
+    >         RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+    >         section 4.3";
+    >     }
     > 
-    >       RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
-    >   }
+    >     // CHANGE NOTE: The identity link-metric-loss below has 
+    >     // been added in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity link-metric-loss {
+    >       base te-types:link-metric-type;
+    >       description
+    >         "The Unidirectional Link Loss Metric,
+    >         measured in units of 0.000003%.";
+    >       reference
+    >         "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+    >         section 4.4
     > 
-    >   // CHANGE NOTE: The identity path-metric-delay-variation below has 
-    >   // been added in this module revision
-    >   // RFC Editor: remove the note above and this note
-    >   identity path-metric-delay-variation {
-    >     base te-types:path-metric-type;
-    >     description
-    >       "The path delay variation encodes the sum of the unidirectional
-    >       delay variation metrics of all links traversed by a P2P path.
-    >       
-    >       The path delay variation metric unit is in microseconds, where
-    >       (2^24 - 1) or 16,777,215 microseconds (16.777215 sec) is the
-    >       maximum value of the path delay variation that can be
-    >       expressed.
-    >       
-    >       Values that are larger than the maximum value SHOULD be
-    >       encoded as the maximum value.";
-    >     reference
-    >       "RFC8233: Extensions to the Path Computation Element
-    >       Communication Protocol (PCEP) to Compute Service-Aware Label
-    >       Switched Paths (LSPs);
+    >         RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+    >         section 4.4";
+    >     }
     > 
-    >       RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
+    >     // CHANGE NOTE: The identity path-metric-delay-variation
+    >     // below has been added in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity path-metric-delay-variation {
+    >       base te-types:path-metric-type;
+    >       description
+    >         "The Path Delay Variation Metric,
+    >         measured in units of microseconds.";
+    >       reference
+    >         "RFC8233: Extensions to the Path Computation Element
+    >         Communication Protocol (PCEP) to Compute Service-Aware Label
+    >         Switched Paths (LSPs), section 3.1.2";
+    >     }
     > 
-    >       RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
-    >   }
+    >     // CHANGE NOTE: The identity path-metric-loss below has 
+    >     // been added in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity path-metric-loss {
+    >       base te-types:path-metric-type;
+    >       description
+    >         "The Path Loss Metric, measured in units of 0.000003%.";
+    >       reference
+    >         "RFC8233: Extensions to the Path Computation Element
+    >         Communication Protocol (PCEP) to Compute Service-Aware Label
+    >         Switched Paths (LSPs), section 3.1.3";
+    >     }
     > 
     >   /*
-    180a307,310
+    180a316,319
     >   /*
     >    * Groupings
     >    */
     > 
-    472a603,672
+    472a612,681
     >     }
     >   }
     > 

--- a/drafts/te-types-update/diffs/te-pkt-types/model-diff.txt
+++ b/drafts/te-types-update/diffs/te-pkt-types/model-diff.txt
@@ -33,31 +33,33 @@
 <      the license terms contained in, the Simplified BSD License set
 ---
 >      the license terms contained in, the Revised BSD License set
-51,52c61,80
+51,52c61,82
 <      This version of this YANG module is part of RFC 8776; see the
 <      RFC itself for full legal notices.";
 ---
 >      This version of this YANG module is part of RFC XXXX
 >      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
 >      for full legal notices.";
->   revision 2024-01-25 {
+>   revision 2024-02-16 {
 >     description
->       "Added common TE packet identities:
+>       "This revision adds the following new identities:
 >        - bandwidth-profile-type;
->        - path-metric-loss;
->        - path-metric-delay-variation.
+>        - link-metric-delay-variation;
+>        - link-metric-loss;
+>        - path-metric-delay-variation;
+>        - path-metric-loss.
 > 
->        Added common TE packet groupings:
+>       This revision adds the following new groupings:
 >        - te-packet-path-bandwidth;
 >        - te-packet-link-bandwidth.
 >        
->        Updated module description.";
+>       This revision provides also few editorial changes.";
 >     reference
 >       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
 >   }
 >   // RFC Editor: replace XXXX with actual RFC number, update date
 >   // information and remove this note
-61c89,187
+61c91,196
 <   /**
 ---
 >   /*
@@ -106,65 +108,72 @@
 >         Marker with Efficient Handling of in-Profile Traffic";
 >     }
 > 
->   // CHANGE NOTE: The identity path-metric-loss below has 
->   // been added in this module revision
->   // RFC Editor: remove the note above and this note
->   identity path-metric-loss {
->     base te-types:path-metric-type;
->     description
->       "The path loss (as a packet percentage) metric type
->       encodes a function of the unidirectional loss metrics of all
->       links traversed by a P2P path.
->        
->       The basic unit is 0.000003%,
->       where (2^24 - 2) or 50.331642% is the maximum value of the
->       path loss percentage that can be expressed.
->       
->       Values that are larger than the maximum value SHOULD be
->       encoded as the maximum value.";
->     reference
->       "RFC8233: Extensions to the Path Computation Element
->       Communication Protocol (PCEP) to Compute Service-Aware Label
->       Switched Paths (LSPs);
+>     // CHANGE NOTE: The identity link-metric-delay-variation
+>     // below has been added in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity link-metric-delay-variation {
+>       base te-types:link-metric-type;
+>       description
+>         "The Unidirectional Delay Variation Metric,
+>         measured in units of microseconds.";
+>       reference
+>         "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+>         section 4.3
 > 
->       RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
+>         RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+>         section 4.3";
+>     }
 > 
->       RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
->   }
+>     // CHANGE NOTE: The identity link-metric-loss below has 
+>     // been added in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity link-metric-loss {
+>       base te-types:link-metric-type;
+>       description
+>         "The Unidirectional Link Loss Metric,
+>         measured in units of 0.000003%.";
+>       reference
+>         "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+>         section 4.4
 > 
->   // CHANGE NOTE: The identity path-metric-delay-variation below has 
->   // been added in this module revision
->   // RFC Editor: remove the note above and this note
->   identity path-metric-delay-variation {
->     base te-types:path-metric-type;
->     description
->       "The path delay variation encodes the sum of the unidirectional
->       delay variation metrics of all links traversed by a P2P path.
->       
->       The path delay variation metric unit is in microseconds, where
->       (2^24 - 1) or 16,777,215 microseconds (16.777215 sec) is the
->       maximum value of the path delay variation that can be
->       expressed.
->       
->       Values that are larger than the maximum value SHOULD be
->       encoded as the maximum value.";
->     reference
->       "RFC8233: Extensions to the Path Computation Element
->       Communication Protocol (PCEP) to Compute Service-Aware Label
->       Switched Paths (LSPs);
+>         RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+>         section 4.4";
+>     }
 > 
->       RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
+>     // CHANGE NOTE: The identity path-metric-delay-variation
+>     // below has been added in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity path-metric-delay-variation {
+>       base te-types:path-metric-type;
+>       description
+>         "The Path Delay Variation Metric,
+>         measured in units of microseconds.";
+>       reference
+>         "RFC8233: Extensions to the Path Computation Element
+>         Communication Protocol (PCEP) to Compute Service-Aware Label
+>         Switched Paths (LSPs), section 3.1.2";
+>     }
 > 
->       RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
->   }
+>     // CHANGE NOTE: The identity path-metric-loss below has 
+>     // been added in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity path-metric-loss {
+>       base te-types:path-metric-type;
+>       description
+>         "The Path Loss Metric, measured in units of 0.000003%.";
+>       reference
+>         "RFC8233: Extensions to the Path Computation Element
+>         Communication Protocol (PCEP) to Compute Service-Aware Label
+>         Switched Paths (LSPs), section 3.1.3";
+>     }
 > 
 >   /*
-180a307,310
+180a316,319
 >   /*
 >    * Groupings
 >    */
 > 
-472a603,672
+472a612,681
 >     }
 >   }
 > 

--- a/drafts/te-types-update/diffs/te-pkt-types/model-updates.txt
+++ b/drafts/te-types-update/diffs/te-pkt-types/model-updates.txt
@@ -33,31 +33,33 @@
     <      the license terms contained in, the Simplified BSD License set
     ---
     >      the license terms contained in, the Revised BSD License set
-    51,52c61,80
+    51,52c61,82
     <      This version of this YANG module is part of RFC 8776; see the
     <      RFC itself for full legal notices.";
     ---
     >      This version of this YANG module is part of RFC XXXX
     >      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
     >      for full legal notices.";
-    >   revision 2024-01-25 {
+    >   revision 2024-02-16 {
     >     description
-    >       "Added common TE packet identities:
+    >       "This revision adds the following new identities:
     >        - bandwidth-profile-type;
-    >        - path-metric-loss;
-    >        - path-metric-delay-variation.
+    >        - link-metric-delay-variation;
+    >        - link-metric-loss;
+    >        - path-metric-delay-variation;
+    >        - path-metric-loss.
     > 
-    >        Added common TE packet groupings:
+    >       This revision adds the following new groupings:
     >        - te-packet-path-bandwidth;
     >        - te-packet-link-bandwidth.
     >        
-    >        Updated module description.";
+    >       This revision provides also few editorial changes.";
     >     reference
     >       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
     >   }
     >   // RFC Editor: replace XXXX with actual RFC number, update date
     >   // information and remove this note
-    61c89,187
+    61c91,196
     <   /**
     ---
     >   /*
@@ -106,65 +108,72 @@
     >         Marker with Efficient Handling of in-Profile Traffic";
     >     }
     > 
-    >   // CHANGE NOTE: The identity path-metric-loss below has 
-    >   // been added in this module revision
-    >   // RFC Editor: remove the note above and this note
-    >   identity path-metric-loss {
-    >     base te-types:path-metric-type;
-    >     description
-    >       "The path loss (as a packet percentage) metric type
-    >       encodes a function of the unidirectional loss metrics of all
-    >       links traversed by a P2P path.
-    >        
-    >       The basic unit is 0.000003%,
-    >       where (2^24 - 2) or 50.331642% is the maximum value of the
-    >       path loss percentage that can be expressed.
-    >       
-    >       Values that are larger than the maximum value SHOULD be
-    >       encoded as the maximum value.";
-    >     reference
-    >       "RFC8233: Extensions to the Path Computation Element
-    >       Communication Protocol (PCEP) to Compute Service-Aware Label
-    >       Switched Paths (LSPs);
+    >     // CHANGE NOTE: The identity link-metric-delay-variation
+    >     // below has been added in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity link-metric-delay-variation {
+    >       base te-types:link-metric-type;
+    >       description
+    >         "The Unidirectional Delay Variation Metric,
+    >         measured in units of microseconds.";
+    >       reference
+    >         "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+    >         section 4.3
     > 
-    >       RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
+    >         RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+    >         section 4.3";
+    >     }
     > 
-    >       RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
-    >   }
+    >     // CHANGE NOTE: The identity link-metric-loss below has 
+    >     // been added in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity link-metric-loss {
+    >       base te-types:link-metric-type;
+    >       description
+    >         "The Unidirectional Link Loss Metric,
+    >         measured in units of 0.000003%.";
+    >       reference
+    >         "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+    >         section 4.4
     > 
-    >   // CHANGE NOTE: The identity path-metric-delay-variation below has 
-    >   // been added in this module revision
-    >   // RFC Editor: remove the note above and this note
-    >   identity path-metric-delay-variation {
-    >     base te-types:path-metric-type;
-    >     description
-    >       "The path delay variation encodes the sum of the unidirectional
-    >       delay variation metrics of all links traversed by a P2P path.
-    >       
-    >       The path delay variation metric unit is in microseconds, where
-    >       (2^24 - 1) or 16,777,215 microseconds (16.777215 sec) is the
-    >       maximum value of the path delay variation that can be
-    >       expressed.
-    >       
-    >       Values that are larger than the maximum value SHOULD be
-    >       encoded as the maximum value.";
-    >     reference
-    >       "RFC8233: Extensions to the Path Computation Element
-    >       Communication Protocol (PCEP) to Compute Service-Aware Label
-    >       Switched Paths (LSPs);
+    >         RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+    >         section 4.4";
+    >     }
     > 
-    >       RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
+    >     // CHANGE NOTE: The identity path-metric-delay-variation
+    >     // below has been added in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity path-metric-delay-variation {
+    >       base te-types:path-metric-type;
+    >       description
+    >         "The Path Delay Variation Metric,
+    >         measured in units of microseconds.";
+    >       reference
+    >         "RFC8233: Extensions to the Path Computation Element
+    >         Communication Protocol (PCEP) to Compute Service-Aware Label
+    >         Switched Paths (LSPs), section 3.1.2";
+    >     }
     > 
-    >       RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
-    >   }
+    >     // CHANGE NOTE: The identity path-metric-loss below has 
+    >     // been added in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity path-metric-loss {
+    >       base te-types:path-metric-type;
+    >       description
+    >         "The Path Loss Metric, measured in units of 0.000003%.";
+    >       reference
+    >         "RFC8233: Extensions to the Path Computation Element
+    >         Communication Protocol (PCEP) to Compute Service-Aware Label
+    >         Switched Paths (LSPs), section 3.1.3";
+    >     }
     > 
     >   /*
-    180a307,310
+    180a316,319
     >   /*
     >    * Groupings
     >    */
     > 
-    472a603,672
+    472a612,681
     >     }
     >   }
     > 

--- a/drafts/te-types-update/diffs/te-types/model-diff-spaces.txt
+++ b/drafts/te-types-update/diffs/te-types/model-diff-spaces.txt
@@ -21,61 +21,134 @@
     <      the license terms contained in, the Simplified BSD License set
     ---
     >      the license terms contained in, the Revised BSD License set
-    65,66c75,113
+    65,66c75,164
     <      This version of this YANG module is part of RFC 8776; see the
     <      RFC itself for full legal notices.";
     ---
     >      This version of this YANG module is part of RFC XXXX
     >      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
     >      for full legal notices.";
-    >   revision 2024-01-29 {
+    >   revision 2024-02-16 {
     >     description
-    >       "Added:
-    >       - base identity lsp-provisioning-error-reason;
-    >       - identity association-type-diversity;
-    >       - identity tunnel-admin-state-auto;
-    >       - identity lsp-restoration-restore-none;
-    >       - identity restoration-scheme-rerouting;
-    >       - base identity path-computation-error-reason and
-    >         its derived identities;
-    >       - base identity protocol-origin-type and
-    >         its derived identities;
-    >       - base identity svec-objective-function-type and its derived
-    >         identities;
-    >       - base identity svec-metric-type and its derived identities;
-    >       - grouping encoding-and-switching-type.
-    >       
-    >       Updated:
-    >       - description of the base identity objective-function-type;
-    >       - description and reference of identity action-exercise;
-    >       - typedef te-node-id to support also 16 octects TE identifiers.
-    >       
-    >       Obsoleted:
-    >       - identity of-minimize-agg-bandwidth-consumption;
-    >       - identity of-minimize-load-most-loaded-link;
-    >       - identity of-minimize-cost-path-set;
-    >       - identity lsp-protection-reroute-extra;
-    >       - identity lsp-protection-reroute.
+    >       "This revision adds the following new identities:
+    >       - lsp-provisioning-error-reason;
+    >       - association-type-diversity;
+    >       - tunnel-admin-state-auto;
+    >       - lsp-restoration-restore-none;
+    >       - restoration-scheme-rerouting;
+    >       - path-metric-optimization-type;
+    >       - link-path-metric-type;
+    >       - link-metric-type and its derived identities;
+    >       - path-computation-error-reason and its derived identities;
+    >       - protocol-origin-type and its derived identities;
+    >       - svec-objective-function-type and its derived identities;
+    >       - svec-metric-type and its derived identities.
     > 
-    >       Container explicit-route-objects-always renamed as
-    >       explicit-route-objects.";
+    >       This revision adds the following new data types:
+    >       - path-type;
+    >       - te-gen-node-id.
+    > 
+    >       This revision adds the following new groupings:
+    >       - encoding-and-switching-type;
+    >       - te-generic-node-id.
+    > 
+    >       This revision updates the following identities:
+    >       - objective-function-type;
+    >       - action-exercise;
+    >       - path-metric-type;
+    >       - path-metric-te;
+    >       - path-metric-igp;
+    >       - path-metric-hop;
+    >       - path-metric-delay-average;
+    >       - path-metric-delay-minimum;
+    >       - path-metric-residual-bandwidth;
+    >       - path-metric-optimize-includes;
+    >       - path-metric-optimize-excludes;
+    >       - te-optimization-criterion.
+    > 
+    >       This revision updates the following data types:
+    >       - te-node-id.
+    > 
+    >       This revision updates the following groupings:
+    >       - explicit-route-hop:
+    >         - adds the following leaves:
+    >           - node-id-uri;
+    >           - link-tp-id-uri;
+    >         - updates the following leaves:
+    >           - node-id;
+    >           - link-tp-id;
+    >       - record-route-state:
+    >         - adds the following leaves:
+    >           - node-id-uri;
+    >           - link-tp-id-uri;
+    >         - updates the following leaves:
+    >           - node-id;
+    >           - link-tp-id;
+    >       - optimization-metric-entry:
+    >         - updates the following leaves:
+    >           - metric-type;
+    >       - tunnel-constraints;
+    >         - adds the following leaves:
+    >           - network-id;
+    >       - path-constraints-route-objects:
+    >         - updates the following containers:
+    >           - explicit-route-objects-always;
+    >       - generic-path-metric-bounds:
+    >         - updates the following leaves:
+    >           - metric-type;
+    >       - generic-path-optimization
+    >         - adds the following leaves:
+    >           - tiebreaker;
+    >         - deprecate the following containers:
+    >           - tiebreakers.
+    > 
+    >       This revision obsoletes the following identities:
+    >       - of-minimize-agg-bandwidth-consumption;
+    >       - of-minimize-load-most-loaded-link;
+    >       - of-minimize-cost-path-set;
+    >       - lsp-protection-reroute-extra;
+    >       - lsp-protection-reroute.
+    > 
+    >       This revision provides also few editorial changes.";
     >     reference
     >       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
     >   }
     >   // RFC Editor: replace XXXX with actual RFC number, update date
     >   // information and remove this note
-    351a399,401
+    70c168
+    <       "Latest revision of TE types.";
+    ---
+    >       "Initial Version of TE types.";
+    86a185
+    > 
+    92a192
+    > 
+    93a194
+    >        
+    111a213
+    > 
+    155a258
+    > 
+    158a262
+    > 
+    263a368
+    > 
+    264a370
+    > 
+    269a376
+    > 
+    351a459,461
     >   // CHANGE NOTE: The typedef te-node-id below has been
     >   // updated in this module revision
     >   // RFC Editor: remove the note above and this note
-    353c403,406
+    353c463,466
     <     type yang:dotted-quad;
     ---
     >     type union {
     >       type yang:dotted-quad;
     >       type inet:ipv6-address-no-zone;
     >     }
-    357,358c410,414
+    357,358c470,474
     <        The identifier is represented as 4 octets in dotted-quad
     <        notation.
     ---
@@ -84,7 +157,7 @@
     >        dotted-quad notation or 16 octets in full, mixed, shortened,
     >        or shortened-mixed IPv6 address notation.
     > 
-    362,363c418,421
+    362,363c478,481
     <        Router ID TLV described in Section 4.3 of RFC 5305, or the
     <        TE Router ID TLV described in Section 3.2.1 of RFC 6119.
     ---
@@ -92,13 +165,17 @@
     >        Router ID TLV described in Section 3.2.1 of RFC 6119, or the
     >        IPv6 TE Router ID TLV described in Section 4.1 of RFC 6119.
     > 
-    368a427
+    368a487
     > 
-    370a430
+    370a490
     > 
-    371a432
+    371a492
     > 
-    545a607,647
+    519a641
+    > 
+    537a660
+    > 
+    545a669,709
     >   // CHANGE NOTE: The typedef path-type below has been
     >   // added in this module revision
     >   // RFC Editor: remove the note above and this note
@@ -140,7 +217,7 @@
     >       "Generic type that identifies a node in a TE topology.";
     >   }
     > 
-    606a709,716
+    606a771,778
     >   // CHANGE NOTE: The base identity lsp-provisioning-error-reason 
     >   // has been added in this module revision
     >   // RFC Editor: remove the note above and this note
@@ -149,7 +226,7 @@
     >       "Base identity for LSP provisioning errors.";
     >   }
     > 
-    982a1093,1110
+    982a1155,1172
     >   // CHANGE NOTE: The identity association-type-diversity below has 
     >   // been added in this module revision
     >   // RFC Editor: remove the note above and this note
@@ -159,7 +236,7 @@
     >       "Association Type diversity used to associate LSPs whose 
     >       paths are to be diverse from each other.";
     >     reference
-    >       "RFC8800: Path Computation Element Communication Protocol 
+    >       "RFC 8800: Path Computation Element Communication Protocol 
     >       (PCEP) Extension for Label Switched Path (LSP) Diversity 
     >       Constraint Signaling";
     >   }
@@ -168,45 +245,92 @@
     >   // objective-function-type has been updated 
     >   // in this module revision
     >   // RFC Editor: remove the note above and this note
-    985c1113
+    985c1175
     <       "Base objective function type.";
     ---
-    >       "Base identity for path objective function type.";
-    1015a1144,1146
+    >       "Base identity for path objective function types.";
+    1015a1206,1208
     >   // CHANGE NOTE: The identity of-minimize-agg-bandwidth-consumption
     >   // below has been obsoleted in this module revision
     >   // RFC Editor: remove the note above and this note
-    1017a1149
+    1017a1211
     >     status obsolete;
-    1020c1152
+    1020c1214,1218
     <        consumption.";
     ---
-    >       consumption.";
-    1023c1155
+    >       consumption.
+    >       
+    >       This identity has been obsoleted: the
+    >       'svec-of-minimize-agg-bandwidth-consumption' identity SHOULD
+    >       be used instead.";
+    1023c1221
     <        Computation Element Communication Protocol (PCEP)";
     ---
     >       Computation Element Communication Protocol (PCEP)";
-    1025a1158,1160
+    1025a1224,1226
     >   // CHANGE NOTE: The identity of-minimize-load-most-loaded-link
     >   // below has been obsoleted in this module revision
     >   // RFC Editor: remove the note above and this note
-    1027a1163
+    1027a1229
     >     status obsolete;
-    1030c1166
+    1030c1232,1236
     <        is carrying the highest load.";
     ---
-    >       is carrying the highest load.";
-    1033c1169
+    >       is carrying the highest load.
+    >       
+    >       This identity has been obsoleted: the
+    >       'svec-of-minimize-load-most-loaded-link' identity SHOULD
+    >       be used instead.";
+    1033c1239
     <        Computation Element Communication Protocol (PCEP)";
     ---
     >       Computation Element Communication Protocol (PCEP)";
-    1035a1172,1174
+    1035a1242,1244
     >   // CHANGE NOTE: The identity of-minimize-cost-path-set
     >   // below has been obsoleted in this module revision
     >   // RFC Editor: remove the note above and this note
-    1037a1177
+    1037a1247
     >     status obsolete;
-    1216a1357,1368
+    1039c1249,1253
+    <       "Objective function for minimizing the cost on a path set.";
+    ---
+    >       "Objective function for minimizing the cost on a path set.
+    >       
+    >       This identity has been obsoleted: the
+    >       'svec-of-minimize-cost-path-set' identity SHOULD
+    >       be used instead.";
+    1049a1264,1266
+    >   // CHANGE NOTE: The reference of the identity path-locally-computed
+    >   // below has been updated in this module revision
+    >   // RFC Editor: remove the note above and this note
+    1056,1057c1273,1274
+    <       "RFC 3272: Overview and Principles of Internet Traffic
+    <        Engineering, Section 5.4";
+    ---
+    >       "RFC 9522: Overview and Principles of Internet Traffic
+    >       Engineering, Section 4.4";
+    1059a1277,1280
+    >   // CHANGE NOTE: The reference of the identity 
+    >   // path-externally-queried below has been updated
+    >   // in this module revision
+    >   // RFC Editor: remove the note above and this note
+    1071c1292
+    <       "RFC 3272: Overview and Principles of Internet Traffic
+    ---
+    >       "RFC 9522: Overview and Principles of Internet Traffic
+    1072a1294
+    > 
+    1076a1299,1302
+    >   // CHANGE NOTE: The reference of the identity 
+    >   // path-explicitly-defined below has been updated
+    >   // in this module revision
+    >   // RFC Editor: remove the note above and this note
+    1085c1311,1312
+    <        RFC 3272: Overview and Principles of Internet Traffic
+    ---
+    > 
+    >        RFC 9522: Overview and Principles of Internet Traffic
+    1216a1444,1455
     >   // CHANGE NOTE: The identity tunnel-admin-state-auto below
     >   // has been added in this module revision
     >   // RFC Editor: remove the note above and this note
@@ -219,7 +343,7 @@
     >       when it is not used by the client layer.";
     >   }
     > 
-    1321a1474,1482
+    1321a1561,1569
     >     // CHANGE NOTE: The identity lsp-restoration-restore-none 
     >     // below has been added in this module revision
     >     // RFC Editor: remove the note above and this note
@@ -229,7 +353,7 @@
     >         "No LSP affected by a failure is restored.";
     >     }
     > 
-    1339a1501,1515
+    1339a1588,1602
     >     // CHANGE NOTE: The identity restoration-scheme-rerouting 
     >     // below has been added in this module revision
     >     // RFC Editor: remove the note above and this note
@@ -245,13 +369,13 @@
     >         for Generalized Multi-Protocol Label Switching (GMPLS)";
     >     }
     > 
-    1383a1560,1562
+    1383a1647,1649
     >   // CHANGE NOTE: The identity lsp-protection-reroute-extra
     >   // below has been obsoleted in this module revision
     >   // RFC Editor: remove the note above and this note
-    1385a1565
+    1385a1652
     >     status obsolete;
-    1387c1567,1571
+    1387c1654,1658
     <       "'(Full) Rerouting' LSP protection type.";
     ---
     >       "'(Full) Rerouting' LSP protection type.
@@ -259,13 +383,13 @@
     >       This identity has been obsoleted: the
     >       'restoration-scheme-rerouting' identity SHOULD be used
     >       instead.";
-    1392a1577,1579
+    1392a1664,1666
     >   // CHANGE NOTE: The identity lsp-protection-reroute
     >   // below has been obsoleted in this module revision
     >   // RFC Editor: remove the note above and this note
-    1394a1582
+    1394a1669
     >     status obsolete;
-    1396c1584,1588
+    1396c1671,1675
     <       "'Rerouting without Extra-Traffic' LSP protection type.";
     ---
     >       "'Rerouting without Extra-Traffic' LSP protection type.
@@ -273,46 +397,327 @@
     >       This identity has been obsoleted: the
     >       'restoration-scheme-rerouting' identity SHOULD be used
     >       instead.";
-    1628a1821,1824
+    1628a1908,1911
     >   // CHANGE NOTE: The description and reference of the 
     >   // identity action-exercise have been updated in this module 
     >   // revision
     >   // RFC Editor: remove the note above and this note
-    1632,1633c1828,1830
+    1632,1633c1915,1917
     <       "An action that starts testing whether or not APS communication
     <        is operating correctly.  It is of lower priority than any
     ---
     >       "An action that starts testing whether or not Automatic 
     >        Protection Switching (APS) communication is operating 
     >        correctly.  It is of lower priority than any
-    1636,1637c1833,1834
+    1636,1637c1920,1921
     <       "RFC 4427: Recovery (Protection and Restoration) Terminology
     <        for Generalized Multi-Protocol Label Switching (GMPLS)";
     ---
     >       "ITU-T G.808.1 v4.0 (05/2014): Generic protection switching - 
     >       Linear trail and subnetwork protection";
-    1916a2114,2116
-    >   // CHANGE NOTE: The description of the identity path-metric-type
-    >   // has been updated in this module revision
-    >   // RFC Editor: remove the note above and this note
-    1919c2119,2122
-    <       "Base identity for the path metric type.";
+    1917c2201,2204
+    <   identity path-metric-type {
     ---
-    >       "Base identity for the path metric type.
-    >       
-    >       Derived identities SHOULD describe the unit and maximum value
-    >       of the path metric types they define.";
-    1939a2143,2145
-    >   // CHANGE NOTE: The reference for the identity path-metric-hop
+    >   // CHANGE NOTE: The path-metric-optimization-type base identity
     >   // has been added in this module revision
     >   // RFC Editor: remove the note above and this note
-    1943a2150,2152
-    >     reference
-    >       "RFC5440: Path Computation Element (PCE) Communication
-    >       Protocol (PCEP)";
-    1945a2155
+    >   identity path-metric-optimization-type {
+    1919c2206,2207
+    <       "Base identity for the path metric type.";
+    ---
+    >       "Base identity used to define the path metric optimization
+    >       types.";
+    1922,1923c2210,2213
+    <   identity path-metric-te {
+    <     base path-metric-type;
+    ---
+    >   // CHANGE NOTE: The link-path-metric-type base identity
+    >   // has been added in this module revision
+    >   // RFC Editor: remove the note above and this note
+    >   identity link-path-metric-type {
+    1925,1928c2215,2221
+    <       "TE path metric.";
+    <     reference
+    <       "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+    <        second MPLS Traffic Engineering (TE) Metric";
+    ---
+    >       "Base identity used to define the link and the path metric
+    >       types.
+    >       
+    >       The unit of the path metric value is interpreted in the
+    >       context of the path metric type and the derived identities
+    >       SHOULD describe the unit of the path metric types they
+    >       define.";
+    1931,1938c2224,2232
+    <   identity path-metric-igp {
+    <     base path-metric-type;
+    <     description
+    <       "IGP path metric.";
+    <     reference
+    <       "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+    <        second MPLS Traffic Engineering (TE) Metric";
+    <   }
+    ---
+    >     // CHANGE NOTE: The link-metric-type base identity
+    >     // and its derived identities
+    >     // have been added in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity link-metric-type {
+    >       base link-path-metric-type;
+    >       description
+    >         "Base identity for the link metric types.";
+    >     }
+    1940,1944c2234,2240
+    <   identity path-metric-hop {
+    <     base path-metric-type;
+    <     description
+    <       "Hop path metric.";
+    <   }
+    ---
+    >       identity link-metric-te {
+    >         base link-metric-type;
+    >         description
+    >           "Traffic Engineering (TE) Link Metric.";
+    >         reference
+    >           "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+    >           Version 2, section 2.5.5
+    1946,1952c2242,2244
+    <   identity path-metric-delay-average {
+    <     base path-metric-type;
+    <     description
+    <       "Average unidirectional link delay.";
+    <     reference
+    <       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+    <   }
+    ---
+    >           RFC 5305: IS-IS Extensions for Traffic Engineering,
+    >           section 3.7";
+    >       }
+    1954,1960c2246,2253
+    <   identity path-metric-delay-minimum {
+    <     base path-metric-type;
+    <     description
+    <       "Minimum unidirectional link delay.";
+    <     reference
+    <       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+    <   }
+    ---
+    >       identity link-metric-igp {
+    >         base link-metric-type;
+    >         description
+    >           "Interior Gateway Protocol (IGP) Link Metric.";
+    >         reference
+    >           "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric
+    >           as a second MPLS Traffic Engineering (TE) Metric";
+    >       }
+    1962,1972c2255,2266
+    <   identity path-metric-residual-bandwidth {
+    <     base path-metric-type;
+    <     description
+    <       "Unidirectional Residual Bandwidth, which is defined to be
+    <        Maximum Bandwidth (RFC 3630) minus the bandwidth currently
+    <        allocated to LSPs.";
+    <     reference
+    <       "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+    <        Version 2
+    <        RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+    <   }
+    ---
+    >       identity link-metric-delay-average {
+    >         base link-metric-type;
+    >         description
+    >           "Unidirectional Link Delay, measured in units of
+    >           microseconds.";
+    >         reference
+    >           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+    >           Extensions, section 4.1
+    >           
+    >           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+    >           Extensions, section 4.1";
+    >       }
+    1974,1979c2268,2279
+    <   identity path-metric-optimize-includes {
+    <     base path-metric-type;
+    <     description
+    <       "A metric that optimizes the number of included resources
+    <        specified in a set.";
+    <   }
+    ---
+    >       identity link-metric-delay-minimum {
+    >         base link-metric-type;
+    >         description
+    >           "Minimum unidirectional Link Delay, measured in units of
+    >           microseconds.";
+    >         reference
+    >           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+    >           Extensions, section 4.2
+    >           
+    >           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+    >           Extensions, section 4.2";
+    >       }
+    1981,1986c2281,2425
+    <   identity path-metric-optimize-excludes {
+    <     base path-metric-type;
+    <     description
+    <       "A metric that optimizes to a maximum the number of excluded
+    <        resources specified in a set.";
+    <   }
+    ---
+    >       identity link-metric-delay-maximum {
+    >         base link-metric-type;
+    >         description
+    >           "Maximum unidirectional Link Delay, measured in units of
+    >           microseconds.";
+    >         reference
+    >           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+    >           Extensions, section 4.2
+    >           
+    >           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+    >           Extensions, section 4.2";
+    >       }
     > 
-    2110a2321,2724
+    >       identity link-metric-residual-bandwidth {
+    >         base link-metric-type;
+    >         description
+    >           "Unidirectional Residual Bandwidth, measured in units of
+    >           bytes per second.
+    >           
+    >           It is defined to be Maximum Bandwidth minus the bandwidth
+    >           currently allocated to LSPs.";
+    >         reference
+    >           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+    >           Extensions, section 4.5
+    >           
+    >           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+    >           Extensions, section 4.5";
+    >       }
+    > 
+    >     // CHANGE NOTE: The base and the description of the
+    >     // path-metric-type identity
+    >     // has been updated in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity path-metric-type {
+    >       base link-path-metric-type;
+    >       base path-metric-optimization-type;
+    >       description
+    >         "Base identity for the path metric types.";
+    >     }
+    > 
+    >       // CHANGE NOTE: The description and the reference of the
+    >       // path-metric-te identity have been updated
+    >       // in this module revision
+    >       // RFC Editor: remove the note above and this note
+    >       identity path-metric-te {
+    >         base path-metric-type;
+    >         description
+    >           "Traffic Engineering (TE) Path Metric.";
+    >         reference
+    >           "RFC 5440: Path Computation Element (PCE) Communication
+    >           Protocol (PCEP), section 7.8";
+    >       }
+    > 
+    >       // CHANGE NOTE: The description and the reference of the
+    >       // path-metric-igp identity have been updated 
+    >       // in this module revision
+    >       // RFC Editor: remove the note above and this note
+    >       identity path-metric-igp {
+    >         base path-metric-type;
+    >         description
+    >           "Interior Gateway Protocol (IGP) Path Metric.";
+    >         reference
+    >           "RFC 5440: Path Computation Element (PCE) Communication
+    >           Protocol (PCEP), section 7.8";
+    >       }
+    > 
+    >       // CHANGE NOTE: The description and the reference of the
+    >       // path-metric-hop identity have been updated
+    >       // in this module revision
+    >       // RFC Editor: remove the note above and this note
+    >       identity path-metric-hop {
+    >         base path-metric-type;
+    >         description
+    >           "Hop Count Path Metric.";
+    >         reference
+    >           "RFC 5440: Path Computation Element (PCE) Communication
+    >           Protocol (PCEP), section 7.8";
+    >       }
+    > 
+    >       // CHANGE NOTE: The description and the reference of the
+    >       // path-metric-delay-average identity have been updated
+    >       // in this module revision
+    >       // RFC Editor: remove the note above and this note
+    >       identity path-metric-delay-average {
+    >         base path-metric-type;
+    >         description
+    >           "The Path Delay Metric, measured in units of
+    >           microseconds.";
+    >         reference
+    >           "RFC8233: Extensions to the Path Computation Element
+    >           Communication Protocol (PCEP) to Compute Service-Aware
+    >           Label Switched Paths (LSPs), section 3.1.1";
+    >       }
+    > 
+    >       // CHANGE NOTE: The description and the reference of the
+    >       // path-metric-delay-minimum identity have been updated
+    >       // in this module revision
+    >       // RFC Editor: remove the note above and this note
+    >       identity path-metric-delay-minimum {
+    >         base path-metric-type;
+    >         description
+    >           "The Path Min Delay Metric, measured in units of
+    >           microseconds.";
+    >         reference
+    >           "I-D.ietf-pce-sid-algo: Carrying SR-Algorithm information
+    >           in PCE-based Networks, section 3.5.1";
+    >       }
+    > 
+    >       // CHANGE NOTE: The description and the reference of the
+    >       // path-metric-residual-bandwidth identity have been updated
+    >       // in this module revision
+    >       // RFC Editor: remove the note above and this note
+    >       identity path-metric-residual-bandwidth {
+    >         base path-metric-type;
+    >         description
+    >           "The Path Residual Bandwidth, defined as the minimum Link
+    >           Residual Bandwidth all the links along the path.
+    > 
+    >           The Path Residual Bandwidth can be seen as the path
+    >           metric associated with the Maximum residual Bandwidth Path
+    >           (MBP) objective function.";
+    >         reference
+    >           "RFC 5541: Encoding of Objective Functions in the Path
+    >           Computation Element Communication Protocol (PCEP)";
+    >       }
+    > 
+    >     // CHANGE NOTE: The base of the path-metric-optimize-includes
+    >     // identity has been updated in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity path-metric-optimize-includes {
+    >       base path-metric-optimization-type;
+    >       description
+    >         "A metric that optimizes the number of included resources
+    >         specified in a set.";
+    >     }
+    > 
+    >     // CHANGE NOTE: The base of the path-metric-optimize-excludes
+    >     // identity has been updated in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity path-metric-optimize-excludes {
+    >       base path-metric-optimization-type;
+    >       description
+    >         "A metric that optimizes to a maximum the number of excluded
+    >         resources specified in a set.";
+    >     }
+    2049a2489,2492
+    >   // CHANGE NOTE: The reference of the identity 
+    >   // te-optimization-criterion below has been updated
+    >   // in this module revision
+    >   // RFC Editor: remove the note above and this note
+    2054c2497
+    <       "RFC 3272: Overview and Principles of Internet Traffic
+    ---
+    >       "RFC 9522: Overview and Principles of Internet Traffic
+    2110a2554,2994
     >   // CHANGE NOTE: The base identity path-computation-error-reason 
     >   // and its derived identities below have been
     >   // added in this module revision
@@ -328,8 +733,8 @@
     >         "Path computation has failed because of an unspecified 
     >         reason.";
     >       reference
-    >         "Section 7.5 of RFC5440: Path Computation Element (PCE)
-    >         Communication Protocol (PCEP)";
+    >         "RFC 5440: Path Computation Element (PCE) Communication
+    >         Protocol (PCEP), section 7.5";
     >     }
     > 
     >     identity path-computation-error-no-topology {
@@ -349,7 +754,13 @@
     >         a Backward-Recursive Path Computation (BRPC) downstream
     >         PCE or a child PCE.";
     >       reference
-    >         "RFC5441, RFC8685";
+    >         "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+    >         Procedure to Compute Shortest Constrained Inter-Domain
+    >         Traffic Engineering Label Switched Paths
+    >         
+    >         RFC 8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture";
     >     }
     > 
     >     identity path-computation-error-pce-unavailable {
@@ -360,10 +771,11 @@
     >         It corresponds to bit 31 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC5440: Path Computation Element (PCE) Communication
-    >         Protocol (PCEP);
+    >         "RFC 5440: Path Computation Element (PCE) Communication
+    >         Protocol (PCEP)
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-no-inclusion-hop {
@@ -382,9 +794,12 @@
     >         It corresponds to bit 19 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC8685;
+    >         "RFC 8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-no-resource {
@@ -396,9 +811,12 @@
     >         It corresponds to bit 20 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC8685;
+    >         "RFC 8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-child-pce-unresponsive {
@@ -410,9 +828,12 @@
     >         It corresponds to bit 21 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC8685;
+    >         "RFC 8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-destination-domain-unknown {
@@ -424,9 +845,12 @@
     >         It corresponds to bit 22 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC8685;
+    >         "RFC 8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-p2mp {
@@ -438,9 +862,12 @@
     >         It corresponds to bit 24 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC8306;
+    >         "RFC 8306: Extensions to the Path Computation Element
+    >         Communication Protocol (PCEP) for Point-to-Multipoint
+    >         Traffic Engineering Label Switched Paths
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-no-gco-migration {
@@ -452,9 +879,12 @@
     >         It corresponds to bit 26 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC5557;
+    >         "RFC 5557: Path Computation Element Communication Protocol
+    >         (PCEP) Requirements and Protocol Extensions in Support of
+    >         Global Concurrent Optimization
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-no-gco-solution {
@@ -466,9 +896,12 @@
     >         It corresponds to bit 25 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC5557;
+    >         "RFC 5557: Path Computation Element Communication Protocol
+    >         (PCEP) Requirements and Protocol Extensions in Support of
+    >         Global Concurrent Optimization
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-pks-expansion {
@@ -480,9 +913,12 @@
     >         It corresponds to bit 27 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC5520;
+    >         "RFC 5520: Preserving Topology Confidentiality in
+    >         Inter-Domain Path Computation Using a Path-Key-Based
+    >         Mechanism
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-brpc-chain-unavailable {
@@ -494,9 +930,12 @@
     >         It corresponds to bit 28 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC5441;
+    >         "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+    >         Procedure to Compute Shortest Constrained Inter-Domain
+    >         Traffic Engineering Label Switched Paths
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-source-unknown {
@@ -508,10 +947,11 @@
     >         It corresponds to bit 29 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC5440: Path Computation Element (PCE) Communication
+    >         "RFC 5440: Path Computation Element (PCE) Communication
     >         Protocol (PCEP);
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-destination-unknown {
@@ -523,10 +963,11 @@
     >         It corresponds to bit 30 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC5440: Path Computation Element (PCE) Communication
+    >         "RFC 5440: Path Computation Element (PCE) Communication
     >         Protocol (PCEP);
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-no-server {
@@ -535,10 +976,11 @@
     >         "Path computation has failed because path computation
     >         server is unavailable.";
     >       reference
-    >         "RFC5440: Path Computation Element (PCE) Communication
+    >         "RFC 5440: Path Computation Element (PCE) Communication
     >         Protocol (PCEP);
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >   // CHANGE NOTE: The base identity protocol-origin-type and 
@@ -563,7 +1005,7 @@
     >         "Protocol origin is Path Computation Engine Protocol 
     >         (PCEP).";
     >       reference
-    >         "RFC5440: Path Computation Element (PCE) Communication
+    >         "RFC 5440: Path Computation Element (PCE) Communication
     >         Protocol (PCEP)";
     >     }
     > 
@@ -571,7 +1013,7 @@
     >       base protocol-origin-type;
     >       description
     >         "Protocol origin is Border Gateway Protocol (BGP).";
-    >       reference "RFC9012";
+    >       reference "RFC 9012";
     >     }
     > 
     >   // CHANGE NOTE: The base identity svec-objective-function-type 
@@ -582,8 +1024,8 @@
     >     description
     >       "Base identity for SVEC objective function type.";
     >     reference
-    >       "RFC5541: Encoding of Objective Functions in the Path
-    >        Computation Element Communication Protocol (PCEP).";
+    >       "RFC 5541: Encoding of Objective Functions in the Path
+    >        Computation Element Communication Protocol (PCEP)";
     >   }
     > 
     >     identity svec-of-minimize-agg-bandwidth-consumption {
@@ -592,8 +1034,8 @@
     >         "Objective function for minimizing aggregate bandwidth 
     >         consumption (MBC).";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
     >     identity svec-of-minimize-load-most-loaded-link {
@@ -602,8 +1044,8 @@
     >         "Objective function for minimizing the load on the link that 
     >         is carrying the highest load (MLL).";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
     >     identity svec-of-minimize-cost-path-set {
@@ -612,8 +1054,8 @@
     >         "Objective function for minimizing the cost on a path set 
     >         (MCC).";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
     >     identity svec-of-minimize-common-transit-domain {
@@ -622,9 +1064,9 @@
     >         "Objective function for minimizing the number of common 
     >         transit domains (MCTD).";
     >       reference
-    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         "RFC 8685: Path Computation Element Communication Protocol 
     >         (PCEP) Extensions for the Hierarchical Path Computation 
-    >         Element (H-PCE) Architecture.";
+    >         Element (H-PCE) Architecture";
     >     }
     > 
     >     identity svec-of-minimize-shared-link {
@@ -633,7 +1075,7 @@
     >         "Objective function for minimizing the number of shared 
     >         links (MSL).";
     >       reference
-    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         "RFC 8685: Path Computation Element Communication Protocol 
     >         (PCEP) Extensions for the Hierarchical Path Computation 
     >         Element (H-PCE) Architecture.";
     >     }
@@ -644,7 +1086,7 @@
     >         "Objective function for minimizing the number of shared 
     >         Shared Risk Link Groups (SRLG) (MSS).";
     >       reference
-    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         "RFC 8685: Path Computation Element Communication Protocol 
     >         (PCEP) Extensions for the Hierarchical Path Computation 
     >         Element (H-PCE) Architecture.";
     >     }
@@ -655,7 +1097,7 @@
     >         "Objective function for minimizing the number of shared 
     >         nodes (MSN).";
     >       reference
-    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         "RFC 8685: Path Computation Element Communication Protocol 
     >         (PCEP) Extensions for the Hierarchical Path Computation 
     >         Element (H-PCE) Architecture.";
     >     }
@@ -668,35 +1110,35 @@
     >     description
     >       "Base identity for SVEC metric type.";
     >     reference
-    >       "RFC5541: Encoding of Objective Functions in the Path
-    >        Computation Element Communication Protocol (PCEP).";
+    >       "RFC 5541: Encoding of Objective Functions in the Path
+    >        Computation Element Communication Protocol (PCEP)";
     >   }
     > 
-    >     identity svec-metric-cumul-te {
+    >     identity svec-metric-cumulative-te {
     >       base svec-metric-type;
     >       description
     >         "Cumulative TE cost.";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
-    >     identity svec-metric-cumul-igp {
+    >     identity svec-metric-cumulative-igp {
     >       base svec-metric-type;
     >       description
     >         "Cumulative IGP cost.";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
-    >     identity svec-metric-cumul-hop {
+    >     identity svec-metric-cumulative-hop {
     >       base svec-metric-type;
     >       description
     >         "Cumulative Hop path metric.";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
     >     identity svec-metric-aggregate-bandwidth-consumption {
@@ -704,8 +1146,8 @@
     >       description
     >         "Aggregate bandwidth consumption.";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
     >     identity svec-metric-load-of-the-most-loaded-link {
@@ -713,15 +1155,29 @@
     >       description
     >         "Load of the most loaded link.";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
-    2506a3121,3123
+    2221,2225c3105,3111
+    <       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions
+    <        RFC 7823: Performance-Based Path Selection for Explicitly
+    <        Routed Label Switched Paths (LSPs) Using TE Metric
+    <        Extensions
+    <        RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
+    ---
+    >       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensionsù
+    >       
+    >       RFC 7823: Performance-Based Path Selection for Explicitly
+    >       Routed Label Switched Paths (LSPs) Using TE Metric
+    >       Extensions
+    > 
+    >       RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
+    2506a3393,3395
     >   // CHANGE NOTE: The explicit-route-hop grouping below has been
     >   // updated in this module revision
     >   // RFC Editor: remove the note above and this note
-    2514a3132,3140
+    2514a3404,3412
     >           must "node-id-uri or node-id" {
     >             description
     >               "At least one node identifier MUST be present.";
@@ -731,9 +1187,9 @@
     >             description
     >               "The identifier of a node in the topology.";
     >           }
-    2517d3142
+    2517d3414
     <             mandatory true;
-    2566a3192,3202
+    2566a3464,3474
     >           must "(link-tp-id-uri or link-tp-id) and " +
     >                 "(node-id-uri or node-id)" {
     >             description
@@ -745,30 +1201,34 @@
     >             description
     >               "Link Termination Point (LTP) identifier.";
     >           }
-    2569d3204
+    2569d3476
     <             mandatory true;
-    2574a3210,3214
+    2574a3482,3486
     >           leaf node-id-uri {
     >             type nw:node-id;
     >             description
     >               "The identifier of a node in the topology.";
     >           }
-    2577d3216
+    2577d3488
     <             mandatory true;
-    2646a3286,3289
+    2631a3543,3545
+    >   // CHANGE NOTE: The explicit-route-hop grouping below has been
+    >   // updated in this module revision
+    >   // RFC Editor: remove the note above and this note
+    2646a3561,3564
     >           must "node-id-uri or node-id" {
     >             description
     >               "At least one node identifier MUST be present.";
     >           }
-    2648a3292,3296
+    2648a3567,3571
     >           leaf node-id-uri {
     >             type nw:node-id;
     >             description
     >               "The identifier of a node in the topology.";
     >           }
-    2651d3298
+    2651d3573
     <             mandatory true;
-    2696a3344,3354
+    2696a3619,3629
     >           must "(link-tp-id-uri or link-tp-id) and " +
     >               "(node-id-uri or node-id)" {
     >             description
@@ -780,44 +1240,103 @@
     >             description
     >               "Link Termination Point (LTP) identifier.";
     >           }
-    2699d3356
+    2699d3631
     <             mandatory true;
-    2704a3362,3366
+    2704a3637,3641
     >           leaf node-id-uri {
     >             type nw:node-id;
     >             description
     >               "The identifier of a node in the topology.";
     >           }
-    2968a3631,3635
+    2881a3819,3821
+    >   // CHANGE NOTE: The grouping optimization-metric-entry below has
+    >   // been updated in this module revision
+    >   // RFC Editor: remove the note above and this note
+    2887c3827
+    <         base path-metric-type;
+    ---
+    >         base path-metric-optimization-type;
+    2964a3905,3907
+    >   // CHANGE NOTE: The grouping tunnel-constraints below has
+    >   // been updated in this module revision
+    >   // RFC Editor: remove the note above and this note
+    2968a3912,3916
     >     leaf network-id {
     >       type nw:network-id;
     >       description
     >         "The network topology identifier.";
     >     }
-    2977c3644,3647
+    2972a3921,3923
+    >   // CHANGE NOTE: The grouping path-constraints-route-objects below
+    >   // has been updated in this module revision
+    >   // RFC Editor: remove the note above and this note
+    2977c3928
     <     container explicit-route-objects-always {
     ---
-    >     // CHANGE NOTE: The explicit-route-objects container below has
-    >     // been updated in this module revision
-    >     // RFC Editor: remove the note above and this note
     >     container explicit-route-objects {
-    2979c3649
+    2979c3930
     <         "Container for the 'exclude route' object list.";
     ---
     >         "Container for the explicit route object lists.";
-    3124,3126c3794,3800
+    3101a4053,4055
+    >   // CHANGE NOTE: The grouping generic-path-metric-bounds below
+    >   // has been updated in this module revision
+    >   // RFC Editor: remove the note above and this note
+    3107c4061
+    <         "TE path metric bounds container.";
+    ---
+    >         "Top-level container for the list of path metric bounds.";
+    3111c4065,4073
+    <           "List of TE path metric bounds.";
+    ---
+    >           "List of path metric bounds, which can apply to link and
+    >           path metrics.
+    >           
+    >           TE paths which have at least one path metric which
+    >           exceeds the specified bounds MUST NOT be selected.
+    >           
+    >           TE paths that traverse TE links which have at least one
+    >           link metric which exceeds the specified bounds MUST NOT
+    >           be selected.";
+    3114c4076
+    <             base path-metric-type;
+    ---
+    >             base link-path-metric-type;
+    3124,3126c4086,4092
     <             "Upper bound on the end-to-end TE path metric.  A zero
     <              indicates an unbounded upper limit for the specific
     <              'metric-type'.";
     ---
-    >             "Upper bound on the end-to-end TE path metric.
+    >             "Upper bound on the specified 'metric-type'.
     >             
     >             A zero indicates an unbounded upper limit for the
-    >             specific 'metric-type'.
+    >             specificied 'metric-type'.
     >             
     >             The unit of is interpreted in the context of the
-    >             path-metric-type.";
-    3379c4053,4112
+    >             'metric-type' identity.";
+    3131a4098,4100
+    >   // CHANGE NOTE: The grouping generic-path-metric-bounds below
+    >   // has been updated in this module revision
+    >   // RFC Editor: remove the note above and this note
+    3154c4123,4127
+    <               "Container for the list of tiebreakers.";
+    ---
+    >               "Container for the list of tiebreakers.
+    >               
+    >               This container has been obsoleted by the tiebreaker
+    >               leaf.";
+    >             status deprecated;
+    3189a4163,4171
+    >     leaf tiebreaker {
+    >       type identityref {
+    >         base path-tiebreaker-type;
+    >       }
+    >       default "te-types:path-tiebreaker-random";
+    >       description
+    >         "The tiebreaker criteria to apply on an equally favored set
+    >         of paths, in order to pick the best.";
+    >     }
+    3379c4361,4420
     < }
     \ No newline at end of file
     ---
@@ -836,7 +1355,7 @@
     >       description
     >         "LSP encoding type.";
     >       reference
-    >         "RFC3945";
+    >         "RFC 3945";
     >     }
     >     leaf switching-type {
     >       type identityref {
@@ -845,7 +1364,7 @@
     >       description
     >         "LSP switching type.";
     >       reference
-    >         "RFC3945";
+    >         "RFC 3945";
     >     }
     >   }
     > 

--- a/drafts/te-types-update/diffs/te-types/model-diff.txt
+++ b/drafts/te-types-update/diffs/te-types/model-diff.txt
@@ -21,61 +21,134 @@
 <      the license terms contained in, the Simplified BSD License set
 ---
 >      the license terms contained in, the Revised BSD License set
-65,66c75,113
+65,66c75,164
 <      This version of this YANG module is part of RFC 8776; see the
 <      RFC itself for full legal notices.";
 ---
 >      This version of this YANG module is part of RFC XXXX
 >      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
 >      for full legal notices.";
->   revision 2024-01-29 {
+>   revision 2024-02-16 {
 >     description
->       "Added:
->       - base identity lsp-provisioning-error-reason;
->       - identity association-type-diversity;
->       - identity tunnel-admin-state-auto;
->       - identity lsp-restoration-restore-none;
->       - identity restoration-scheme-rerouting;
->       - base identity path-computation-error-reason and
->         its derived identities;
->       - base identity protocol-origin-type and
->         its derived identities;
->       - base identity svec-objective-function-type and its derived
->         identities;
->       - base identity svec-metric-type and its derived identities;
->       - grouping encoding-and-switching-type.
->       
->       Updated:
->       - description of the base identity objective-function-type;
->       - description and reference of identity action-exercise;
->       - typedef te-node-id to support also 16 octects TE identifiers.
->       
->       Obsoleted:
->       - identity of-minimize-agg-bandwidth-consumption;
->       - identity of-minimize-load-most-loaded-link;
->       - identity of-minimize-cost-path-set;
->       - identity lsp-protection-reroute-extra;
->       - identity lsp-protection-reroute.
+>       "This revision adds the following new identities:
+>       - lsp-provisioning-error-reason;
+>       - association-type-diversity;
+>       - tunnel-admin-state-auto;
+>       - lsp-restoration-restore-none;
+>       - restoration-scheme-rerouting;
+>       - path-metric-optimization-type;
+>       - link-path-metric-type;
+>       - link-metric-type and its derived identities;
+>       - path-computation-error-reason and its derived identities;
+>       - protocol-origin-type and its derived identities;
+>       - svec-objective-function-type and its derived identities;
+>       - svec-metric-type and its derived identities.
 > 
->       Container explicit-route-objects-always renamed as
->       explicit-route-objects.";
+>       This revision adds the following new data types:
+>       - path-type;
+>       - te-gen-node-id.
+> 
+>       This revision adds the following new groupings:
+>       - encoding-and-switching-type;
+>       - te-generic-node-id.
+> 
+>       This revision updates the following identities:
+>       - objective-function-type;
+>       - action-exercise;
+>       - path-metric-type;
+>       - path-metric-te;
+>       - path-metric-igp;
+>       - path-metric-hop;
+>       - path-metric-delay-average;
+>       - path-metric-delay-minimum;
+>       - path-metric-residual-bandwidth;
+>       - path-metric-optimize-includes;
+>       - path-metric-optimize-excludes;
+>       - te-optimization-criterion.
+> 
+>       This revision updates the following data types:
+>       - te-node-id.
+> 
+>       This revision updates the following groupings:
+>       - explicit-route-hop:
+>         - adds the following leaves:
+>           - node-id-uri;
+>           - link-tp-id-uri;
+>         - updates the following leaves:
+>           - node-id;
+>           - link-tp-id;
+>       - record-route-state:
+>         - adds the following leaves:
+>           - node-id-uri;
+>           - link-tp-id-uri;
+>         - updates the following leaves:
+>           - node-id;
+>           - link-tp-id;
+>       - optimization-metric-entry:
+>         - updates the following leaves:
+>           - metric-type;
+>       - tunnel-constraints;
+>         - adds the following leaves:
+>           - network-id;
+>       - path-constraints-route-objects:
+>         - updates the following containers:
+>           - explicit-route-objects-always;
+>       - generic-path-metric-bounds:
+>         - updates the following leaves:
+>           - metric-type;
+>       - generic-path-optimization
+>         - adds the following leaves:
+>           - tiebreaker;
+>         - deprecate the following containers:
+>           - tiebreakers.
+> 
+>       This revision obsoletes the following identities:
+>       - of-minimize-agg-bandwidth-consumption;
+>       - of-minimize-load-most-loaded-link;
+>       - of-minimize-cost-path-set;
+>       - lsp-protection-reroute-extra;
+>       - lsp-protection-reroute.
+> 
+>       This revision provides also few editorial changes.";
 >     reference
 >       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
 >   }
 >   // RFC Editor: replace XXXX with actual RFC number, update date
 >   // information and remove this note
-351a399,401
+70c168
+<       "Latest revision of TE types.";
+---
+>       "Initial Version of TE types.";
+86a185
+> 
+92a192
+> 
+93a194
+>        
+111a213
+> 
+155a258
+> 
+158a262
+> 
+263a368
+> 
+264a370
+> 
+269a376
+> 
+351a459,461
 >   // CHANGE NOTE: The typedef te-node-id below has been
 >   // updated in this module revision
 >   // RFC Editor: remove the note above and this note
-353c403,406
+353c463,466
 <     type yang:dotted-quad;
 ---
 >     type union {
 >       type yang:dotted-quad;
 >       type inet:ipv6-address-no-zone;
 >     }
-357,358c410,414
+357,358c470,474
 <        The identifier is represented as 4 octets in dotted-quad
 <        notation.
 ---
@@ -84,7 +157,7 @@
 >        dotted-quad notation or 16 octets in full, mixed, shortened,
 >        or shortened-mixed IPv6 address notation.
 > 
-362,363c418,421
+362,363c478,481
 <        Router ID TLV described in Section 4.3 of RFC 5305, or the
 <        TE Router ID TLV described in Section 3.2.1 of RFC 6119.
 ---
@@ -92,13 +165,17 @@
 >        Router ID TLV described in Section 3.2.1 of RFC 6119, or the
 >        IPv6 TE Router ID TLV described in Section 4.1 of RFC 6119.
 > 
-368a427
+368a487
 > 
-370a430
+370a490
 > 
-371a432
+371a492
 > 
-545a607,647
+519a641
+> 
+537a660
+> 
+545a669,709
 >   // CHANGE NOTE: The typedef path-type below has been
 >   // added in this module revision
 >   // RFC Editor: remove the note above and this note
@@ -140,7 +217,7 @@
 >       "Generic type that identifies a node in a TE topology.";
 >   }
 > 
-606a709,716
+606a771,778
 >   // CHANGE NOTE: The base identity lsp-provisioning-error-reason 
 >   // has been added in this module revision
 >   // RFC Editor: remove the note above and this note
@@ -149,7 +226,7 @@
 >       "Base identity for LSP provisioning errors.";
 >   }
 > 
-982a1093,1110
+982a1155,1172
 >   // CHANGE NOTE: The identity association-type-diversity below has 
 >   // been added in this module revision
 >   // RFC Editor: remove the note above and this note
@@ -159,7 +236,7 @@
 >       "Association Type diversity used to associate LSPs whose 
 >       paths are to be diverse from each other.";
 >     reference
->       "RFC8800: Path Computation Element Communication Protocol 
+>       "RFC 8800: Path Computation Element Communication Protocol 
 >       (PCEP) Extension for Label Switched Path (LSP) Diversity 
 >       Constraint Signaling";
 >   }
@@ -168,45 +245,92 @@
 >   // objective-function-type has been updated 
 >   // in this module revision
 >   // RFC Editor: remove the note above and this note
-985c1113
+985c1175
 <       "Base objective function type.";
 ---
->       "Base identity for path objective function type.";
-1015a1144,1146
+>       "Base identity for path objective function types.";
+1015a1206,1208
 >   // CHANGE NOTE: The identity of-minimize-agg-bandwidth-consumption
 >   // below has been obsoleted in this module revision
 >   // RFC Editor: remove the note above and this note
-1017a1149
+1017a1211
 >     status obsolete;
-1020c1152
+1020c1214,1218
 <        consumption.";
 ---
->       consumption.";
-1023c1155
+>       consumption.
+>       
+>       This identity has been obsoleted: the
+>       'svec-of-minimize-agg-bandwidth-consumption' identity SHOULD
+>       be used instead.";
+1023c1221
 <        Computation Element Communication Protocol (PCEP)";
 ---
 >       Computation Element Communication Protocol (PCEP)";
-1025a1158,1160
+1025a1224,1226
 >   // CHANGE NOTE: The identity of-minimize-load-most-loaded-link
 >   // below has been obsoleted in this module revision
 >   // RFC Editor: remove the note above and this note
-1027a1163
+1027a1229
 >     status obsolete;
-1030c1166
+1030c1232,1236
 <        is carrying the highest load.";
 ---
->       is carrying the highest load.";
-1033c1169
+>       is carrying the highest load.
+>       
+>       This identity has been obsoleted: the
+>       'svec-of-minimize-load-most-loaded-link' identity SHOULD
+>       be used instead.";
+1033c1239
 <        Computation Element Communication Protocol (PCEP)";
 ---
 >       Computation Element Communication Protocol (PCEP)";
-1035a1172,1174
+1035a1242,1244
 >   // CHANGE NOTE: The identity of-minimize-cost-path-set
 >   // below has been obsoleted in this module revision
 >   // RFC Editor: remove the note above and this note
-1037a1177
+1037a1247
 >     status obsolete;
-1216a1357,1368
+1039c1249,1253
+<       "Objective function for minimizing the cost on a path set.";
+---
+>       "Objective function for minimizing the cost on a path set.
+>       
+>       This identity has been obsoleted: the
+>       'svec-of-minimize-cost-path-set' identity SHOULD
+>       be used instead.";
+1049a1264,1266
+>   // CHANGE NOTE: The reference of the identity path-locally-computed
+>   // below has been updated in this module revision
+>   // RFC Editor: remove the note above and this note
+1056,1057c1273,1274
+<       "RFC 3272: Overview and Principles of Internet Traffic
+<        Engineering, Section 5.4";
+---
+>       "RFC 9522: Overview and Principles of Internet Traffic
+>       Engineering, Section 4.4";
+1059a1277,1280
+>   // CHANGE NOTE: The reference of the identity 
+>   // path-externally-queried below has been updated
+>   // in this module revision
+>   // RFC Editor: remove the note above and this note
+1071c1292
+<       "RFC 3272: Overview and Principles of Internet Traffic
+---
+>       "RFC 9522: Overview and Principles of Internet Traffic
+1072a1294
+> 
+1076a1299,1302
+>   // CHANGE NOTE: The reference of the identity 
+>   // path-explicitly-defined below has been updated
+>   // in this module revision
+>   // RFC Editor: remove the note above and this note
+1085c1311,1312
+<        RFC 3272: Overview and Principles of Internet Traffic
+---
+> 
+>        RFC 9522: Overview and Principles of Internet Traffic
+1216a1444,1455
 >   // CHANGE NOTE: The identity tunnel-admin-state-auto below
 >   // has been added in this module revision
 >   // RFC Editor: remove the note above and this note
@@ -219,7 +343,7 @@
 >       when it is not used by the client layer.";
 >   }
 > 
-1321a1474,1482
+1321a1561,1569
 >     // CHANGE NOTE: The identity lsp-restoration-restore-none 
 >     // below has been added in this module revision
 >     // RFC Editor: remove the note above and this note
@@ -229,7 +353,7 @@
 >         "No LSP affected by a failure is restored.";
 >     }
 > 
-1339a1501,1515
+1339a1588,1602
 >     // CHANGE NOTE: The identity restoration-scheme-rerouting 
 >     // below has been added in this module revision
 >     // RFC Editor: remove the note above and this note
@@ -245,13 +369,13 @@
 >         for Generalized Multi-Protocol Label Switching (GMPLS)";
 >     }
 > 
-1383a1560,1562
+1383a1647,1649
 >   // CHANGE NOTE: The identity lsp-protection-reroute-extra
 >   // below has been obsoleted in this module revision
 >   // RFC Editor: remove the note above and this note
-1385a1565
+1385a1652
 >     status obsolete;
-1387c1567,1571
+1387c1654,1658
 <       "'(Full) Rerouting' LSP protection type.";
 ---
 >       "'(Full) Rerouting' LSP protection type.
@@ -259,13 +383,13 @@
 >       This identity has been obsoleted: the
 >       'restoration-scheme-rerouting' identity SHOULD be used
 >       instead.";
-1392a1577,1579
+1392a1664,1666
 >   // CHANGE NOTE: The identity lsp-protection-reroute
 >   // below has been obsoleted in this module revision
 >   // RFC Editor: remove the note above and this note
-1394a1582
+1394a1669
 >     status obsolete;
-1396c1584,1588
+1396c1671,1675
 <       "'Rerouting without Extra-Traffic' LSP protection type.";
 ---
 >       "'Rerouting without Extra-Traffic' LSP protection type.
@@ -273,46 +397,327 @@
 >       This identity has been obsoleted: the
 >       'restoration-scheme-rerouting' identity SHOULD be used
 >       instead.";
-1628a1821,1824
+1628a1908,1911
 >   // CHANGE NOTE: The description and reference of the 
 >   // identity action-exercise have been updated in this module 
 >   // revision
 >   // RFC Editor: remove the note above and this note
-1632,1633c1828,1830
+1632,1633c1915,1917
 <       "An action that starts testing whether or not APS communication
 <        is operating correctly.  It is of lower priority than any
 ---
 >       "An action that starts testing whether or not Automatic 
 >        Protection Switching (APS) communication is operating 
 >        correctly.  It is of lower priority than any
-1636,1637c1833,1834
+1636,1637c1920,1921
 <       "RFC 4427: Recovery (Protection and Restoration) Terminology
 <        for Generalized Multi-Protocol Label Switching (GMPLS)";
 ---
 >       "ITU-T G.808.1 v4.0 (05/2014): Generic protection switching - 
 >       Linear trail and subnetwork protection";
-1916a2114,2116
->   // CHANGE NOTE: The description of the identity path-metric-type
->   // has been updated in this module revision
->   // RFC Editor: remove the note above and this note
-1919c2119,2122
-<       "Base identity for the path metric type.";
+1917c2201,2204
+<   identity path-metric-type {
 ---
->       "Base identity for the path metric type.
->       
->       Derived identities SHOULD describe the unit and maximum value
->       of the path metric types they define.";
-1939a2143,2145
->   // CHANGE NOTE: The reference for the identity path-metric-hop
+>   // CHANGE NOTE: The path-metric-optimization-type base identity
 >   // has been added in this module revision
 >   // RFC Editor: remove the note above and this note
-1943a2150,2152
->     reference
->       "RFC5440: Path Computation Element (PCE) Communication
->       Protocol (PCEP)";
-1945a2155
+>   identity path-metric-optimization-type {
+1919c2206,2207
+<       "Base identity for the path metric type.";
+---
+>       "Base identity used to define the path metric optimization
+>       types.";
+1922,1923c2210,2213
+<   identity path-metric-te {
+<     base path-metric-type;
+---
+>   // CHANGE NOTE: The link-path-metric-type base identity
+>   // has been added in this module revision
+>   // RFC Editor: remove the note above and this note
+>   identity link-path-metric-type {
+1925,1928c2215,2221
+<       "TE path metric.";
+<     reference
+<       "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+<        second MPLS Traffic Engineering (TE) Metric";
+---
+>       "Base identity used to define the link and the path metric
+>       types.
+>       
+>       The unit of the path metric value is interpreted in the
+>       context of the path metric type and the derived identities
+>       SHOULD describe the unit of the path metric types they
+>       define.";
+1931,1938c2224,2232
+<   identity path-metric-igp {
+<     base path-metric-type;
+<     description
+<       "IGP path metric.";
+<     reference
+<       "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+<        second MPLS Traffic Engineering (TE) Metric";
+<   }
+---
+>     // CHANGE NOTE: The link-metric-type base identity
+>     // and its derived identities
+>     // have been added in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity link-metric-type {
+>       base link-path-metric-type;
+>       description
+>         "Base identity for the link metric types.";
+>     }
+1940,1944c2234,2240
+<   identity path-metric-hop {
+<     base path-metric-type;
+<     description
+<       "Hop path metric.";
+<   }
+---
+>       identity link-metric-te {
+>         base link-metric-type;
+>         description
+>           "Traffic Engineering (TE) Link Metric.";
+>         reference
+>           "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+>           Version 2, section 2.5.5
+1946,1952c2242,2244
+<   identity path-metric-delay-average {
+<     base path-metric-type;
+<     description
+<       "Average unidirectional link delay.";
+<     reference
+<       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+<   }
+---
+>           RFC 5305: IS-IS Extensions for Traffic Engineering,
+>           section 3.7";
+>       }
+1954,1960c2246,2253
+<   identity path-metric-delay-minimum {
+<     base path-metric-type;
+<     description
+<       "Minimum unidirectional link delay.";
+<     reference
+<       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+<   }
+---
+>       identity link-metric-igp {
+>         base link-metric-type;
+>         description
+>           "Interior Gateway Protocol (IGP) Link Metric.";
+>         reference
+>           "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric
+>           as a second MPLS Traffic Engineering (TE) Metric";
+>       }
+1962,1972c2255,2266
+<   identity path-metric-residual-bandwidth {
+<     base path-metric-type;
+<     description
+<       "Unidirectional Residual Bandwidth, which is defined to be
+<        Maximum Bandwidth (RFC 3630) minus the bandwidth currently
+<        allocated to LSPs.";
+<     reference
+<       "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+<        Version 2
+<        RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+<   }
+---
+>       identity link-metric-delay-average {
+>         base link-metric-type;
+>         description
+>           "Unidirectional Link Delay, measured in units of
+>           microseconds.";
+>         reference
+>           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+>           Extensions, section 4.1
+>           
+>           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+>           Extensions, section 4.1";
+>       }
+1974,1979c2268,2279
+<   identity path-metric-optimize-includes {
+<     base path-metric-type;
+<     description
+<       "A metric that optimizes the number of included resources
+<        specified in a set.";
+<   }
+---
+>       identity link-metric-delay-minimum {
+>         base link-metric-type;
+>         description
+>           "Minimum unidirectional Link Delay, measured in units of
+>           microseconds.";
+>         reference
+>           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+>           Extensions, section 4.2
+>           
+>           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+>           Extensions, section 4.2";
+>       }
+1981,1986c2281,2425
+<   identity path-metric-optimize-excludes {
+<     base path-metric-type;
+<     description
+<       "A metric that optimizes to a maximum the number of excluded
+<        resources specified in a set.";
+<   }
+---
+>       identity link-metric-delay-maximum {
+>         base link-metric-type;
+>         description
+>           "Maximum unidirectional Link Delay, measured in units of
+>           microseconds.";
+>         reference
+>           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+>           Extensions, section 4.2
+>           
+>           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+>           Extensions, section 4.2";
+>       }
 > 
-2110a2321,2724
+>       identity link-metric-residual-bandwidth {
+>         base link-metric-type;
+>         description
+>           "Unidirectional Residual Bandwidth, measured in units of
+>           bytes per second.
+>           
+>           It is defined to be Maximum Bandwidth minus the bandwidth
+>           currently allocated to LSPs.";
+>         reference
+>           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+>           Extensions, section 4.5
+>           
+>           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+>           Extensions, section 4.5";
+>       }
+> 
+>     // CHANGE NOTE: The base and the description of the
+>     // path-metric-type identity
+>     // has been updated in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity path-metric-type {
+>       base link-path-metric-type;
+>       base path-metric-optimization-type;
+>       description
+>         "Base identity for the path metric types.";
+>     }
+> 
+>       // CHANGE NOTE: The description and the reference of the
+>       // path-metric-te identity have been updated
+>       // in this module revision
+>       // RFC Editor: remove the note above and this note
+>       identity path-metric-te {
+>         base path-metric-type;
+>         description
+>           "Traffic Engineering (TE) Path Metric.";
+>         reference
+>           "RFC 5440: Path Computation Element (PCE) Communication
+>           Protocol (PCEP), section 7.8";
+>       }
+> 
+>       // CHANGE NOTE: The description and the reference of the
+>       // path-metric-igp identity have been updated 
+>       // in this module revision
+>       // RFC Editor: remove the note above and this note
+>       identity path-metric-igp {
+>         base path-metric-type;
+>         description
+>           "Interior Gateway Protocol (IGP) Path Metric.";
+>         reference
+>           "RFC 5440: Path Computation Element (PCE) Communication
+>           Protocol (PCEP), section 7.8";
+>       }
+> 
+>       // CHANGE NOTE: The description and the reference of the
+>       // path-metric-hop identity have been updated
+>       // in this module revision
+>       // RFC Editor: remove the note above and this note
+>       identity path-metric-hop {
+>         base path-metric-type;
+>         description
+>           "Hop Count Path Metric.";
+>         reference
+>           "RFC 5440: Path Computation Element (PCE) Communication
+>           Protocol (PCEP), section 7.8";
+>       }
+> 
+>       // CHANGE NOTE: The description and the reference of the
+>       // path-metric-delay-average identity have been updated
+>       // in this module revision
+>       // RFC Editor: remove the note above and this note
+>       identity path-metric-delay-average {
+>         base path-metric-type;
+>         description
+>           "The Path Delay Metric, measured in units of
+>           microseconds.";
+>         reference
+>           "RFC8233: Extensions to the Path Computation Element
+>           Communication Protocol (PCEP) to Compute Service-Aware
+>           Label Switched Paths (LSPs), section 3.1.1";
+>       }
+> 
+>       // CHANGE NOTE: The description and the reference of the
+>       // path-metric-delay-minimum identity have been updated
+>       // in this module revision
+>       // RFC Editor: remove the note above and this note
+>       identity path-metric-delay-minimum {
+>         base path-metric-type;
+>         description
+>           "The Path Min Delay Metric, measured in units of
+>           microseconds.";
+>         reference
+>           "I-D.ietf-pce-sid-algo: Carrying SR-Algorithm information
+>           in PCE-based Networks, section 3.5.1";
+>       }
+> 
+>       // CHANGE NOTE: The description and the reference of the
+>       // path-metric-residual-bandwidth identity have been updated
+>       // in this module revision
+>       // RFC Editor: remove the note above and this note
+>       identity path-metric-residual-bandwidth {
+>         base path-metric-type;
+>         description
+>           "The Path Residual Bandwidth, defined as the minimum Link
+>           Residual Bandwidth all the links along the path.
+> 
+>           The Path Residual Bandwidth can be seen as the path
+>           metric associated with the Maximum residual Bandwidth Path
+>           (MBP) objective function.";
+>         reference
+>           "RFC 5541: Encoding of Objective Functions in the Path
+>           Computation Element Communication Protocol (PCEP)";
+>       }
+> 
+>     // CHANGE NOTE: The base of the path-metric-optimize-includes
+>     // identity has been updated in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity path-metric-optimize-includes {
+>       base path-metric-optimization-type;
+>       description
+>         "A metric that optimizes the number of included resources
+>         specified in a set.";
+>     }
+> 
+>     // CHANGE NOTE: The base of the path-metric-optimize-excludes
+>     // identity has been updated in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity path-metric-optimize-excludes {
+>       base path-metric-optimization-type;
+>       description
+>         "A metric that optimizes to a maximum the number of excluded
+>         resources specified in a set.";
+>     }
+2049a2489,2492
+>   // CHANGE NOTE: The reference of the identity 
+>   // te-optimization-criterion below has been updated
+>   // in this module revision
+>   // RFC Editor: remove the note above and this note
+2054c2497
+<       "RFC 3272: Overview and Principles of Internet Traffic
+---
+>       "RFC 9522: Overview and Principles of Internet Traffic
+2110a2554,2994
 >   // CHANGE NOTE: The base identity path-computation-error-reason 
 >   // and its derived identities below have been
 >   // added in this module revision
@@ -328,8 +733,8 @@
 >         "Path computation has failed because of an unspecified 
 >         reason.";
 >       reference
->         "Section 7.5 of RFC5440: Path Computation Element (PCE)
->         Communication Protocol (PCEP)";
+>         "RFC 5440: Path Computation Element (PCE) Communication
+>         Protocol (PCEP), section 7.5";
 >     }
 > 
 >     identity path-computation-error-no-topology {
@@ -349,7 +754,13 @@
 >         a Backward-Recursive Path Computation (BRPC) downstream
 >         PCE or a child PCE.";
 >       reference
->         "RFC5441, RFC8685";
+>         "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+>         Procedure to Compute Shortest Constrained Inter-Domain
+>         Traffic Engineering Label Switched Paths
+>         
+>         RFC 8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture";
 >     }
 > 
 >     identity path-computation-error-pce-unavailable {
@@ -360,10 +771,11 @@
 >         It corresponds to bit 31 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC5440: Path Computation Element (PCE) Communication
->         Protocol (PCEP);
+>         "RFC 5440: Path Computation Element (PCE) Communication
+>         Protocol (PCEP)
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-no-inclusion-hop {
@@ -382,9 +794,12 @@
 >         It corresponds to bit 19 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC8685;
+>         "RFC 8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-no-resource {
@@ -396,9 +811,12 @@
 >         It corresponds to bit 20 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC8685;
+>         "RFC 8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-child-pce-unresponsive {
@@ -410,9 +828,12 @@
 >         It corresponds to bit 21 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC8685;
+>         "RFC 8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-destination-domain-unknown {
@@ -424,9 +845,12 @@
 >         It corresponds to bit 22 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC8685;
+>         "RFC 8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-p2mp {
@@ -438,9 +862,12 @@
 >         It corresponds to bit 24 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC8306;
+>         "RFC 8306: Extensions to the Path Computation Element
+>         Communication Protocol (PCEP) for Point-to-Multipoint
+>         Traffic Engineering Label Switched Paths
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-no-gco-migration {
@@ -452,9 +879,12 @@
 >         It corresponds to bit 26 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC5557;
+>         "RFC 5557: Path Computation Element Communication Protocol
+>         (PCEP) Requirements and Protocol Extensions in Support of
+>         Global Concurrent Optimization
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-no-gco-solution {
@@ -466,9 +896,12 @@
 >         It corresponds to bit 25 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC5557;
+>         "RFC 5557: Path Computation Element Communication Protocol
+>         (PCEP) Requirements and Protocol Extensions in Support of
+>         Global Concurrent Optimization
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-pks-expansion {
@@ -480,9 +913,12 @@
 >         It corresponds to bit 27 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC5520;
+>         "RFC 5520: Preserving Topology Confidentiality in
+>         Inter-Domain Path Computation Using a Path-Key-Based
+>         Mechanism
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-brpc-chain-unavailable {
@@ -494,9 +930,12 @@
 >         It corresponds to bit 28 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC5441;
+>         "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+>         Procedure to Compute Shortest Constrained Inter-Domain
+>         Traffic Engineering Label Switched Paths
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-source-unknown {
@@ -508,10 +947,11 @@
 >         It corresponds to bit 29 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC5440: Path Computation Element (PCE) Communication
+>         "RFC 5440: Path Computation Element (PCE) Communication
 >         Protocol (PCEP);
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-destination-unknown {
@@ -523,10 +963,11 @@
 >         It corresponds to bit 30 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC5440: Path Computation Element (PCE) Communication
+>         "RFC 5440: Path Computation Element (PCE) Communication
 >         Protocol (PCEP);
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-no-server {
@@ -535,10 +976,11 @@
 >         "Path computation has failed because path computation
 >         server is unavailable.";
 >       reference
->         "RFC5440: Path Computation Element (PCE) Communication
+>         "RFC 5440: Path Computation Element (PCE) Communication
 >         Protocol (PCEP);
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >   // CHANGE NOTE: The base identity protocol-origin-type and 
@@ -563,7 +1005,7 @@
 >         "Protocol origin is Path Computation Engine Protocol 
 >         (PCEP).";
 >       reference
->         "RFC5440: Path Computation Element (PCE) Communication
+>         "RFC 5440: Path Computation Element (PCE) Communication
 >         Protocol (PCEP)";
 >     }
 > 
@@ -571,7 +1013,7 @@
 >       base protocol-origin-type;
 >       description
 >         "Protocol origin is Border Gateway Protocol (BGP).";
->       reference "RFC9012";
+>       reference "RFC 9012";
 >     }
 > 
 >   // CHANGE NOTE: The base identity svec-objective-function-type 
@@ -582,8 +1024,8 @@
 >     description
 >       "Base identity for SVEC objective function type.";
 >     reference
->       "RFC5541: Encoding of Objective Functions in the Path
->        Computation Element Communication Protocol (PCEP).";
+>       "RFC 5541: Encoding of Objective Functions in the Path
+>        Computation Element Communication Protocol (PCEP)";
 >   }
 > 
 >     identity svec-of-minimize-agg-bandwidth-consumption {
@@ -592,8 +1034,8 @@
 >         "Objective function for minimizing aggregate bandwidth 
 >         consumption (MBC).";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
 >     identity svec-of-minimize-load-most-loaded-link {
@@ -602,8 +1044,8 @@
 >         "Objective function for minimizing the load on the link that 
 >         is carrying the highest load (MLL).";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
 >     identity svec-of-minimize-cost-path-set {
@@ -612,8 +1054,8 @@
 >         "Objective function for minimizing the cost on a path set 
 >         (MCC).";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
 >     identity svec-of-minimize-common-transit-domain {
@@ -622,9 +1064,9 @@
 >         "Objective function for minimizing the number of common 
 >         transit domains (MCTD).";
 >       reference
->         "RFC8685: Path Computation Element Communication Protocol 
+>         "RFC 8685: Path Computation Element Communication Protocol 
 >         (PCEP) Extensions for the Hierarchical Path Computation 
->         Element (H-PCE) Architecture.";
+>         Element (H-PCE) Architecture";
 >     }
 > 
 >     identity svec-of-minimize-shared-link {
@@ -633,7 +1075,7 @@
 >         "Objective function for minimizing the number of shared 
 >         links (MSL).";
 >       reference
->         "RFC8685: Path Computation Element Communication Protocol 
+>         "RFC 8685: Path Computation Element Communication Protocol 
 >         (PCEP) Extensions for the Hierarchical Path Computation 
 >         Element (H-PCE) Architecture.";
 >     }
@@ -644,7 +1086,7 @@
 >         "Objective function for minimizing the number of shared 
 >         Shared Risk Link Groups (SRLG) (MSS).";
 >       reference
->         "RFC8685: Path Computation Element Communication Protocol 
+>         "RFC 8685: Path Computation Element Communication Protocol 
 >         (PCEP) Extensions for the Hierarchical Path Computation 
 >         Element (H-PCE) Architecture.";
 >     }
@@ -655,7 +1097,7 @@
 >         "Objective function for minimizing the number of shared 
 >         nodes (MSN).";
 >       reference
->         "RFC8685: Path Computation Element Communication Protocol 
+>         "RFC 8685: Path Computation Element Communication Protocol 
 >         (PCEP) Extensions for the Hierarchical Path Computation 
 >         Element (H-PCE) Architecture.";
 >     }
@@ -668,35 +1110,35 @@
 >     description
 >       "Base identity for SVEC metric type.";
 >     reference
->       "RFC5541: Encoding of Objective Functions in the Path
->        Computation Element Communication Protocol (PCEP).";
+>       "RFC 5541: Encoding of Objective Functions in the Path
+>        Computation Element Communication Protocol (PCEP)";
 >   }
 > 
->     identity svec-metric-cumul-te {
+>     identity svec-metric-cumulative-te {
 >       base svec-metric-type;
 >       description
 >         "Cumulative TE cost.";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
->     identity svec-metric-cumul-igp {
+>     identity svec-metric-cumulative-igp {
 >       base svec-metric-type;
 >       description
 >         "Cumulative IGP cost.";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
->     identity svec-metric-cumul-hop {
+>     identity svec-metric-cumulative-hop {
 >       base svec-metric-type;
 >       description
 >         "Cumulative Hop path metric.";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
 >     identity svec-metric-aggregate-bandwidth-consumption {
@@ -704,8 +1146,8 @@
 >       description
 >         "Aggregate bandwidth consumption.";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
 >     identity svec-metric-load-of-the-most-loaded-link {
@@ -713,15 +1155,29 @@
 >       description
 >         "Load of the most loaded link.";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
-2506a3121,3123
+2221,2225c3105,3111
+<       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions
+<        RFC 7823: Performance-Based Path Selection for Explicitly
+<        Routed Label Switched Paths (LSPs) Using TE Metric
+<        Extensions
+<        RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
+---
+>       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensionsù
+>       
+>       RFC 7823: Performance-Based Path Selection for Explicitly
+>       Routed Label Switched Paths (LSPs) Using TE Metric
+>       Extensions
+> 
+>       RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
+2506a3393,3395
 >   // CHANGE NOTE: The explicit-route-hop grouping below has been
 >   // updated in this module revision
 >   // RFC Editor: remove the note above and this note
-2514a3132,3140
+2514a3404,3412
 >           must "node-id-uri or node-id" {
 >             description
 >               "At least one node identifier MUST be present.";
@@ -731,9 +1187,9 @@
 >             description
 >               "The identifier of a node in the topology.";
 >           }
-2517d3142
+2517d3414
 <             mandatory true;
-2566a3192,3202
+2566a3464,3474
 >           must "(link-tp-id-uri or link-tp-id) and " +
 >                 "(node-id-uri or node-id)" {
 >             description
@@ -745,30 +1201,34 @@
 >             description
 >               "Link Termination Point (LTP) identifier.";
 >           }
-2569d3204
+2569d3476
 <             mandatory true;
-2574a3210,3214
+2574a3482,3486
 >           leaf node-id-uri {
 >             type nw:node-id;
 >             description
 >               "The identifier of a node in the topology.";
 >           }
-2577d3216
+2577d3488
 <             mandatory true;
-2646a3286,3289
+2631a3543,3545
+>   // CHANGE NOTE: The explicit-route-hop grouping below has been
+>   // updated in this module revision
+>   // RFC Editor: remove the note above and this note
+2646a3561,3564
 >           must "node-id-uri or node-id" {
 >             description
 >               "At least one node identifier MUST be present.";
 >           }
-2648a3292,3296
+2648a3567,3571
 >           leaf node-id-uri {
 >             type nw:node-id;
 >             description
 >               "The identifier of a node in the topology.";
 >           }
-2651d3298
+2651d3573
 <             mandatory true;
-2696a3344,3354
+2696a3619,3629
 >           must "(link-tp-id-uri or link-tp-id) and " +
 >               "(node-id-uri or node-id)" {
 >             description
@@ -780,44 +1240,103 @@
 >             description
 >               "Link Termination Point (LTP) identifier.";
 >           }
-2699d3356
+2699d3631
 <             mandatory true;
-2704a3362,3366
+2704a3637,3641
 >           leaf node-id-uri {
 >             type nw:node-id;
 >             description
 >               "The identifier of a node in the topology.";
 >           }
-2968a3631,3635
+2881a3819,3821
+>   // CHANGE NOTE: The grouping optimization-metric-entry below has
+>   // been updated in this module revision
+>   // RFC Editor: remove the note above and this note
+2887c3827
+<         base path-metric-type;
+---
+>         base path-metric-optimization-type;
+2964a3905,3907
+>   // CHANGE NOTE: The grouping tunnel-constraints below has
+>   // been updated in this module revision
+>   // RFC Editor: remove the note above and this note
+2968a3912,3916
 >     leaf network-id {
 >       type nw:network-id;
 >       description
 >         "The network topology identifier.";
 >     }
-2977c3644,3647
+2972a3921,3923
+>   // CHANGE NOTE: The grouping path-constraints-route-objects below
+>   // has been updated in this module revision
+>   // RFC Editor: remove the note above and this note
+2977c3928
 <     container explicit-route-objects-always {
 ---
->     // CHANGE NOTE: The explicit-route-objects container below has
->     // been updated in this module revision
->     // RFC Editor: remove the note above and this note
 >     container explicit-route-objects {
-2979c3649
+2979c3930
 <         "Container for the 'exclude route' object list.";
 ---
 >         "Container for the explicit route object lists.";
-3124,3126c3794,3800
+3101a4053,4055
+>   // CHANGE NOTE: The grouping generic-path-metric-bounds below
+>   // has been updated in this module revision
+>   // RFC Editor: remove the note above and this note
+3107c4061
+<         "TE path metric bounds container.";
+---
+>         "Top-level container for the list of path metric bounds.";
+3111c4065,4073
+<           "List of TE path metric bounds.";
+---
+>           "List of path metric bounds, which can apply to link and
+>           path metrics.
+>           
+>           TE paths which have at least one path metric which
+>           exceeds the specified bounds MUST NOT be selected.
+>           
+>           TE paths that traverse TE links which have at least one
+>           link metric which exceeds the specified bounds MUST NOT
+>           be selected.";
+3114c4076
+<             base path-metric-type;
+---
+>             base link-path-metric-type;
+3124,3126c4086,4092
 <             "Upper bound on the end-to-end TE path metric.  A zero
 <              indicates an unbounded upper limit for the specific
 <              'metric-type'.";
 ---
->             "Upper bound on the end-to-end TE path metric.
+>             "Upper bound on the specified 'metric-type'.
 >             
 >             A zero indicates an unbounded upper limit for the
->             specific 'metric-type'.
+>             specificied 'metric-type'.
 >             
 >             The unit of is interpreted in the context of the
->             path-metric-type.";
-3379c4053,4112
+>             'metric-type' identity.";
+3131a4098,4100
+>   // CHANGE NOTE: The grouping generic-path-metric-bounds below
+>   // has been updated in this module revision
+>   // RFC Editor: remove the note above and this note
+3154c4123,4127
+<               "Container for the list of tiebreakers.";
+---
+>               "Container for the list of tiebreakers.
+>               
+>               This container has been obsoleted by the tiebreaker
+>               leaf.";
+>             status deprecated;
+3189a4163,4171
+>     leaf tiebreaker {
+>       type identityref {
+>         base path-tiebreaker-type;
+>       }
+>       default "te-types:path-tiebreaker-random";
+>       description
+>         "The tiebreaker criteria to apply on an equally favored set
+>         of paths, in order to pick the best.";
+>     }
+3379c4361,4420
 < }
 \ No newline at end of file
 ---
@@ -836,7 +1355,7 @@
 >       description
 >         "LSP encoding type.";
 >       reference
->         "RFC3945";
+>         "RFC 3945";
 >     }
 >     leaf switching-type {
 >       type identityref {
@@ -845,7 +1364,7 @@
 >       description
 >         "LSP switching type.";
 >       reference
->         "RFC3945";
+>         "RFC 3945";
 >     }
 >   }
 > 

--- a/drafts/te-types-update/diffs/te-types/model-updates.txt
+++ b/drafts/te-types-update/diffs/te-types/model-updates.txt
@@ -21,61 +21,134 @@
     <      the license terms contained in, the Simplified BSD License set
     ---
     >      the license terms contained in, the Revised BSD License set
-    65,66c75,113
+    65,66c75,164
     <      This version of this YANG module is part of RFC 8776; see the
     <      RFC itself for full legal notices.";
     ---
     >      This version of this YANG module is part of RFC XXXX
     >      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
     >      for full legal notices.";
-    >   revision 2024-01-29 {
+    >   revision 2024-02-16 {
     >     description
-    >       "Added:
-    >       - base identity lsp-provisioning-error-reason;
-    >       - identity association-type-diversity;
-    >       - identity tunnel-admin-state-auto;
-    >       - identity lsp-restoration-restore-none;
-    >       - identity restoration-scheme-rerouting;
-    >       - base identity path-computation-error-reason and
-    >         its derived identities;
-    >       - base identity protocol-origin-type and
-    >         its derived identities;
-    >       - base identity svec-objective-function-type and its derived
-    >         identities;
-    >       - base identity svec-metric-type and its derived identities;
-    >       - grouping encoding-and-switching-type.
-    >       
-    >       Updated:
-    >       - description of the base identity objective-function-type;
-    >       - description and reference of identity action-exercise;
-    >       - typedef te-node-id to support also 16 octects TE identifiers.
-    >       
-    >       Obsoleted:
-    >       - identity of-minimize-agg-bandwidth-consumption;
-    >       - identity of-minimize-load-most-loaded-link;
-    >       - identity of-minimize-cost-path-set;
-    >       - identity lsp-protection-reroute-extra;
-    >       - identity lsp-protection-reroute.
+    >       "This revision adds the following new identities:
+    >       - lsp-provisioning-error-reason;
+    >       - association-type-diversity;
+    >       - tunnel-admin-state-auto;
+    >       - lsp-restoration-restore-none;
+    >       - restoration-scheme-rerouting;
+    >       - path-metric-optimization-type;
+    >       - link-path-metric-type;
+    >       - link-metric-type and its derived identities;
+    >       - path-computation-error-reason and its derived identities;
+    >       - protocol-origin-type and its derived identities;
+    >       - svec-objective-function-type and its derived identities;
+    >       - svec-metric-type and its derived identities.
     > 
-    >       Container explicit-route-objects-always renamed as
-    >       explicit-route-objects.";
+    >       This revision adds the following new data types:
+    >       - path-type;
+    >       - te-gen-node-id.
+    > 
+    >       This revision adds the following new groupings:
+    >       - encoding-and-switching-type;
+    >       - te-generic-node-id.
+    > 
+    >       This revision updates the following identities:
+    >       - objective-function-type;
+    >       - action-exercise;
+    >       - path-metric-type;
+    >       - path-metric-te;
+    >       - path-metric-igp;
+    >       - path-metric-hop;
+    >       - path-metric-delay-average;
+    >       - path-metric-delay-minimum;
+    >       - path-metric-residual-bandwidth;
+    >       - path-metric-optimize-includes;
+    >       - path-metric-optimize-excludes;
+    >       - te-optimization-criterion.
+    > 
+    >       This revision updates the following data types:
+    >       - te-node-id.
+    > 
+    >       This revision updates the following groupings:
+    >       - explicit-route-hop:
+    >         - adds the following leaves:
+    >           - node-id-uri;
+    >           - link-tp-id-uri;
+    >         - updates the following leaves:
+    >           - node-id;
+    >           - link-tp-id;
+    >       - record-route-state:
+    >         - adds the following leaves:
+    >           - node-id-uri;
+    >           - link-tp-id-uri;
+    >         - updates the following leaves:
+    >           - node-id;
+    >           - link-tp-id;
+    >       - optimization-metric-entry:
+    >         - updates the following leaves:
+    >           - metric-type;
+    >       - tunnel-constraints;
+    >         - adds the following leaves:
+    >           - network-id;
+    >       - path-constraints-route-objects:
+    >         - updates the following containers:
+    >           - explicit-route-objects-always;
+    >       - generic-path-metric-bounds:
+    >         - updates the following leaves:
+    >           - metric-type;
+    >       - generic-path-optimization
+    >         - adds the following leaves:
+    >           - tiebreaker;
+    >         - deprecate the following containers:
+    >           - tiebreakers.
+    > 
+    >       This revision obsoletes the following identities:
+    >       - of-minimize-agg-bandwidth-consumption;
+    >       - of-minimize-load-most-loaded-link;
+    >       - of-minimize-cost-path-set;
+    >       - lsp-protection-reroute-extra;
+    >       - lsp-protection-reroute.
+    > 
+    >       This revision provides also few editorial changes.";
     >     reference
     >       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
     >   }
     >   // RFC Editor: replace XXXX with actual RFC number, update date
     >   // information and remove this note
-    351a399,401
+    70c168
+    <       "Latest revision of TE types.";
+    ---
+    >       "Initial Version of TE types.";
+    86a185
+    > 
+    92a192
+    > 
+    93a194
+    >        
+    111a213
+    > 
+    155a258
+    > 
+    158a262
+    > 
+    263a368
+    > 
+    264a370
+    > 
+    269a376
+    > 
+    351a459,461
     >   // CHANGE NOTE: The typedef te-node-id below has been
     >   // updated in this module revision
     >   // RFC Editor: remove the note above and this note
-    353c403,406
+    353c463,466
     <     type yang:dotted-quad;
     ---
     >     type union {
     >       type yang:dotted-quad;
     >       type inet:ipv6-address-no-zone;
     >     }
-    357,358c410,414
+    357,358c470,474
     <        The identifier is represented as 4 octets in dotted-quad
     <        notation.
     ---
@@ -84,7 +157,7 @@
     >        dotted-quad notation or 16 octets in full, mixed, shortened,
     >        or shortened-mixed IPv6 address notation.
     > 
-    362,363c418,421
+    362,363c478,481
     <        Router ID TLV described in Section 4.3 of RFC 5305, or the
     <        TE Router ID TLV described in Section 3.2.1 of RFC 6119.
     ---
@@ -92,13 +165,17 @@
     >        Router ID TLV described in Section 3.2.1 of RFC 6119, or the
     >        IPv6 TE Router ID TLV described in Section 4.1 of RFC 6119.
     > 
-    368a427
+    368a487
     > 
-    370a430
+    370a490
     > 
-    371a432
+    371a492
     > 
-    545a607,647
+    519a641
+    > 
+    537a660
+    > 
+    545a669,709
     >   // CHANGE NOTE: The typedef path-type below has been
     >   // added in this module revision
     >   // RFC Editor: remove the note above and this note
@@ -140,7 +217,7 @@
     >       "Generic type that identifies a node in a TE topology.";
     >   }
     > 
-    606a709,716
+    606a771,778
     >   // CHANGE NOTE: The base identity lsp-provisioning-error-reason 
     >   // has been added in this module revision
     >   // RFC Editor: remove the note above and this note
@@ -149,7 +226,7 @@
     >       "Base identity for LSP provisioning errors.";
     >   }
     > 
-    982a1093,1110
+    982a1155,1172
     >   // CHANGE NOTE: The identity association-type-diversity below has 
     >   // been added in this module revision
     >   // RFC Editor: remove the note above and this note
@@ -159,7 +236,7 @@
     >       "Association Type diversity used to associate LSPs whose 
     >       paths are to be diverse from each other.";
     >     reference
-    >       "RFC8800: Path Computation Element Communication Protocol 
+    >       "RFC 8800: Path Computation Element Communication Protocol 
     >       (PCEP) Extension for Label Switched Path (LSP) Diversity 
     >       Constraint Signaling";
     >   }
@@ -168,45 +245,92 @@
     >   // objective-function-type has been updated 
     >   // in this module revision
     >   // RFC Editor: remove the note above and this note
-    985c1113
+    985c1175
     <       "Base objective function type.";
     ---
-    >       "Base identity for path objective function type.";
-    1015a1144,1146
+    >       "Base identity for path objective function types.";
+    1015a1206,1208
     >   // CHANGE NOTE: The identity of-minimize-agg-bandwidth-consumption
     >   // below has been obsoleted in this module revision
     >   // RFC Editor: remove the note above and this note
-    1017a1149
+    1017a1211
     >     status obsolete;
-    1020c1152
+    1020c1214,1218
     <        consumption.";
     ---
-    >       consumption.";
-    1023c1155
+    >       consumption.
+    >       
+    >       This identity has been obsoleted: the
+    >       'svec-of-minimize-agg-bandwidth-consumption' identity SHOULD
+    >       be used instead.";
+    1023c1221
     <        Computation Element Communication Protocol (PCEP)";
     ---
     >       Computation Element Communication Protocol (PCEP)";
-    1025a1158,1160
+    1025a1224,1226
     >   // CHANGE NOTE: The identity of-minimize-load-most-loaded-link
     >   // below has been obsoleted in this module revision
     >   // RFC Editor: remove the note above and this note
-    1027a1163
+    1027a1229
     >     status obsolete;
-    1030c1166
+    1030c1232,1236
     <        is carrying the highest load.";
     ---
-    >       is carrying the highest load.";
-    1033c1169
+    >       is carrying the highest load.
+    >       
+    >       This identity has been obsoleted: the
+    >       'svec-of-minimize-load-most-loaded-link' identity SHOULD
+    >       be used instead.";
+    1033c1239
     <        Computation Element Communication Protocol (PCEP)";
     ---
     >       Computation Element Communication Protocol (PCEP)";
-    1035a1172,1174
+    1035a1242,1244
     >   // CHANGE NOTE: The identity of-minimize-cost-path-set
     >   // below has been obsoleted in this module revision
     >   // RFC Editor: remove the note above and this note
-    1037a1177
+    1037a1247
     >     status obsolete;
-    1216a1357,1368
+    1039c1249,1253
+    <       "Objective function for minimizing the cost on a path set.";
+    ---
+    >       "Objective function for minimizing the cost on a path set.
+    >       
+    >       This identity has been obsoleted: the
+    >       'svec-of-minimize-cost-path-set' identity SHOULD
+    >       be used instead.";
+    1049a1264,1266
+    >   // CHANGE NOTE: The reference of the identity path-locally-computed
+    >   // below has been updated in this module revision
+    >   // RFC Editor: remove the note above and this note
+    1056,1057c1273,1274
+    <       "RFC 3272: Overview and Principles of Internet Traffic
+    <        Engineering, Section 5.4";
+    ---
+    >       "RFC 9522: Overview and Principles of Internet Traffic
+    >       Engineering, Section 4.4";
+    1059a1277,1280
+    >   // CHANGE NOTE: The reference of the identity 
+    >   // path-externally-queried below has been updated
+    >   // in this module revision
+    >   // RFC Editor: remove the note above and this note
+    1071c1292
+    <       "RFC 3272: Overview and Principles of Internet Traffic
+    ---
+    >       "RFC 9522: Overview and Principles of Internet Traffic
+    1072a1294
+    > 
+    1076a1299,1302
+    >   // CHANGE NOTE: The reference of the identity 
+    >   // path-explicitly-defined below has been updated
+    >   // in this module revision
+    >   // RFC Editor: remove the note above and this note
+    1085c1311,1312
+    <        RFC 3272: Overview and Principles of Internet Traffic
+    ---
+    > 
+    >        RFC 9522: Overview and Principles of Internet Traffic
+    1216a1444,1455
     >   // CHANGE NOTE: The identity tunnel-admin-state-auto below
     >   // has been added in this module revision
     >   // RFC Editor: remove the note above and this note
@@ -219,7 +343,7 @@
     >       when it is not used by the client layer.";
     >   }
     > 
-    1321a1474,1482
+    1321a1561,1569
     >     // CHANGE NOTE: The identity lsp-restoration-restore-none 
     >     // below has been added in this module revision
     >     // RFC Editor: remove the note above and this note
@@ -229,7 +353,7 @@
     >         "No LSP affected by a failure is restored.";
     >     }
     > 
-    1339a1501,1515
+    1339a1588,1602
     >     // CHANGE NOTE: The identity restoration-scheme-rerouting 
     >     // below has been added in this module revision
     >     // RFC Editor: remove the note above and this note
@@ -245,13 +369,13 @@
     >         for Generalized Multi-Protocol Label Switching (GMPLS)";
     >     }
     > 
-    1383a1560,1562
+    1383a1647,1649
     >   // CHANGE NOTE: The identity lsp-protection-reroute-extra
     >   // below has been obsoleted in this module revision
     >   // RFC Editor: remove the note above and this note
-    1385a1565
+    1385a1652
     >     status obsolete;
-    1387c1567,1571
+    1387c1654,1658
     <       "'(Full) Rerouting' LSP protection type.";
     ---
     >       "'(Full) Rerouting' LSP protection type.
@@ -259,13 +383,13 @@
     >       This identity has been obsoleted: the
     >       'restoration-scheme-rerouting' identity SHOULD be used
     >       instead.";
-    1392a1577,1579
+    1392a1664,1666
     >   // CHANGE NOTE: The identity lsp-protection-reroute
     >   // below has been obsoleted in this module revision
     >   // RFC Editor: remove the note above and this note
-    1394a1582
+    1394a1669
     >     status obsolete;
-    1396c1584,1588
+    1396c1671,1675
     <       "'Rerouting without Extra-Traffic' LSP protection type.";
     ---
     >       "'Rerouting without Extra-Traffic' LSP protection type.
@@ -273,46 +397,327 @@
     >       This identity has been obsoleted: the
     >       'restoration-scheme-rerouting' identity SHOULD be used
     >       instead.";
-    1628a1821,1824
+    1628a1908,1911
     >   // CHANGE NOTE: The description and reference of the 
     >   // identity action-exercise have been updated in this module 
     >   // revision
     >   // RFC Editor: remove the note above and this note
-    1632,1633c1828,1830
+    1632,1633c1915,1917
     <       "An action that starts testing whether or not APS communication
     <        is operating correctly.  It is of lower priority than any
     ---
     >       "An action that starts testing whether or not Automatic 
     >        Protection Switching (APS) communication is operating 
     >        correctly.  It is of lower priority than any
-    1636,1637c1833,1834
+    1636,1637c1920,1921
     <       "RFC 4427: Recovery (Protection and Restoration) Terminology
     <        for Generalized Multi-Protocol Label Switching (GMPLS)";
     ---
     >       "ITU-T G.808.1 v4.0 (05/2014): Generic protection switching - 
     >       Linear trail and subnetwork protection";
-    1916a2114,2116
-    >   // CHANGE NOTE: The description of the identity path-metric-type
-    >   // has been updated in this module revision
-    >   // RFC Editor: remove the note above and this note
-    1919c2119,2122
-    <       "Base identity for the path metric type.";
+    1917c2201,2204
+    <   identity path-metric-type {
     ---
-    >       "Base identity for the path metric type.
-    >       
-    >       Derived identities SHOULD describe the unit and maximum value
-    >       of the path metric types they define.";
-    1939a2143,2145
-    >   // CHANGE NOTE: The reference for the identity path-metric-hop
+    >   // CHANGE NOTE: The path-metric-optimization-type base identity
     >   // has been added in this module revision
     >   // RFC Editor: remove the note above and this note
-    1943a2150,2152
-    >     reference
-    >       "RFC5440: Path Computation Element (PCE) Communication
-    >       Protocol (PCEP)";
-    1945a2155
+    >   identity path-metric-optimization-type {
+    1919c2206,2207
+    <       "Base identity for the path metric type.";
+    ---
+    >       "Base identity used to define the path metric optimization
+    >       types.";
+    1922,1923c2210,2213
+    <   identity path-metric-te {
+    <     base path-metric-type;
+    ---
+    >   // CHANGE NOTE: The link-path-metric-type base identity
+    >   // has been added in this module revision
+    >   // RFC Editor: remove the note above and this note
+    >   identity link-path-metric-type {
+    1925,1928c2215,2221
+    <       "TE path metric.";
+    <     reference
+    <       "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+    <        second MPLS Traffic Engineering (TE) Metric";
+    ---
+    >       "Base identity used to define the link and the path metric
+    >       types.
+    >       
+    >       The unit of the path metric value is interpreted in the
+    >       context of the path metric type and the derived identities
+    >       SHOULD describe the unit of the path metric types they
+    >       define.";
+    1931,1938c2224,2232
+    <   identity path-metric-igp {
+    <     base path-metric-type;
+    <     description
+    <       "IGP path metric.";
+    <     reference
+    <       "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+    <        second MPLS Traffic Engineering (TE) Metric";
+    <   }
+    ---
+    >     // CHANGE NOTE: The link-metric-type base identity
+    >     // and its derived identities
+    >     // have been added in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity link-metric-type {
+    >       base link-path-metric-type;
+    >       description
+    >         "Base identity for the link metric types.";
+    >     }
+    1940,1944c2234,2240
+    <   identity path-metric-hop {
+    <     base path-metric-type;
+    <     description
+    <       "Hop path metric.";
+    <   }
+    ---
+    >       identity link-metric-te {
+    >         base link-metric-type;
+    >         description
+    >           "Traffic Engineering (TE) Link Metric.";
+    >         reference
+    >           "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+    >           Version 2, section 2.5.5
+    1946,1952c2242,2244
+    <   identity path-metric-delay-average {
+    <     base path-metric-type;
+    <     description
+    <       "Average unidirectional link delay.";
+    <     reference
+    <       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+    <   }
+    ---
+    >           RFC 5305: IS-IS Extensions for Traffic Engineering,
+    >           section 3.7";
+    >       }
+    1954,1960c2246,2253
+    <   identity path-metric-delay-minimum {
+    <     base path-metric-type;
+    <     description
+    <       "Minimum unidirectional link delay.";
+    <     reference
+    <       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+    <   }
+    ---
+    >       identity link-metric-igp {
+    >         base link-metric-type;
+    >         description
+    >           "Interior Gateway Protocol (IGP) Link Metric.";
+    >         reference
+    >           "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric
+    >           as a second MPLS Traffic Engineering (TE) Metric";
+    >       }
+    1962,1972c2255,2266
+    <   identity path-metric-residual-bandwidth {
+    <     base path-metric-type;
+    <     description
+    <       "Unidirectional Residual Bandwidth, which is defined to be
+    <        Maximum Bandwidth (RFC 3630) minus the bandwidth currently
+    <        allocated to LSPs.";
+    <     reference
+    <       "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+    <        Version 2
+    <        RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+    <   }
+    ---
+    >       identity link-metric-delay-average {
+    >         base link-metric-type;
+    >         description
+    >           "Unidirectional Link Delay, measured in units of
+    >           microseconds.";
+    >         reference
+    >           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+    >           Extensions, section 4.1
+    >           
+    >           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+    >           Extensions, section 4.1";
+    >       }
+    1974,1979c2268,2279
+    <   identity path-metric-optimize-includes {
+    <     base path-metric-type;
+    <     description
+    <       "A metric that optimizes the number of included resources
+    <        specified in a set.";
+    <   }
+    ---
+    >       identity link-metric-delay-minimum {
+    >         base link-metric-type;
+    >         description
+    >           "Minimum unidirectional Link Delay, measured in units of
+    >           microseconds.";
+    >         reference
+    >           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+    >           Extensions, section 4.2
+    >           
+    >           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+    >           Extensions, section 4.2";
+    >       }
+    1981,1986c2281,2425
+    <   identity path-metric-optimize-excludes {
+    <     base path-metric-type;
+    <     description
+    <       "A metric that optimizes to a maximum the number of excluded
+    <        resources specified in a set.";
+    <   }
+    ---
+    >       identity link-metric-delay-maximum {
+    >         base link-metric-type;
+    >         description
+    >           "Maximum unidirectional Link Delay, measured in units of
+    >           microseconds.";
+    >         reference
+    >           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+    >           Extensions, section 4.2
+    >           
+    >           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+    >           Extensions, section 4.2";
+    >       }
     > 
-    2110a2321,2724
+    >       identity link-metric-residual-bandwidth {
+    >         base link-metric-type;
+    >         description
+    >           "Unidirectional Residual Bandwidth, measured in units of
+    >           bytes per second.
+    >           
+    >           It is defined to be Maximum Bandwidth minus the bandwidth
+    >           currently allocated to LSPs.";
+    >         reference
+    >           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+    >           Extensions, section 4.5
+    >           
+    >           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+    >           Extensions, section 4.5";
+    >       }
+    > 
+    >     // CHANGE NOTE: The base and the description of the
+    >     // path-metric-type identity
+    >     // has been updated in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity path-metric-type {
+    >       base link-path-metric-type;
+    >       base path-metric-optimization-type;
+    >       description
+    >         "Base identity for the path metric types.";
+    >     }
+    > 
+    >       // CHANGE NOTE: The description and the reference of the
+    >       // path-metric-te identity have been updated
+    >       // in this module revision
+    >       // RFC Editor: remove the note above and this note
+    >       identity path-metric-te {
+    >         base path-metric-type;
+    >         description
+    >           "Traffic Engineering (TE) Path Metric.";
+    >         reference
+    >           "RFC 5440: Path Computation Element (PCE) Communication
+    >           Protocol (PCEP), section 7.8";
+    >       }
+    > 
+    >       // CHANGE NOTE: The description and the reference of the
+    >       // path-metric-igp identity have been updated 
+    >       // in this module revision
+    >       // RFC Editor: remove the note above and this note
+    >       identity path-metric-igp {
+    >         base path-metric-type;
+    >         description
+    >           "Interior Gateway Protocol (IGP) Path Metric.";
+    >         reference
+    >           "RFC 5440: Path Computation Element (PCE) Communication
+    >           Protocol (PCEP), section 7.8";
+    >       }
+    > 
+    >       // CHANGE NOTE: The description and the reference of the
+    >       // path-metric-hop identity have been updated
+    >       // in this module revision
+    >       // RFC Editor: remove the note above and this note
+    >       identity path-metric-hop {
+    >         base path-metric-type;
+    >         description
+    >           "Hop Count Path Metric.";
+    >         reference
+    >           "RFC 5440: Path Computation Element (PCE) Communication
+    >           Protocol (PCEP), section 7.8";
+    >       }
+    > 
+    >       // CHANGE NOTE: The description and the reference of the
+    >       // path-metric-delay-average identity have been updated
+    >       // in this module revision
+    >       // RFC Editor: remove the note above and this note
+    >       identity path-metric-delay-average {
+    >         base path-metric-type;
+    >         description
+    >           "The Path Delay Metric, measured in units of
+    >           microseconds.";
+    >         reference
+    >           "RFC8233: Extensions to the Path Computation Element
+    >           Communication Protocol (PCEP) to Compute Service-Aware
+    >           Label Switched Paths (LSPs), section 3.1.1";
+    >       }
+    > 
+    >       // CHANGE NOTE: The description and the reference of the
+    >       // path-metric-delay-minimum identity have been updated
+    >       // in this module revision
+    >       // RFC Editor: remove the note above and this note
+    >       identity path-metric-delay-minimum {
+    >         base path-metric-type;
+    >         description
+    >           "The Path Min Delay Metric, measured in units of
+    >           microseconds.";
+    >         reference
+    >           "I-D.ietf-pce-sid-algo: Carrying SR-Algorithm information
+    >           in PCE-based Networks, section 3.5.1";
+    >       }
+    > 
+    >       // CHANGE NOTE: The description and the reference of the
+    >       // path-metric-residual-bandwidth identity have been updated
+    >       // in this module revision
+    >       // RFC Editor: remove the note above and this note
+    >       identity path-metric-residual-bandwidth {
+    >         base path-metric-type;
+    >         description
+    >           "The Path Residual Bandwidth, defined as the minimum Link
+    >           Residual Bandwidth all the links along the path.
+    > 
+    >           The Path Residual Bandwidth can be seen as the path
+    >           metric associated with the Maximum residual Bandwidth Path
+    >           (MBP) objective function.";
+    >         reference
+    >           "RFC 5541: Encoding of Objective Functions in the Path
+    >           Computation Element Communication Protocol (PCEP)";
+    >       }
+    > 
+    >     // CHANGE NOTE: The base of the path-metric-optimize-includes
+    >     // identity has been updated in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity path-metric-optimize-includes {
+    >       base path-metric-optimization-type;
+    >       description
+    >         "A metric that optimizes the number of included resources
+    >         specified in a set.";
+    >     }
+    > 
+    >     // CHANGE NOTE: The base of the path-metric-optimize-excludes
+    >     // identity has been updated in this module revision
+    >     // RFC Editor: remove the note above and this note
+    >     identity path-metric-optimize-excludes {
+    >       base path-metric-optimization-type;
+    >       description
+    >         "A metric that optimizes to a maximum the number of excluded
+    >         resources specified in a set.";
+    >     }
+    2049a2489,2492
+    >   // CHANGE NOTE: The reference of the identity 
+    >   // te-optimization-criterion below has been updated
+    >   // in this module revision
+    >   // RFC Editor: remove the note above and this note
+    2054c2497
+    <       "RFC 3272: Overview and Principles of Internet Traffic
+    ---
+    >       "RFC 9522: Overview and Principles of Internet Traffic
+    2110a2554,2994
     >   // CHANGE NOTE: The base identity path-computation-error-reason 
     >   // and its derived identities below have been
     >   // added in this module revision
@@ -328,8 +733,8 @@
     >         "Path computation has failed because of an unspecified 
     >         reason.";
     >       reference
-    >         "Section 7.5 of RFC5440: Path Computation Element (PCE)
-    >         Communication Protocol (PCEP)";
+    >         "RFC 5440: Path Computation Element (PCE) Communication
+    >         Protocol (PCEP), section 7.5";
     >     }
     > 
     >     identity path-computation-error-no-topology {
@@ -349,7 +754,13 @@
     >         a Backward-Recursive Path Computation (BRPC) downstream
     >         PCE or a child PCE.";
     >       reference
-    >         "RFC5441, RFC8685";
+    >         "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+    >         Procedure to Compute Shortest Constrained Inter-Domain
+    >         Traffic Engineering Label Switched Paths
+    >         
+    >         RFC 8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture";
     >     }
     > 
     >     identity path-computation-error-pce-unavailable {
@@ -360,10 +771,11 @@
     >         It corresponds to bit 31 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC5440: Path Computation Element (PCE) Communication
-    >         Protocol (PCEP);
+    >         "RFC 5440: Path Computation Element (PCE) Communication
+    >         Protocol (PCEP)
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-no-inclusion-hop {
@@ -382,9 +794,12 @@
     >         It corresponds to bit 19 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC8685;
+    >         "RFC 8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-no-resource {
@@ -396,9 +811,12 @@
     >         It corresponds to bit 20 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC8685;
+    >         "RFC 8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-child-pce-unresponsive {
@@ -410,9 +828,12 @@
     >         It corresponds to bit 21 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC8685;
+    >         "RFC 8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-destination-domain-unknown {
@@ -424,9 +845,12 @@
     >         It corresponds to bit 22 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC8685;
+    >         "RFC 8685: Path Computation Element Communication Protocol 
+    >         (PCEP) Extensions for the Hierarchical Path Computation 
+    >         Element (H-PCE) Architecture
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-p2mp {
@@ -438,9 +862,12 @@
     >         It corresponds to bit 24 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC8306;
+    >         "RFC 8306: Extensions to the Path Computation Element
+    >         Communication Protocol (PCEP) for Point-to-Multipoint
+    >         Traffic Engineering Label Switched Paths
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-no-gco-migration {
@@ -452,9 +879,12 @@
     >         It corresponds to bit 26 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC5557;
+    >         "RFC 5557: Path Computation Element Communication Protocol
+    >         (PCEP) Requirements and Protocol Extensions in Support of
+    >         Global Concurrent Optimization
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-no-gco-solution {
@@ -466,9 +896,12 @@
     >         It corresponds to bit 25 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC5557;
+    >         "RFC 5557: Path Computation Element Communication Protocol
+    >         (PCEP) Requirements and Protocol Extensions in Support of
+    >         Global Concurrent Optimization
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-pks-expansion {
@@ -480,9 +913,12 @@
     >         It corresponds to bit 27 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC5520;
+    >         "RFC 5520: Preserving Topology Confidentiality in
+    >         Inter-Domain Path Computation Using a Path-Key-Based
+    >         Mechanism
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-brpc-chain-unavailable {
@@ -494,9 +930,12 @@
     >         It corresponds to bit 28 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC5441;
+    >         "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+    >         Procedure to Compute Shortest Constrained Inter-Domain
+    >         Traffic Engineering Label Switched Paths
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-source-unknown {
@@ -508,10 +947,11 @@
     >         It corresponds to bit 29 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC5440: Path Computation Element (PCE) Communication
+    >         "RFC 5440: Path Computation Element (PCE) Communication
     >         Protocol (PCEP);
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-destination-unknown {
@@ -523,10 +963,11 @@
     >         It corresponds to bit 30 of the Flags field of the 
     >         NO-PATH-VECTOR TLV.";
     >       reference
-    >         "RFC5440: Path Computation Element (PCE) Communication
+    >         "RFC 5440: Path Computation Element (PCE) Communication
     >         Protocol (PCEP);
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >     identity path-computation-error-no-server {
@@ -535,10 +976,11 @@
     >         "Path computation has failed because path computation
     >         server is unavailable.";
     >       reference
-    >         "RFC5440: Path Computation Element (PCE) Communication
+    >         "RFC 5440: Path Computation Element (PCE) Communication
     >         Protocol (PCEP);
     >         
-    >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+    >         https://www.iana.org/assignments/pcep
+    >         /pcep.xhtml#no-path-vector-tlv";
     >     }
     > 
     >   // CHANGE NOTE: The base identity protocol-origin-type and 
@@ -563,7 +1005,7 @@
     >         "Protocol origin is Path Computation Engine Protocol 
     >         (PCEP).";
     >       reference
-    >         "RFC5440: Path Computation Element (PCE) Communication
+    >         "RFC 5440: Path Computation Element (PCE) Communication
     >         Protocol (PCEP)";
     >     }
     > 
@@ -571,7 +1013,7 @@
     >       base protocol-origin-type;
     >       description
     >         "Protocol origin is Border Gateway Protocol (BGP).";
-    >       reference "RFC9012";
+    >       reference "RFC 9012";
     >     }
     > 
     >   // CHANGE NOTE: The base identity svec-objective-function-type 
@@ -582,8 +1024,8 @@
     >     description
     >       "Base identity for SVEC objective function type.";
     >     reference
-    >       "RFC5541: Encoding of Objective Functions in the Path
-    >        Computation Element Communication Protocol (PCEP).";
+    >       "RFC 5541: Encoding of Objective Functions in the Path
+    >        Computation Element Communication Protocol (PCEP)";
     >   }
     > 
     >     identity svec-of-minimize-agg-bandwidth-consumption {
@@ -592,8 +1034,8 @@
     >         "Objective function for minimizing aggregate bandwidth 
     >         consumption (MBC).";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
     >     identity svec-of-minimize-load-most-loaded-link {
@@ -602,8 +1044,8 @@
     >         "Objective function for minimizing the load on the link that 
     >         is carrying the highest load (MLL).";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
     >     identity svec-of-minimize-cost-path-set {
@@ -612,8 +1054,8 @@
     >         "Objective function for minimizing the cost on a path set 
     >         (MCC).";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
     >     identity svec-of-minimize-common-transit-domain {
@@ -622,9 +1064,9 @@
     >         "Objective function for minimizing the number of common 
     >         transit domains (MCTD).";
     >       reference
-    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         "RFC 8685: Path Computation Element Communication Protocol 
     >         (PCEP) Extensions for the Hierarchical Path Computation 
-    >         Element (H-PCE) Architecture.";
+    >         Element (H-PCE) Architecture";
     >     }
     > 
     >     identity svec-of-minimize-shared-link {
@@ -633,7 +1075,7 @@
     >         "Objective function for minimizing the number of shared 
     >         links (MSL).";
     >       reference
-    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         "RFC 8685: Path Computation Element Communication Protocol 
     >         (PCEP) Extensions for the Hierarchical Path Computation 
     >         Element (H-PCE) Architecture.";
     >     }
@@ -644,7 +1086,7 @@
     >         "Objective function for minimizing the number of shared 
     >         Shared Risk Link Groups (SRLG) (MSS).";
     >       reference
-    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         "RFC 8685: Path Computation Element Communication Protocol 
     >         (PCEP) Extensions for the Hierarchical Path Computation 
     >         Element (H-PCE) Architecture.";
     >     }
@@ -655,7 +1097,7 @@
     >         "Objective function for minimizing the number of shared 
     >         nodes (MSN).";
     >       reference
-    >         "RFC8685: Path Computation Element Communication Protocol 
+    >         "RFC 8685: Path Computation Element Communication Protocol 
     >         (PCEP) Extensions for the Hierarchical Path Computation 
     >         Element (H-PCE) Architecture.";
     >     }
@@ -668,35 +1110,35 @@
     >     description
     >       "Base identity for SVEC metric type.";
     >     reference
-    >       "RFC5541: Encoding of Objective Functions in the Path
-    >        Computation Element Communication Protocol (PCEP).";
+    >       "RFC 5541: Encoding of Objective Functions in the Path
+    >        Computation Element Communication Protocol (PCEP)";
     >   }
     > 
-    >     identity svec-metric-cumul-te {
+    >     identity svec-metric-cumulative-te {
     >       base svec-metric-type;
     >       description
     >         "Cumulative TE cost.";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
-    >     identity svec-metric-cumul-igp {
+    >     identity svec-metric-cumulative-igp {
     >       base svec-metric-type;
     >       description
     >         "Cumulative IGP cost.";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
-    >     identity svec-metric-cumul-hop {
+    >     identity svec-metric-cumulative-hop {
     >       base svec-metric-type;
     >       description
     >         "Cumulative Hop path metric.";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
     >     identity svec-metric-aggregate-bandwidth-consumption {
@@ -704,8 +1146,8 @@
     >       description
     >         "Aggregate bandwidth consumption.";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
     >     identity svec-metric-load-of-the-most-loaded-link {
@@ -713,15 +1155,29 @@
     >       description
     >         "Load of the most loaded link.";
     >       reference
-    >         "RFC5541: Encoding of Objective Functions in the Path
-    >         Computation Element Communication Protocol (PCEP).";
+    >         "RFC 5541: Encoding of Objective Functions in the Path
+    >         Computation Element Communication Protocol (PCEP)";
     >     }
     > 
-    2506a3121,3123
+    2221,2225c3105,3111
+    <       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions
+    <        RFC 7823: Performance-Based Path Selection for Explicitly
+    <        Routed Label Switched Paths (LSPs) Using TE Metric
+    <        Extensions
+    <        RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
+    ---
+    >       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensionsù
+    >       
+    >       RFC 7823: Performance-Based Path Selection for Explicitly
+    >       Routed Label Switched Paths (LSPs) Using TE Metric
+    >       Extensions
+    > 
+    >       RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
+    2506a3393,3395
     >   // CHANGE NOTE: The explicit-route-hop grouping below has been
     >   // updated in this module revision
     >   // RFC Editor: remove the note above and this note
-    2514a3132,3140
+    2514a3404,3412
     >           must "node-id-uri or node-id" {
     >             description
     >               "At least one node identifier MUST be present.";
@@ -731,9 +1187,9 @@
     >             description
     >               "The identifier of a node in the topology.";
     >           }
-    2517d3142
+    2517d3414
     <             mandatory true;
-    2566a3192,3202
+    2566a3464,3474
     >           must "(link-tp-id-uri or link-tp-id) and " +
     >                 "(node-id-uri or node-id)" {
     >             description
@@ -745,30 +1201,34 @@
     >             description
     >               "Link Termination Point (LTP) identifier.";
     >           }
-    2569d3204
+    2569d3476
     <             mandatory true;
-    2574a3210,3214
+    2574a3482,3486
     >           leaf node-id-uri {
     >             type nw:node-id;
     >             description
     >               "The identifier of a node in the topology.";
     >           }
-    2577d3216
+    2577d3488
     <             mandatory true;
-    2646a3286,3289
+    2631a3543,3545
+    >   // CHANGE NOTE: The explicit-route-hop grouping below has been
+    >   // updated in this module revision
+    >   // RFC Editor: remove the note above and this note
+    2646a3561,3564
     >           must "node-id-uri or node-id" {
     >             description
     >               "At least one node identifier MUST be present.";
     >           }
-    2648a3292,3296
+    2648a3567,3571
     >           leaf node-id-uri {
     >             type nw:node-id;
     >             description
     >               "The identifier of a node in the topology.";
     >           }
-    2651d3298
+    2651d3573
     <             mandatory true;
-    2696a3344,3354
+    2696a3619,3629
     >           must "(link-tp-id-uri or link-tp-id) and " +
     >               "(node-id-uri or node-id)" {
     >             description
@@ -780,44 +1240,103 @@
     >             description
     >               "Link Termination Point (LTP) identifier.";
     >           }
-    2699d3356
+    2699d3631
     <             mandatory true;
-    2704a3362,3366
+    2704a3637,3641
     >           leaf node-id-uri {
     >             type nw:node-id;
     >             description
     >               "The identifier of a node in the topology.";
     >           }
-    2968a3631,3635
+    2881a3819,3821
+    >   // CHANGE NOTE: The grouping optimization-metric-entry below has
+    >   // been updated in this module revision
+    >   // RFC Editor: remove the note above and this note
+    2887c3827
+    <         base path-metric-type;
+    ---
+    >         base path-metric-optimization-type;
+    2964a3905,3907
+    >   // CHANGE NOTE: The grouping tunnel-constraints below has
+    >   // been updated in this module revision
+    >   // RFC Editor: remove the note above and this note
+    2968a3912,3916
     >     leaf network-id {
     >       type nw:network-id;
     >       description
     >         "The network topology identifier.";
     >     }
-    2977c3644,3647
+    2972a3921,3923
+    >   // CHANGE NOTE: The grouping path-constraints-route-objects below
+    >   // has been updated in this module revision
+    >   // RFC Editor: remove the note above and this note
+    2977c3928
     <     container explicit-route-objects-always {
     ---
-    >     // CHANGE NOTE: The explicit-route-objects container below has
-    >     // been updated in this module revision
-    >     // RFC Editor: remove the note above and this note
     >     container explicit-route-objects {
-    2979c3649
+    2979c3930
     <         "Container for the 'exclude route' object list.";
     ---
     >         "Container for the explicit route object lists.";
-    3124,3126c3794,3800
+    3101a4053,4055
+    >   // CHANGE NOTE: The grouping generic-path-metric-bounds below
+    >   // has been updated in this module revision
+    >   // RFC Editor: remove the note above and this note
+    3107c4061
+    <         "TE path metric bounds container.";
+    ---
+    >         "Top-level container for the list of path metric bounds.";
+    3111c4065,4073
+    <           "List of TE path metric bounds.";
+    ---
+    >           "List of path metric bounds, which can apply to link and
+    >           path metrics.
+    >           
+    >           TE paths which have at least one path metric which
+    >           exceeds the specified bounds MUST NOT be selected.
+    >           
+    >           TE paths that traverse TE links which have at least one
+    >           link metric which exceeds the specified bounds MUST NOT
+    >           be selected.";
+    3114c4076
+    <             base path-metric-type;
+    ---
+    >             base link-path-metric-type;
+    3124,3126c4086,4092
     <             "Upper bound on the end-to-end TE path metric.  A zero
     <              indicates an unbounded upper limit for the specific
     <              'metric-type'.";
     ---
-    >             "Upper bound on the end-to-end TE path metric.
+    >             "Upper bound on the specified 'metric-type'.
     >             
     >             A zero indicates an unbounded upper limit for the
-    >             specific 'metric-type'.
+    >             specificied 'metric-type'.
     >             
     >             The unit of is interpreted in the context of the
-    >             path-metric-type.";
-    3379c4053,4112
+    >             'metric-type' identity.";
+    3131a4098,4100
+    >   // CHANGE NOTE: The grouping generic-path-metric-bounds below
+    >   // has been updated in this module revision
+    >   // RFC Editor: remove the note above and this note
+    3154c4123,4127
+    <               "Container for the list of tiebreakers.";
+    ---
+    >               "Container for the list of tiebreakers.
+    >               
+    >               This container has been obsoleted by the tiebreaker
+    >               leaf.";
+    >             status deprecated;
+    3189a4163,4171
+    >     leaf tiebreaker {
+    >       type identityref {
+    >         base path-tiebreaker-type;
+    >       }
+    >       default "te-types:path-tiebreaker-random";
+    >       description
+    >         "The tiebreaker criteria to apply on an equally favored set
+    >         of paths, in order to pick the best.";
+    >     }
+    3379c4361,4420
     < }
     \ No newline at end of file
     ---
@@ -836,7 +1355,7 @@
     >       description
     >         "LSP encoding type.";
     >       reference
-    >         "RFC3945";
+    >         "RFC 3945";
     >     }
     >     leaf switching-type {
     >       type identityref {
@@ -845,7 +1364,7 @@
     >       description
     >         "LSP switching type.";
     >       reference
-    >         "RFC3945";
+    >         "RFC 3945";
     >     }
     >   }
     > 

--- a/drafts/te-types-update/draft-ietf-teas-rfc8776-update.md
+++ b/drafts/te-types-update/draft-ietf-teas-rfc8776-update.md
@@ -4,7 +4,7 @@ coding: utf-8
 title: Common YANG Data Types for Traffic Engineering
 
 abbrev: TE Common YANG Types
-docname: draft-ietf-teas-rfc8776-update-09
+docname: draft-ietf-teas-rfc8776-update-10
 obsoletes: 8776
 submissiontype: IETF
 workgroup: TEAS Working Group
@@ -70,7 +70,7 @@ informative:
 
 --- abstract
 
-This document defines a collection of common data types and groupings in YANG data modeling language. These derived common types and groupings are intended to be imported by modules that model Traffic Engineering (TE) configuration and state capabilities. This document obsoletes RFC 8776.
+This document defines a collection of common data types, identities, and groupings in YANG data modeling language. These derived common types and groupings are intended to be imported by modules that model Traffic Engineering (TE) configuration and state capabilities. This document obsoletes RFC 8776.
 
 --- middle
 
@@ -78,15 +78,9 @@ This document defines a collection of common data types and groupings in YANG da
 
 YANG {{!RFC6020}} {{!RFC7950}} is a data modeling language used to model configuration data, state data, Remote Procedure Calls, and notifications for network management protocols such as the Network Configuration Protocol (NETCONF) {{!RFC6241}}. The YANG language supports a small set of built-in data types and provides mechanisms to derive other types from the built-in types.
 
-This document introduces a collection of common data types derived from the built-in YANG data types. The derived types and groupings are designed to be the common types applicable for modeling Traffic Engineering (TE) features in model(s) defined outside of this document.
+This document introduces a collection of common data types derived from the built-in YANG data types. The derived data types, identities, and groupings are designed to be the common definitions applicable for modeling Traffic Engineering (TE) features in model(s) defined outside of this document.
 
-This document adds few additional common data types, identities, and groupings to both the "ietf-te-types" and the "ietf-te-packet-types" YANG models and obsoletes {{!RFC8776}}.
-
-For further details, see the revision statements of the YANG modules in Sections X and Y or the summary in Appendix A.
-
-CHANGE NOTE: These definitions have been developed in {{?I-D.ietf-teas-yang-te}}, {{?I-D.ietf-teas-yang-path-computation}} and {{?I-D.ietf-teas-yang-l3-te-topo}} and are quite mature: {{?I-D.ietf-teas-yang-te}} and {{?I-D.ietf-teas-yang-path-computation}} in particular are in WG Last Call and some definitions have been moved to this document as part of WG LC comments resolution.
-
-RFC Editor: remove the CHANGE NOTE above and this note
+This document adds new common data types, identities, and groupings to both the "ietf-te-types" and the "ietf-te-packet-types" YANG models and obsoletes {{!RFC8776}}. For further details, see the revision statements of the YANG modules in {{te-yang-code}} and {{pkt-yang-code}}, or the summary in {{changes-bis}}.
 
 ## Requirements Notation
 
@@ -553,7 +547,195 @@ RFC Editor: Please replace XXXX with the RFC number assigned to this document.
 
 # Changes from RFC 8776
 
-To be added in a future revision of this draft.
+This version adds new common data types, identities, and groupings to the YANG modules. It also updates some of the existing data types, identities, and groupings in the YANG modules and fixes few bugs in {{!RFC8776}}.
+
+The following new identities have been added to the 'ietf-te-types' module:
+
+- lsp-provisioning-error-reason;
+
+- association-type-diversity;
+
+- tunnel-admin-state-auto;
+
+- lsp-restoration-restore-none;
+
+- restoration-scheme-rerouting;
+
+- path-metric-optimization-type;
+
+- link-path-metric-type;
+
+- link-metric-type and its derived identities;
+
+- path-computation-error-reason and its derived identities;
+
+- protocol-origin-type and its derived identities;
+
+- svec-objective-function-type and its derived identities;
+
+- svec-metric-type and its derived identities.
+
+The following new data types have been added to the 'ietf-te-types' module:
+
+- path-type;
+
+- te-gen-node-id.
+
+The following new groupings have been added to the 'ietf-te-types' module:
+
+- encoding-and-switching-type;
+
+- te-generic-node-id.
+
+The following new identities have been added to the 'ietf-te-packet-types' module:
+
+- bandwidth-profile-type;
+
+- link-metric-delay-variation;
+
+- link-metric-loss;
+
+- path-metric-delay-variation;
+
+- path-metric-loss.
+
+The following new groupings have been added to the 'ietf-te-packet-types' module:
+
+- te-packet-path-bandwidth;
+
+- te-packet-link-bandwidth.
+
+The following identities, already defined in {{!RFC8776}}, have been updated in the 'ietf-te-types' module:
+
+- objective-function-type (editorial);
+
+- action-exercise (bug fix);
+
+- path-metric-type:
+
+   new base identities have been added;
+
+- path-metric-te (bug fix);
+
+- path-metric-igp (bug fix);
+
+- path-metric-hop (bug fix);
+
+- path-metric-delay-average (bug fix);
+
+- path-metric-delay-minimum (bug fix);
+
+- path-metric-residual-bandwidth (bug fix);
+
+- path-metric-optimize-includes (bug fix);
+
+- path-metric-optimize-excludes (bug fix);
+
+- te-optimization-criterion (editorial).
+
+The following data type, already defined in {{!RFC8776}}, has been updated in the 'ietf-te-types' module:
+
+- te-node-id;
+
+   The data type has been changed to be a union.
+
+The following groupings, already defined in {{!RFC8776}}, have been updated in the 'ietf-te-types' module:
+
+- explicit-route-hop
+
+   The following new leaves have been added to the 'explicit-route-hop' grouping:
+
+   - node-id-uri;
+
+   - link-tp-id-uri;
+
+   The following leaves, already defined in {{!RFC8776}}, have been updated in the 'explicit-route-hop':
+
+   - node-id;
+
+   - link-tp-id.
+
+      The mandatory true statements for the node-id and link-tp-id have been replaced by must statements that requires at least the presence of:
+
+      - node-id or node-id-uri;
+
+      - link-tp-id or link-tp-id-uri.
+
+- explicit-route-hop
+
+   The following new leaves have been added to the 'explicit-route-hop' grouping:
+
+   - node-id-uri;
+
+   - link-tp-id-uri;
+
+   The following leaves, already defined in {{!RFC8776}}, have been updated in the 'explicit-route-hop':
+
+   - node-id;
+
+   - link-tp-id.
+
+      The mandatory true statements for the node-id and link-tp-id have been replaced by must statements that requires at least the presence of:
+
+      - node-id or node-id-uri;
+
+      - link-tp-id or link-tp-id-uri.
+
+- optimization-metric-entry:
+
+   The following leaves, already defined in {{!RFC8776}}, have been updated in the 'optimization-metric-entry':
+
+   - metric-type;
+
+      The base identity has been updated without impacting the set of derived identities that are allowed.
+
+- tunnel-constraints;
+
+   The following new leaf have been added to the 'tunnel-constraints' grouping:
+
+    - network-id;
+
+- path-constraints-route-objects:
+
+   The following container, already defined in {{!RFC8776}}, has been updated in the 'path-constraints-route-objects':
+
+    - explicit-route-objects-always;
+
+      The container has been renamed as 'explicit-route-objects'. This change is not affecting any IETF standard YANG models since this grouping has not yet been used by any YANG model defined in existing IETF RFCs.
+
+- generic-path-metric-bounds:
+
+   The following leaves, already defined in {{!RFC8776}}, have been updated in the 'optimization-metric-entry':
+
+   - metric-type;
+
+      The base identity has been updated to:
+
+      - increase the set of derived identities that are allowed and;
+
+      - remove from this set the 'path-metric-optimize-includes' and the 'path-metric-optimize-excludes' identities (bug fixing)
+      
+- generic-path-optimization
+
+   The following new leaf have been added to the 'generic-path-optimization' grouping:
+
+    - tiebreaker;
+
+   The following container, already defined in {{!RFC8776}}, has been deprecated:
+
+    - tiebreakers.
+
+The following identities, already defined in {{!RFC8776}}, have been obsoletes in the 'ietf-te-types' module for bug fixing:
+
+- of-minimize-agg-bandwidth-consumption;
+
+- of-minimize-load-most-loaded-link;
+
+- of-minimize-cost-path-set;
+
+- lsp-protection-reroute-extra;
+
+- lsp-protection-reroute.
 
 {: #te-yang-diff}
 

--- a/drafts/te-types-update/draft-ietf-teas-rfc8776-update.txt
+++ b/drafts/te-types-update/draft-ietf-teas-rfc8776-update.txt
@@ -6,25 +6,25 @@ TEAS Working Group                                               I. Busi
 Internet-Draft                                                    Huawei
 Obsoletes: 8776 (if approved)                                     A. Guo
 Intended status: Standards Track                  Futurewei Technologies
-Expires: 1 August 2024                                            X. Liu
+Expires: 20 August 2024                                           X. Liu
                                                                Alef Edge
                                                                  T. Saad
                                                       Cisco Systems Inc.
                                                               I. Bryskin
                                                               Individual
-                                                         29 January 2024
+                                                        17 February 2024
 
 
              Common YANG Data Types for Traffic Engineering
-                   draft-ietf-teas-rfc8776-update-09
+                   draft-ietf-teas-rfc8776-update-10
 
 Abstract
 
-   This document defines a collection of common data types and groupings
-   in YANG data modeling language.  These derived common types and
-   groupings are intended to be imported by modules that model Traffic
-   Engineering (TE) configuration and state capabilities.  This document
-   obsoletes RFC 8776.
+   This document defines a collection of common data types, identities,
+   and groupings in YANG data modeling language.  These derived common
+   types and groupings are intended to be imported by modules that model
+   Traffic Engineering (TE) configuration and state capabilities.  This
+   document obsoletes RFC 8776.
 
 Status of This Memo
 
@@ -41,7 +41,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 1 August 2024.
+   This Internet-Draft will expire on 20 August 2024.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Busi, et al.              Expires 1 August 2024                 [Page 1]
+Busi, et al.             Expires 20 August 2024                 [Page 1]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -80,19 +80,19 @@ Table of Contents
        3.1.2.  Protocol Origin . . . . . . . . . . . . . . . . . . .  11
      3.2.  Packet TE Types Module Contents . . . . . . . . . . . . .  11
    4.  TE Types YANG Module  . . . . . . . . . . . . . . . . . . . .  13
-   5.  Packet TE Types YANG Module . . . . . . . . . . . . . . . . .  99
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . . 114
-   7.  Security Considerations . . . . . . . . . . . . . . . . . . . 114
-   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . . 115
-     8.1.  Normative References  . . . . . . . . . . . . . . . . . . 115
-     8.2.  Informative References  . . . . . . . . . . . . . . . . . 117
-   Appendix A.  Changes from RFC 8776  . . . . . . . . . . . . . . . 125
-     A.1.  TE Types YANG Diffs . . . . . . . . . . . . . . . . . . . 125
-     A.2.  Packet TE Types YANG Diffs  . . . . . . . . . . . . . . . 144
-   Appendix B.  Option Considered for updating RFC8776 . . . . . . . 150
-   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . . 151
-   Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . . 151
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . . 151
+   5.  Packet TE Types YANG Module . . . . . . . . . . . . . . . . . 105
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . . 120
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . . 121
+   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . . 121
+     8.1.  Normative References  . . . . . . . . . . . . . . . . . . 121
+     8.2.  Informative References  . . . . . . . . . . . . . . . . . 124
+   Appendix A.  Changes from RFC 8776  . . . . . . . . . . . . . . . 131
+     A.1.  TE Types YANG Diffs . . . . . . . . . . . . . . . . . . . 135
+     A.2.  Packet TE Types YANG Diffs  . . . . . . . . . . . . . . . 165
+   Appendix B.  Option Considered for updating RFC8776 . . . . . . . 171
+   Acknowledgements  . . . . . . . . . . . . . . . . . . . . . . . . 172
+   Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . . 172
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . . 172
 
 1.  Introduction
 
@@ -109,32 +109,22 @@ Table of Contents
 
 
 
-Busi, et al.              Expires 1 August 2024                 [Page 2]
+Busi, et al.             Expires 20 August 2024                 [Page 2]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
    This document introduces a collection of common data types derived
-   from the built-in YANG data types.  The derived types and groupings
-   are designed to be the common types applicable for modeling Traffic
-   Engineering (TE) features in model(s) defined outside of this
-   document.
+   from the built-in YANG data types.  The derived data types,
+   identities, and groupings are designed to be the common definitions
+   applicable for modeling Traffic Engineering (TE) features in model(s)
+   defined outside of this document.
 
-   This document adds few additional common data types, identities, and
-   groupings to both the "ietf-te-types" and the "ietf-te-packet-types"
-   YANG models and obsoletes [RFC8776].
-
-   For further details, see the revision statements of the YANG modules
-   in Sections X and Y or the summary in Appendix A.
-
-   CHANGE NOTE: These definitions have been developed in
-   [I-D.ietf-teas-yang-te], [I-D.ietf-teas-yang-path-computation] and
-   [I-D.ietf-teas-yang-l3-te-topo] and are quite mature:
-   [I-D.ietf-teas-yang-te] and [I-D.ietf-teas-yang-path-computation] in
-   particular are in WG Last Call and some definitions have been moved
-   to this document as part of WG LC comments resolution.
-
-   RFC Editor: remove the CHANGE NOTE above and this note
+   This document adds new common data types, identities, and groupings
+   to both the "ietf-te-types" and the "ietf-te-packet-types" YANG
+   models and obsoletes [RFC8776].  For further details, see the
+   revision statements of the YANG modules in Section 4 and Section 5,
+   or the summary in Appendix A.
 
 1.1.  Requirements Notation
 
@@ -155,21 +145,6 @@ Internet-Draft            TE Common YANG Types              January 2024
    are prefixed using the standard prefix associated with the
    corresponding YANG imported modules, as shown in Table 1.
 
-
-
-
-
-
-
-
-
-
-
-Busi, et al.              Expires 1 August 2024                 [Page 3]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
           +=================+======================+===========+
           | Prefix          | YANG module          | Reference |
           +=================+======================+===========+
@@ -185,6 +160,15 @@ Internet-Draft            TE Common YANG Types              January 2024
           +-----------------+----------------------+-----------+
 
              Table 1: Prefixes and corresponding YANG modules
+
+
+
+
+
+Busi, et al.             Expires 20 August 2024                 [Page 3]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
    RFC Editor: Please replace XXXX with the RFC number assigned to this
    document.
@@ -219,13 +203,6 @@ Internet-Draft            TE Common YANG Types              January 2024
 
       Traffic Engineering
 
-
-
-Busi, et al.              Expires 1 August 2024                 [Page 4]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
    DS-TE:
 
       Differentiated Services Traffic Engineering
@@ -241,6 +218,13 @@ Internet-Draft            TE Common YANG Types              January 2024
    APS:
 
       Automatic Protection Switching
+
+
+
+Busi, et al.             Expires 20 August 2024                 [Page 4]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
    SD:
 
@@ -274,14 +258,6 @@ Internet-Draft            TE Common YANG Types              January 2024
    The "ietf-te-types" module contains the following YANG reusable types
    and groupings:
 
-
-
-
-Busi, et al.              Expires 1 August 2024                 [Page 5]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
    te-bandwidth:
 
       A YANG grouping that defines the generic TE bandwidth.  The
@@ -296,6 +272,15 @@ Internet-Draft            TE Common YANG Types              January 2024
       unspecified technologies, "rt-types:generalized-label" is used.
 
    performance-metrics-attributes:
+
+
+
+
+
+Busi, et al.             Expires 20 August 2024                 [Page 5]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
       A YANG grouping that defines one-way and two-way measured
       Performance Metrics (PM) and indications of anomalies on link(s)
@@ -330,14 +315,6 @@ Internet-Draft            TE Common YANG Types              January 2024
 
    te-node-id:
 
-
-
-
-Busi, et al.              Expires 1 August 2024                 [Page 6]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
       A type representing the identifier for a node in a TE topology.
       The identifier is represented as 4 octets in dotted-quad notation.
       This attribute MAY be mapped to the Router Address TLV described
@@ -349,6 +326,17 @@ Internet-Draft            TE Common YANG Types              January 2024
       Section 6.2 of [RFC6827].
 
    te-topology-id:
+
+
+
+
+
+
+
+Busi, et al.             Expires 20 August 2024                 [Page 6]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
       A type representing the identifier for a topology.  It is optional
       to have one or more prefixes at the beginning, separated by
@@ -387,13 +375,6 @@ Internet-Draft            TE Common YANG Types              January 2024
       An enumerated type for the different statuses of a recovery action
       as defined in [RFC4427] and [RFC6378].
 
-
-
-Busi, et al.              Expires 1 August 2024                 [Page 7]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
    path-attribute-flags:
 
       A base YANG identity for supported LSP path flags as defined in
@@ -405,6 +386,13 @@ Internet-Draft            TE Common YANG Types              January 2024
 
       A base YANG identity for supported link protection types as
       defined in [RFC4872] and [RFC4427].
+
+
+
+Busi, et al.             Expires 20 August 2024                 [Page 7]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
    restoration-scheme-type:
 
@@ -442,14 +430,6 @@ Internet-Draft            TE Common YANG Types              January 2024
    to be used only for path objective functions and a new svec-
    objective-function-type identity has been added for the
    Synchronization VECtor (SVEC) objective functions.  Therefore the of-
-
-
-
-Busi, et al.              Expires 1 August 2024                 [Page 8]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
    minimize-agg-bandwidth-consumption, of-minimize-load-most-loaded-link
    and of-minimize-cost-path-set identities, defined in [RFC5541] and
    derived from the objective-function-type identity, have been
@@ -462,6 +442,13 @@ Internet-Draft            TE Common YANG Types              January 2024
 
       A base YANG identity for supported TE tunnel types as defined in
       [RFC3209] and [RFC4875].
+
+
+
+Busi, et al.             Expires 20 August 2024                 [Page 8]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
    lsp-encoding-types:
 
@@ -498,14 +485,6 @@ Internet-Draft            TE Common YANG Types              January 2024
       the path metric type.  The derived identities SHOULD describe the
       unit and maximum value of the path metric types they define.
 
-
-
-
-Busi, et al.              Expires 1 August 2024                 [Page 9]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
       For example, the bound of the 'path-metric-loss', defined in
       'ietf-te-packet-types', is defined in multiples of the basic unit
       0.000003% as described in [RFC7471] and [RFC8570].
@@ -519,6 +498,13 @@ Internet-Draft            TE Common YANG Types              January 2024
 
       An enumerated type for the different TE link access types as
       defined in [RFC3630].
+
+
+
+Busi, et al.             Expires 20 August 2024                 [Page 9]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
    CHANGE NOTE: The module "ietf-te-types" has been updated to add the
    following YANG identities, types and groupings.
@@ -553,15 +539,6 @@ Internet-Draft            TE Common YANG Types              January 2024
 
    encoding-and-switching-type:
 
-
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 10]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
       This is a common grouping to define the LSP encoding and switching
       types.
 
@@ -576,6 +553,14 @@ Internet-Draft            TE Common YANG Types              January 2024
    restoration-type base YANG identity has been provided in RFC8776.
 
    RFC Editor: remove the two CHANGE NOTEs above and this note
+
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 10]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
 3.1.1.  Path Computation Errors
 
@@ -609,15 +594,6 @@ Internet-Draft            TE Common YANG Types              January 2024
    The "ietf-te-packet-types" module (Section 5) covers the common types
    and groupings that are specific to packet technology.
 
-
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 11]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
    The "ietf-te-packet-types" module contains the following YANG
    reusable types and groupings:
 
@@ -632,6 +608,15 @@ Internet-Draft            TE Common YANG Types              January 2024
       [RFC4124].
 
    bc-type:
+
+
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 11]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
       A type that represents Diffserv-TE Bandwidth Constraints (BCs) as
       defined in [RFC4124].
@@ -665,15 +650,6 @@ Internet-Draft            TE Common YANG Types              January 2024
 
    te-packet-path-bandwidth
 
-
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 12]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
       A YANG grouping that defines the path bandwidth information and
       could be used in any Packet TE model (e.g., MPLS-TE topology
       model) for the path bandwidth representation (e.g., the bandwidth
@@ -685,6 +661,18 @@ Internet-Draft            TE Common YANG Types              January 2024
 
       The Packet TE path bandwidth can be represented by a bandwidth
       profile as follow:
+
+
+
+
+
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 12]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
             +--:(packet)
               +--rw bandwidth-profile-name?   string
@@ -722,14 +710,6 @@ Internet-Draft            TE Common YANG Types              January 2024
    [RFC4736], [RFC6004], [RFC6511], [RFC7139], [RFC7308], [RFC7551],
    [RFC7571], [RFC7579], and [ITU-T_G.709].
 
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 13]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
    CHANGE NOTE: Please focus your review only on the updates to the YANG
    model: see also Appendix A.1.
 
@@ -742,6 +722,14 @@ Internet-Draft            TE Common YANG Types              January 2024
      prefix te-types;
 
      import ietf-inet-types {
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 13]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        prefix inet;
        reference
          "RFC 6991: Common YANG Data Types";
@@ -778,14 +766,6 @@ Internet-Draft            TE Common YANG Types              January 2024
                   <mailto:tsaad.net@gmail.com>
 
         Editor:   Rakesh Gandhi
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 14]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
                   <mailto:rgandhi@cisco.com>
 
         Editor:   Vishnu Pavan Beeram
@@ -798,6 +778,14 @@ Internet-Draft            TE Common YANG Types              January 2024
                   <mailto:i_bryskin@yahoo.com>";
      description
        "This YANG module contains a collection of generally useful
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 14]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
         YANG data type definitions specific to TE.  The model fully
         conforms to the Network Management Datastore Architecture
         (NMDA).
@@ -821,45 +809,103 @@ Internet-Draft            TE Common YANG Types              January 2024
         This version of this YANG module is part of RFC XXXX
         (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
         for full legal notices.";
-     revision 2024-01-29 {
+     revision 2024-02-16 {
        description
-         "Added:
-         - base identity lsp-provisioning-error-reason;
-         - identity association-type-diversity;
-         - identity tunnel-admin-state-auto;
-         - identity lsp-restoration-restore-none;
-         - identity restoration-scheme-rerouting;
-         - base identity path-computation-error-reason and
-           its derived identities;
-         - base identity protocol-origin-type and
-           its derived identities;
-         - base identity svec-objective-function-type and its derived
+         "This revision adds the following new identities:
+         - lsp-provisioning-error-reason;
+         - association-type-diversity;
+         - tunnel-admin-state-auto;
+         - lsp-restoration-restore-none;
+         - restoration-scheme-rerouting;
+         - path-metric-optimization-type;
+         - link-path-metric-type;
+         - link-metric-type and its derived identities;
+         - path-computation-error-reason and its derived identities;
+         - protocol-origin-type and its derived identities;
+         - svec-objective-function-type and its derived identities;
+         - svec-metric-type and its derived identities.
+
+         This revision adds the following new data types:
+         - path-type;
+         - te-gen-node-id.
+
+         This revision adds the following new groupings:
+         - encoding-and-switching-type;
+         - te-generic-node-id.
+
+         This revision updates the following identities:
 
 
 
-Busi, et al.              Expires 1 August 2024                [Page 15]
+Busi, et al.             Expires 20 August 2024                [Page 15]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
-           identities;
-         - base identity svec-metric-type and its derived identities;
-         - grouping encoding-and-switching-type.
+         - objective-function-type;
+         - action-exercise;
+         - path-metric-type;
+         - path-metric-te;
+         - path-metric-igp;
+         - path-metric-hop;
+         - path-metric-delay-average;
+         - path-metric-delay-minimum;
+         - path-metric-residual-bandwidth;
+         - path-metric-optimize-includes;
+         - path-metric-optimize-excludes;
+         - te-optimization-criterion.
 
-         Updated:
-         - description of the base identity objective-function-type;
-         - description and reference of identity action-exercise;
-         - typedef te-node-id to support also 16 octects TE identifiers.
+         This revision updates the following data types:
+         - te-node-id.
 
-         Obsoleted:
-         - identity of-minimize-agg-bandwidth-consumption;
-         - identity of-minimize-load-most-loaded-link;
-         - identity of-minimize-cost-path-set;
-         - identity lsp-protection-reroute-extra;
-         - identity lsp-protection-reroute.
+         This revision updates the following groupings:
+         - explicit-route-hop:
+           - adds the following leaves:
+             - node-id-uri;
+             - link-tp-id-uri;
+           - updates the following leaves:
+             - node-id;
+             - link-tp-id;
+         - record-route-state:
+           - adds the following leaves:
+             - node-id-uri;
+             - link-tp-id-uri;
+           - updates the following leaves:
+             - node-id;
+             - link-tp-id;
+         - optimization-metric-entry:
+           - updates the following leaves:
+             - metric-type;
+         - tunnel-constraints;
+           - adds the following leaves:
+             - network-id;
+         - path-constraints-route-objects:
+           - updates the following containers:
+             - explicit-route-objects-always;
+         - generic-path-metric-bounds:
+           - updates the following leaves:
+             - metric-type;
+         - generic-path-optimization
+           - adds the following leaves:
+             - tiebreaker;
+           - deprecate the following containers:
+             - tiebreakers.
 
-         Container explicit-route-objects-always renamed as
-         explicit-route-objects.";
+
+
+Busi, et al.             Expires 20 August 2024                [Page 16]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+         This revision obsoletes the following identities:
+         - of-minimize-agg-bandwidth-consumption;
+         - of-minimize-load-most-loaded-link;
+         - of-minimize-cost-path-set;
+         - lsp-protection-reroute-extra;
+         - lsp-protection-reroute.
+
+         This revision provides also few editorial changes.";
        reference
          "RFC XXXX: Common YANG Data Types for Traffic Engineering";
      }
@@ -868,7 +914,7 @@ Internet-Draft            TE Common YANG Types              January 2024
 
      revision 2020-06-10 {
        description
-         "Latest revision of TE types.";
+         "Initial Version of TE types.";
        reference
          "RFC 8776: Common YANG Data Types for Traffic Engineering";
      }
@@ -885,26 +931,29 @@ Internet-Draft            TE Common YANG Types              January 2024
        description
          "Administrative group / resource class / color representation
           in 'hex-string' type.
+
           The most significant byte in the hex-string is the farthest
           to the left in the byte sequence.  Leading zero bytes in the
           configured value may be omitted for brevity.";
        reference
          "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 16]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
           Version 2
+
           RFC 5305: IS-IS Extensions for Traffic Engineering
+
           RFC 7308: Extended Administrative Groups in MPLS Traffic
           Engineering (MPLS-TE)";
      }
 
      typedef admin-groups {
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 17]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        type union {
          type admin-group;
          type extended-admin-group;
@@ -918,6 +967,7 @@ Internet-Draft            TE Common YANG Types              January 2024
        description
          "Extended administrative group / resource class / color
           representation in 'hex-string' type.
+
           The most significant byte in the hex-string is the farthest
           to the left in the byte sequence.  Leading zero bytes in the
           configured value may be omitted for brevity.";
@@ -946,20 +996,20 @@ Internet-Draft            TE Common YANG Types              January 2024
            description
              "Unknown.";
          }
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 17]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
          enum normal {
            value 1;
            description
              "Normal.  Indicates that the anomalous bit is not set.";
          }
          enum abnormal {
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 18]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            value 2;
            description
              "Abnormal.  Indicates that the anomalous bit is set.";
@@ -970,9 +1020,11 @@ Internet-Draft            TE Common YANG Types              January 2024
           bit not set), abnormal (anomalous bit set), or unknown.";
        reference
          "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions
+
           RFC 7823: Performance-Based Path Selection for Explicitly
           Routed Label Switched Paths (LSPs) Using TE Metric
           Extensions
+
           RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
      }
 
@@ -1002,18 +1054,18 @@ Internet-Draft            TE Common YANG Types              January 2024
              "In some test mode.";
          }
          enum preparing-maintenance {
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 18]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
            description
              "The resource is disabled in the control plane to prepare
               for a graceful shutdown for maintenance purposes.";
            reference
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 19]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
              "RFC 5817: Graceful Shutdown in MPLS and Generalized MPLS
               Traffic Engineering Networks";
          }
@@ -1058,18 +1110,18 @@ Internet-Draft            TE Common YANG Types              January 2024
           For the Optical Transport Network (OTN) switching type,
           a list of integers can be used, such as '0,2,3,1', indicating
           two ODU0s and one ODU3.  ('ODU' stands for 'Optical Data
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 19]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
           Unit'.)  For Dense Wavelength Division Multiplexing (DWDM),
           a list of pairs of slot numbers and widths can be used,
           such as '0,2,3,3', indicating a frequency slot 0 with
           slot width 2 and a frequency slot 3 with slot width 3.
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 20]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
           Canonically, the string is represented as all lowercase and in
           hex, where the prefix '0x' precedes the hex number.";
        reference
@@ -1094,12 +1146,15 @@ Internet-Draft            TE Common YANG Types              January 2024
        description
          "An identifier to uniquely identify an operator, which can be
           either a provider or a client.
+
           The definition of this type is taken from RFCs 6370 and 5003.
+
           This attribute type is used solely to provide a globally
           unique context for TE topologies.";
        reference
          "RFC 5003: Attachment Individual Identifier (AII) Types for
           Aggregation
+
           RFC 6370: MPLS Transport Profile (MPLS-TP) Identifiers";
      }
 
@@ -1114,15 +1169,15 @@ Internet-Draft            TE Common YANG Types              January 2024
              "A strict hop in an explicit path.";
          }
        }
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 20]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        description
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 21]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          "Enumerated type for specifying loose or strict paths.";
        reference
          "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
@@ -1170,15 +1225,15 @@ Internet-Draft            TE Common YANG Types              January 2024
              "The explicit route represents an incoming link on
               a node.";
          }
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 21]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
          enum outgoing {
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 22]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            description
              "The explicit route represents an outgoing link on
               a node.";
@@ -1229,9 +1284,10 @@ Internet-Draft            TE Common YANG Types              January 2024
 
 
 
-Busi, et al.              Expires 1 August 2024                [Page 22]
+
+Busi, et al.             Expires 20 August 2024                [Page 23]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
           RFC 5305: IS-IS Extensions for Traffic Engineering,
@@ -1285,9 +1341,9 @@ Internet-Draft            TE Common YANG Types              January 2024
 
 
 
-Busi, et al.              Expires 1 August 2024                [Page 23]
+Busi, et al.             Expires 20 August 2024                [Page 24]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
      typedef te-recovery-status {
@@ -1341,9 +1397,9 @@ Internet-Draft            TE Common YANG Types              January 2024
 
 
 
-Busi, et al.              Expires 1 August 2024                [Page 24]
+Busi, et al.             Expires 20 August 2024                [Page 25]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
              "The recovery domain is recovering from a failure/degrade
@@ -1397,9 +1453,9 @@ Internet-Draft            TE Common YANG Types              January 2024
 
 
 
-Busi, et al.              Expires 1 August 2024                [Page 25]
+Busi, et al.             Expires 20 August 2024                [Page 26]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
            // empty string
@@ -1411,6 +1467,7 @@ Internet-Draft            TE Common YANG Types              January 2024
        }
        description
          "An identifier for a topology.
+
           It is optional to have one or more prefixes at the beginning,
           separated by colons.  The prefixes can be 'network-types' as
           defined in the 'ietf-network' module in RFC 8345, to help the
@@ -1429,6 +1486,7 @@ Internet-Draft            TE Common YANG Types              January 2024
        }
        description
          "An identifier for a TE link endpoint on a node.
+
           This attribute is mapped to a local or remote link identifier
           as defined in RFCs 3630 and 5305.";
        reference
@@ -1448,16 +1506,16 @@ Internet-Draft            TE Common YANG Types              January 2024
          }
          enum secondary-path {
            description
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 27]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
              "Indicates that the TE path is a secondary path.";
          }
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 26]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
          enum primary-reverse-path {
            description
              "Indicates that the TE path is a primary reverse path.";
@@ -1504,16 +1562,16 @@ Internet-Draft            TE Common YANG Types              January 2024
          "RFC 4090: Fast Reroute Extensions to RSVP-TE for LSP Tunnels";
      }
 
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 28]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
      feature extended-admin-groups {
        description
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 27]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
          "Indicates support for TE link extended administrative
           groups.";
        reference
@@ -1560,15 +1618,16 @@ Internet-Draft            TE Common YANG Types              January 2024
      // RFC Editor: remove the note above and this note
      identity lsp-provisioning-error-reason {
        description
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 29]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          "Base identity for LSP provisioning errors.";
      }
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 28]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
 
      identity session-attributes-flags {
        description
@@ -1615,16 +1674,16 @@ Internet-Draft            TE Common YANG Types              January 2024
        description
          "Requests FRR node protection on LSRs, if present.";
        reference
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 30]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          "RFC 4090: Fast Reroute Extensions to RSVP-TE for LSP Tunnels";
      }
-
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 29]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
 
      identity path-reevaluation-request {
        base session-attributes-flags;
@@ -1671,17 +1730,17 @@ Internet-Draft            TE Common YANG Types              January 2024
 
      identity boundary-rerouting-desired {
        base lsp-attributes-flags;
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 31]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        description
          "Indicates boundary rerouting behavior for an LSP undergoing
           establishment.  This MAY also be used to specify
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 30]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
           segment-based LSP recovery through nested crankback for
           established LSPs.  The boundary Area Border Router (ABR) /
           Autonomous System Border Router (ASBR) can decide to forward
@@ -1727,17 +1786,17 @@ Internet-Draft            TE Common YANG Types              January 2024
      }
 
      identity contiguous-lsp-desired {
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 32]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        base lsp-attributes-flags;
        description
          "Indicates that a contiguous LSP is desired.";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 31]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        reference
          "RFC 5151: Inter-Domain MPLS and GMPLS Traffic Engineering --
           Resource Reservation Protocol-Traffic Engineering (RSVP-TE)
@@ -1783,17 +1842,17 @@ Internet-Draft            TE Common YANG Types              January 2024
 
      identity oob-mapping-flag {
        base lsp-attributes-flags;
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 33]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        description
          "Indicates that signaling of the egress binding information is
           out of band (e.g., via the Border Gateway Protocol (BGP)).";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 32]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        reference
          "RFC 6511: Non-Penultimate Hop Popping Behavior and Out-of-Band
           Mapping for RSVP-TE Label Switched Paths
@@ -1839,16 +1898,16 @@ Internet-Draft            TE Common YANG Types              January 2024
          "RFC 7570: Label Switched Path (LSP) Attribute in the Explicit
           Route Object (ERO)
           RFC 8001: RSVP-TE Extensions for Collecting Shared Risk
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 34]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
           Link Group (SRLG) Information";
      }
-
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 33]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
 
      identity loopback-desired {
        base lsp-attributes-flags;
@@ -1895,17 +1954,17 @@ Internet-Draft            TE Common YANG Types              January 2024
 
      identity link-protection-extra-traffic {
        base link-protection-type;
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 35]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        description
          "Extra-Traffic protected link type.";
        reference
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 34]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
          "RFC 4427: Recovery (Protection and Restoration) Terminology
           for Generalized Multi-Protocol Label Switching (GMPLS)";
      }
@@ -1951,17 +2010,17 @@ Internet-Draft            TE Common YANG Types              January 2024
 
      identity association-type-recovery {
        base association-type;
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 36]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        description
          "Association type for recovery, used to associate LSPs of the
           same tunnel for recovery.";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 35]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        reference
          "RFC 4872: RSVP-TE Extensions in Support of End-to-End
           Generalized Multi-Protocol Label Switching (GMPLS) Recovery
@@ -2007,19 +2066,19 @@ Internet-Draft            TE Common YANG Types              January 2024
      // RFC Editor: remove the note above and this note
      identity association-type-diversity {
        base association-type;
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 37]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        description
          "Association Type diversity used to associate LSPs whose
          paths are to be diverse from each other.";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 36]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        reference
-         "RFC8800: Path Computation Element Communication Protocol
+         "RFC 8800: Path Computation Element Communication Protocol
          (PCEP) Extension for Label Switched Path (LSP) Diversity
          Constraint Signaling";
      }
@@ -2030,7 +2089,7 @@ Internet-Draft            TE Common YANG Types              January 2024
      // RFC Editor: remove the note above and this note
      identity objective-function-type {
        description
-         "Base identity for path objective function type.";
+         "Base identity for path objective function types.";
      }
 
      identity of-minimize-cost-path {
@@ -2063,21 +2122,25 @@ Internet-Draft            TE Common YANG Types              January 2024
 
      // CHANGE NOTE: The identity of-minimize-agg-bandwidth-consumption
      // below has been obsoleted in this module revision
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 38]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
      // RFC Editor: remove the note above and this note
      identity of-minimize-agg-bandwidth-consumption {
        base objective-function-type;
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 37]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        status obsolete;
        description
          "Objective function for minimizing aggregate bandwidth
-         consumption.";
+         consumption.
+
+         This identity has been obsoleted: the
+         'svec-of-minimize-agg-bandwidth-consumption' identity SHOULD
+         be used instead.";
        reference
          "RFC 5541: Encoding of Objective Functions in the Path
          Computation Element Communication Protocol (PCEP)";
@@ -2091,7 +2154,11 @@ Internet-Draft            TE Common YANG Types              January 2024
        status obsolete;
        description
          "Objective function for minimizing the load on the link that
-         is carrying the highest load.";
+         is carrying the highest load.
+
+         This identity has been obsoleted: the
+         'svec-of-minimize-load-most-loaded-link' identity SHOULD
+         be used instead.";
        reference
          "RFC 5541: Encoding of Objective Functions in the Path
          Computation Element Communication Protocol (PCEP)";
@@ -2104,9 +2171,21 @@ Internet-Draft            TE Common YANG Types              January 2024
        base objective-function-type;
        status obsolete;
        description
-         "Objective function for minimizing the cost on a path set.";
+         "Objective function for minimizing the cost on a path set.
+
+         This identity has been obsoleted: the
+         'svec-of-minimize-cost-path-set' identity SHOULD
+         be used instead.";
        reference
          "RFC 5541: Encoding of Objective Functions in the Path
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 39]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
           Computation Element Communication Protocol (PCEP)";
      }
 
@@ -2115,24 +2194,23 @@ Internet-Draft            TE Common YANG Types              January 2024
          "Base identity for supported path computation mechanisms.";
      }
 
+     // CHANGE NOTE: The reference of the identity path-locally-computed
+     // below has been updated in this module revision
+     // RFC Editor: remove the note above and this note
      identity path-locally-computed {
        base path-computation-method;
        description
          "Indicates a constrained-path LSP in which the
           path is computed by the local LER.";
        reference
-         "RFC 3272: Overview and Principles of Internet Traffic
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 38]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
-          Engineering, Section 5.4";
+         "RFC 9522: Overview and Principles of Internet Traffic
+         Engineering, Section 4.4";
      }
 
+     // CHANGE NOTE: The reference of the identity
+     // path-externally-queried below has been updated
+     // in this module revision
+     // RFC Editor: remove the note above and this note
      identity path-externally-queried {
        base path-computation-method;
        description
@@ -2144,13 +2222,26 @@ Internet-Draft            TE Common YANG Types              January 2024
           returned by the external source may require further local
           computation on the device.";
        reference
-         "RFC 3272: Overview and Principles of Internet Traffic
+         "RFC 9522: Overview and Principles of Internet Traffic
           Engineering
+
           RFC 4657: Path Computation Element (PCE) Communication
           Protocol Generic Requirements";
      }
 
+     // CHANGE NOTE: The reference of the identity
+     // path-explicitly-defined below has been updated
+     // in this module revision
+     // RFC Editor: remove the note above and this note
      identity path-explicitly-defined {
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 40]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        base path-computation-method;
        description
          "Constrained-path LSP in which the path is
@@ -2158,7 +2249,8 @@ Internet-Draft            TE Common YANG Types              January 2024
           hops.";
        reference
          "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels
-          RFC 3272: Overview and Principles of Internet Traffic
+
+          RFC 9522: Overview and Principles of Internet Traffic
           Engineering";
      }
 
@@ -2177,14 +2269,6 @@ Internet-Draft            TE Common YANG Types              January 2024
          "RFC 4657: Path Computation Element (PCE) Communication
           Protocol Generic Requirements";
      }
-
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 39]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
 
      identity lsp-metric-absolute {
        base lsp-metric-type;
@@ -2206,6 +2290,13 @@ Internet-Draft            TE Common YANG Types              January 2024
          "RFC 4657: Path Computation Element (PCE) Communication
           Protocol Generic Requirements";
      }
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 41]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
      identity te-tunnel-type {
        description
@@ -2234,14 +2325,6 @@ Internet-Draft            TE Common YANG Types              January 2024
        description
          "Base identity from which specific tunnel action types
           are derived.";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 40]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
      }
 
      identity tunnel-action-resetup {
@@ -2263,6 +2346,14 @@ Internet-Draft            TE Common YANG Types              January 2024
        description
          "TE tunnel action that switches the tunnel's LSP to use the
           specified path.";
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 42]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
      }
 
      identity te-action-result {
@@ -2290,14 +2381,6 @@ Internet-Draft            TE Common YANG Types              January 2024
      }
 
      identity tunnel-admin-state-type {
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 41]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        description
          "Base identity for TE tunnel administrative states.";
      }
@@ -2319,6 +2402,14 @@ Internet-Draft            TE Common YANG Types              January 2024
      // RFC Editor: remove the note above and this note
      identity tunnel-admin-state-auto {
        base tunnel-admin-state-type;
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 43]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        description
          "Tunnel administrative auto state. The administrative status
          in state datastore transitions to 'tunnel-admin-up' when the
@@ -2346,14 +2437,6 @@ Internet-Draft            TE Common YANG Types              January 2024
      identity lsp-state-type {
        description
          "Base identity for TE LSP states.";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 42]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
      }
 
      identity lsp-path-computing {
@@ -2375,6 +2458,14 @@ Internet-Draft            TE Common YANG Types              January 2024
      }
 
      identity lsp-state-setting-up {
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 44]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        base lsp-state-type;
        description
          "State is being set up.";
@@ -2402,14 +2493,6 @@ Internet-Draft            TE Common YANG Types              January 2024
        base lsp-state-type;
        description
          "State is being torn down.";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 43]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
      }
 
      identity lsp-state-down {
@@ -2431,6 +2514,14 @@ Internet-Draft            TE Common YANG Types              January 2024
        reference
          "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels,
           Section 2.5";
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 45]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
      }
 
      identity path-invalidation-action-teardown {
@@ -2458,14 +2549,6 @@ Internet-Draft            TE Common YANG Types              January 2024
 
      identity lsp-restoration-restore-any {
        base lsp-restoration-type;
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 44]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        description
          "Any LSP affected by a failure is restored.";
      }
@@ -2487,6 +2570,14 @@ Internet-Draft            TE Common YANG Types              January 2024
        // RFC Editor: remove the note above and this note
        identity restoration-scheme-rerouting {
          base restoration-scheme-type;
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 46]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          description
            "Restoration LSP is computed after the failure detection.
 
@@ -2515,13 +2606,6 @@ Internet-Draft            TE Common YANG Types              January 2024
           for Generalized Multi-Protocol Label Switching (GMPLS)";
      }
 
-
-
-Busi, et al.              Expires 1 August 2024                [Page 45]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
      identity restoration-scheme-presignaled {
        base restoration-scheme-type;
        description
@@ -2542,6 +2626,14 @@ Internet-Draft            TE Common YANG Types              January 2024
      identity lsp-protection-unprotected {
        base lsp-protection-type;
        description
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 47]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          "'Unprotected' LSP protection type.";
        reference
          "RFC 4872: RSVP-TE Extensions in Support of End-to-End
@@ -2570,14 +2662,6 @@ Internet-Draft            TE Common YANG Types              January 2024
      // RFC Editor: remove the note above and this note
      identity lsp-protection-reroute {
        base lsp-protection-type;
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 46]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        status obsolete;
        description
          "'Rerouting without Extra-Traffic' LSP protection type.
@@ -2598,6 +2682,13 @@ Internet-Draft            TE Common YANG Types              January 2024
          "RFC 4872: RSVP-TE Extensions in Support of End-to-End
           Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
      }
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 48]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
      identity lsp-protection-1-for-1 {
        base lsp-protection-type;
@@ -2626,14 +2717,6 @@ Internet-Draft            TE Common YANG Types              January 2024
           Generalized Multi-Protocol Label Switching (GMPLS) Recovery";
      }
 
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 47]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
      identity lsp-protection-extra-traffic {
        base lsp-protection-type;
        description
@@ -2655,6 +2738,14 @@ Internet-Draft            TE Common YANG Types              January 2024
      }
 
      identity signal-fail-of-protection {
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 49]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        base lsp-protection-state;
        description
          "The protection transport entity has a signal fail condition
@@ -2683,13 +2774,6 @@ Internet-Draft            TE Common YANG Types              January 2024
           for Generalized Multi-Protocol Label Switching (GMPLS)";
      }
 
-
-
-Busi, et al.              Expires 1 August 2024                [Page 48]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
      identity signal-fail {
        base lsp-protection-state;
        description
@@ -2709,6 +2793,14 @@ Internet-Draft            TE Common YANG Types              January 2024
          "RFC 4427: Recovery (Protection and Restoration) Terminology
           for Generalized Multi-Protocol Label Switching (GMPLS)";
      }
+
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 50]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
      identity manual-switch {
        base lsp-protection-state;
@@ -2738,14 +2830,6 @@ Internet-Draft            TE Common YANG Types              January 2024
           for Generalized Multi-Protocol Label Switching (GMPLS)";
      }
 
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 49]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
      identity failure-of-protocol {
        base lsp-protection-state;
        description
@@ -2766,6 +2850,14 @@ Internet-Draft            TE Common YANG Types              January 2024
        base protection-external-commands;
        description
          "A temporary configuration action initiated by an operator
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 51]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
           command that prevents any switchover action from being taken
           and, as such, freezes the current state.";
        reference
@@ -2794,14 +2886,6 @@ Internet-Draft            TE Common YANG Types              January 2024
      }
 
      identity clear-lockout-of-normal {
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 50]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        base protection-external-commands;
        description
          "An action that clears the active lockout of the
@@ -2822,6 +2906,13 @@ Internet-Draft            TE Common YANG Types              January 2024
          "RFC 4427: Recovery (Protection and Restoration) Terminology
           for Generalized Multi-Protocol Label Switching (GMPLS)";
      }
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 52]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
      identity action-forced-switch {
        base protection-external-commands;
@@ -2850,14 +2941,6 @@ Internet-Draft            TE Common YANG Types              January 2024
 
      // CHANGE NOTE: The description and reference of the
      // identity action-exercise have been updated in this module
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 51]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
      // revision
      // RFC Editor: remove the note above and this note
      identity action-exercise {
@@ -2879,6 +2962,14 @@ Internet-Draft            TE Common YANG Types              January 2024
           protection, forced switchover, manual switchover, WTR state,
           or exercise command.";
        reference
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 53]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          "RFC 4427: Recovery (Protection and Restoration) Terminology
           for Generalized Multi-Protocol Label Switching (GMPLS)";
      }
@@ -2906,14 +2997,6 @@ Internet-Draft            TE Common YANG Types              January 2024
          "Ethernet Virtual Private Line (EVPL).";
        reference
          "RFC 6004: Generalized MPLS (GMPLS) Support for Metro Ethernet
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 52]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
           Forum and G.8011 Ethernet Service Switching";
      }
 
@@ -2934,6 +3017,14 @@ Internet-Draft            TE Common YANG Types              January 2024
          "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
           Signaling Functional Description";
      }
+
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 54]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
      identity switching-otn {
        base switching-capabilities;
@@ -2962,14 +3053,6 @@ Internet-Draft            TE Common YANG Types              January 2024
           Signaling Functional Description";
      }
 
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 53]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
      identity switching-fsc {
        base switching-capabilities;
        description
@@ -2991,6 +3074,14 @@ Internet-Draft            TE Common YANG Types              January 2024
        base lsp-encoding-types;
        description
          "Packet LSP encoding.";
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 55]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        reference
          "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
           Signaling Functional Description";
@@ -3018,14 +3109,6 @@ Internet-Draft            TE Common YANG Types              January 2024
        base lsp-encoding-types;
        description
          "SDH ITU-T G.707 / SONET ANSI T1.105 LSP encoding.";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 54]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        reference
          "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
           Signaling Functional Description";
@@ -3047,6 +3130,14 @@ Internet-Draft            TE Common YANG Types              January 2024
        reference
          "RFC 3471: Generalized Multi-Protocol Label Switching (GMPLS)
           Signaling Functional Description";
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 56]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
      }
 
      identity lsp-encoding-fiber {
@@ -3074,14 +3165,6 @@ Internet-Draft            TE Common YANG Types              January 2024
        reference
          "RFC 4328: Generalized Multi-Protocol Label Switching (GMPLS)
           Signaling Extensions for G.709 Optical Transport Networks
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 55]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
           Control";
      }
 
@@ -3103,6 +3186,13 @@ Internet-Draft            TE Common YANG Types              January 2024
          "RFC 6004: Generalized MPLS (GMPLS) Support for Metro
           Ethernet Forum and G.8011 Ethernet Service Switching";
      }
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 57]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
      identity path-signaling-type {
        description
@@ -3130,14 +3220,6 @@ Internet-Draft            TE Common YANG Types              January 2024
          "Segment-routing path setup.";
      }
 
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 56]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
      identity path-scope-type {
        description
          "Base identity from which specific path scope types are
@@ -3159,6 +3241,14 @@ Internet-Draft            TE Common YANG Types              January 2024
        reference
          "RFC 4873: GMPLS Segment Recovery";
      }
+
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 58]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
      identity route-usage-type {
        description
@@ -3186,108 +3276,274 @@ Internet-Draft            TE Common YANG Types              January 2024
          "Excludes SRLGs.";
        reference
          "RFC 4874: Exclude Routes - Extension to Resource ReserVation
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 57]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
           Protocol-Traffic Engineering (RSVP-TE)";
      }
 
-     // CHANGE NOTE: The description of the identity path-metric-type
-     // has been updated in this module revision
-     // RFC Editor: remove the note above and this note
-     identity path-metric-type {
-       description
-         "Base identity for the path metric type.
-
-         Derived identities SHOULD describe the unit and maximum value
-         of the path metric types they define.";
-     }
-
-     identity path-metric-te {
-       base path-metric-type;
-       description
-         "TE path metric.";
-       reference
-         "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
-          second MPLS Traffic Engineering (TE) Metric";
-     }
-
-     identity path-metric-igp {
-       base path-metric-type;
-       description
-         "IGP path metric.";
-       reference
-         "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
-          second MPLS Traffic Engineering (TE) Metric";
-     }
-
-     // CHANGE NOTE: The reference for the identity path-metric-hop
+     // CHANGE NOTE: The path-metric-optimization-type base identity
      // has been added in this module revision
      // RFC Editor: remove the note above and this note
-     identity path-metric-hop {
-       base path-metric-type;
+     identity path-metric-optimization-type {
        description
-         "Hop path metric.";
-       reference
-         "RFC5440: Path Computation Element (PCE) Communication
-         Protocol (PCEP)";
+         "Base identity used to define the path metric optimization
+         types.";
      }
 
-
-     identity path-metric-delay-average {
-       base path-metric-type;
+     // CHANGE NOTE: The link-path-metric-type base identity
+     // has been added in this module revision
+     // RFC Editor: remove the note above and this note
+     identity link-path-metric-type {
        description
+         "Base identity used to define the link and the path metric
+         types.
+
+         The unit of the path metric value is interpreted in the
+         context of the path metric type and the derived identities
 
 
 
-Busi, et al.              Expires 1 August 2024                [Page 58]
+Busi, et al.             Expires 20 August 2024                [Page 59]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
-         "Average unidirectional link delay.";
-       reference
-         "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+         SHOULD describe the unit of the path metric types they
+         define.";
      }
 
-     identity path-metric-delay-minimum {
-       base path-metric-type;
-       description
-         "Minimum unidirectional link delay.";
-       reference
-         "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-     }
+       // CHANGE NOTE: The link-metric-type base identity
+       // and its derived identities
+       // have been added in this module revision
+       // RFC Editor: remove the note above and this note
+       identity link-metric-type {
+         base link-path-metric-type;
+         description
+           "Base identity for the link metric types.";
+       }
 
-     identity path-metric-residual-bandwidth {
-       base path-metric-type;
-       description
-         "Unidirectional Residual Bandwidth, which is defined to be
-          Maximum Bandwidth (RFC 3630) minus the bandwidth currently
-          allocated to LSPs.";
-       reference
-         "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
-          Version 2
-          RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-     }
+         identity link-metric-te {
+           base link-metric-type;
+           description
+             "Traffic Engineering (TE) Link Metric.";
+           reference
+             "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+             Version 2, section 2.5.5
 
-     identity path-metric-optimize-includes {
-       base path-metric-type;
-       description
-         "A metric that optimizes the number of included resources
-          specified in a set.";
-     }
+             RFC 5305: IS-IS Extensions for Traffic Engineering,
+             section 3.7";
+         }
 
-     identity path-metric-optimize-excludes {
-       base path-metric-type;
-       description
-         "A metric that optimizes to a maximum the number of excluded
-          resources specified in a set.";
-     }
+         identity link-metric-igp {
+           base link-metric-type;
+           description
+             "Interior Gateway Protocol (IGP) Link Metric.";
+           reference
+             "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric
+             as a second MPLS Traffic Engineering (TE) Metric";
+         }
+
+         identity link-metric-delay-average {
+           base link-metric-type;
+           description
+             "Unidirectional Link Delay, measured in units of
+             microseconds.";
+           reference
+             "RFC 7471: OSPF Traffic Engineering (TE) Metric
+             Extensions, section 4.1
+
+             RFC 8570: IS-IS Traffic Engineering (TE) Metric
+             Extensions, section 4.1";
+         }
+
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 60]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+         identity link-metric-delay-minimum {
+           base link-metric-type;
+           description
+             "Minimum unidirectional Link Delay, measured in units of
+             microseconds.";
+           reference
+             "RFC 7471: OSPF Traffic Engineering (TE) Metric
+             Extensions, section 4.2
+
+             RFC 8570: IS-IS Traffic Engineering (TE) Metric
+             Extensions, section 4.2";
+         }
+
+         identity link-metric-delay-maximum {
+           base link-metric-type;
+           description
+             "Maximum unidirectional Link Delay, measured in units of
+             microseconds.";
+           reference
+             "RFC 7471: OSPF Traffic Engineering (TE) Metric
+             Extensions, section 4.2
+
+             RFC 8570: IS-IS Traffic Engineering (TE) Metric
+             Extensions, section 4.2";
+         }
+
+         identity link-metric-residual-bandwidth {
+           base link-metric-type;
+           description
+             "Unidirectional Residual Bandwidth, measured in units of
+             bytes per second.
+
+             It is defined to be Maximum Bandwidth minus the bandwidth
+             currently allocated to LSPs.";
+           reference
+             "RFC 7471: OSPF Traffic Engineering (TE) Metric
+             Extensions, section 4.5
+
+             RFC 8570: IS-IS Traffic Engineering (TE) Metric
+             Extensions, section 4.5";
+         }
+
+       // CHANGE NOTE: The base and the description of the
+       // path-metric-type identity
+       // has been updated in this module revision
+       // RFC Editor: remove the note above and this note
+       identity path-metric-type {
+         base link-path-metric-type;
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 61]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+         base path-metric-optimization-type;
+         description
+           "Base identity for the path metric types.";
+       }
+
+         // CHANGE NOTE: The description and the reference of the
+         // path-metric-te identity have been updated
+         // in this module revision
+         // RFC Editor: remove the note above and this note
+         identity path-metric-te {
+           base path-metric-type;
+           description
+             "Traffic Engineering (TE) Path Metric.";
+           reference
+             "RFC 5440: Path Computation Element (PCE) Communication
+             Protocol (PCEP), section 7.8";
+         }
+
+         // CHANGE NOTE: The description and the reference of the
+         // path-metric-igp identity have been updated
+         // in this module revision
+         // RFC Editor: remove the note above and this note
+         identity path-metric-igp {
+           base path-metric-type;
+           description
+             "Interior Gateway Protocol (IGP) Path Metric.";
+           reference
+             "RFC 5440: Path Computation Element (PCE) Communication
+             Protocol (PCEP), section 7.8";
+         }
+
+         // CHANGE NOTE: The description and the reference of the
+         // path-metric-hop identity have been updated
+         // in this module revision
+         // RFC Editor: remove the note above and this note
+         identity path-metric-hop {
+           base path-metric-type;
+           description
+             "Hop Count Path Metric.";
+           reference
+             "RFC 5440: Path Computation Element (PCE) Communication
+             Protocol (PCEP), section 7.8";
+         }
+
+         // CHANGE NOTE: The description and the reference of the
+         // path-metric-delay-average identity have been updated
+         // in this module revision
+         // RFC Editor: remove the note above and this note
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 62]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+         identity path-metric-delay-average {
+           base path-metric-type;
+           description
+             "The Path Delay Metric, measured in units of
+             microseconds.";
+           reference
+             "RFC8233: Extensions to the Path Computation Element
+             Communication Protocol (PCEP) to Compute Service-Aware
+             Label Switched Paths (LSPs), section 3.1.1";
+         }
+
+         // CHANGE NOTE: The description and the reference of the
+         // path-metric-delay-minimum identity have been updated
+         // in this module revision
+         // RFC Editor: remove the note above and this note
+         identity path-metric-delay-minimum {
+           base path-metric-type;
+           description
+             "The Path Min Delay Metric, measured in units of
+             microseconds.";
+           reference
+             "I-D.ietf-pce-sid-algo: Carrying SR-Algorithm information
+             in PCE-based Networks, section 3.5.1";
+         }
+
+         // CHANGE NOTE: The description and the reference of the
+         // path-metric-residual-bandwidth identity have been updated
+         // in this module revision
+         // RFC Editor: remove the note above and this note
+         identity path-metric-residual-bandwidth {
+           base path-metric-type;
+           description
+             "The Path Residual Bandwidth, defined as the minimum Link
+             Residual Bandwidth all the links along the path.
+
+             The Path Residual Bandwidth can be seen as the path
+             metric associated with the Maximum residual Bandwidth Path
+             (MBP) objective function.";
+           reference
+             "RFC 5541: Encoding of Objective Functions in the Path
+             Computation Element Communication Protocol (PCEP)";
+         }
+
+       // CHANGE NOTE: The base of the path-metric-optimize-includes
+       // identity has been updated in this module revision
+       // RFC Editor: remove the note above and this note
+       identity path-metric-optimize-includes {
+         base path-metric-optimization-type;
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 63]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+         description
+           "A metric that optimizes the number of included resources
+           specified in a set.";
+       }
+
+       // CHANGE NOTE: The base of the path-metric-optimize-excludes
+       // identity has been updated in this module revision
+       // RFC Editor: remove the note above and this note
+       identity path-metric-optimize-excludes {
+         base path-metric-optimization-type;
+         description
+           "A metric that optimizes to a maximum the number of excluded
+           resources specified in a set.";
+       }
 
      identity path-tiebreaker-type {
        description
@@ -3298,14 +3554,6 @@ Internet-Draft            TE Common YANG Types              January 2024
        base path-tiebreaker-type;
        description
          "Min-Fill LSP path placement.";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 59]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
      }
 
      identity path-tiebreaker-maxfill {
@@ -3330,6 +3578,14 @@ Internet-Draft            TE Common YANG Types              January 2024
      identity resource-aff-include-all {
        base resource-affinities-type;
        description
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 64]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          "The set of attribute filters associated with a
           tunnel, all of which must be present for a link
           to be acceptable.";
@@ -3354,24 +3610,20 @@ Internet-Draft            TE Common YANG Types              January 2024
        description
          "The set of attribute filters associated with a
           tunnel, any of which renders a link unacceptable.";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 60]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        reference
          "RFC 2702: Requirements for Traffic Engineering Over MPLS
           RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
      }
 
+     // CHANGE NOTE: The reference of the identity
+     // te-optimization-criterion below has been updated
+     // in this module revision
+     // RFC Editor: remove the note above and this note
      identity te-optimization-criterion {
        description
          "Base identity for the TE optimization criteria.";
        reference
-         "RFC 3272: Overview and Principles of Internet Traffic
+         "RFC 9522: Overview and Principles of Internet Traffic
           Engineering";
      }
 
@@ -3382,6 +3634,14 @@ Internet-Draft            TE Common YANG Types              January 2024
      }
 
      identity cost {
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 65]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        base te-optimization-criterion;
        description
          "Optimized on cost.";
@@ -3410,14 +3670,6 @@ Internet-Draft            TE Common YANG Types              January 2024
          "Ignores SRLGs in the path computation.";
      }
 
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 61]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
      identity srlg-strict {
        base path-computation-srlg-type;
        description
@@ -3438,6 +3690,14 @@ Internet-Draft            TE Common YANG Types              January 2024
 
      // CHANGE NOTE: The base identity path-computation-error-reason
      // and its derived identities below have been
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 66]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
      // added in this module revision
      // RFC Editor: remove the note above and this note
      identity path-computation-error-reason {
@@ -3451,8 +3711,8 @@ Internet-Draft            TE Common YANG Types              January 2024
            "Path computation has failed because of an unspecified
            reason.";
          reference
-           "Section 7.5 of RFC5440: Path Computation Element (PCE)
-           Communication Protocol (PCEP)";
+           "RFC 5440: Path Computation Element (PCE) Communication
+           Protocol (PCEP), section 7.5";
        }
 
        identity path-computation-error-no-topology {
@@ -3466,21 +3726,19 @@ Internet-Draft            TE Common YANG Types              January 2024
          base path-computation-error-reason;
          description
            "Path computation has failed because one or more dependent
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 62]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
            path computation servers are unavailable.
 
            The dependent path computation server could be
            a Backward-Recursive Path Computation (BRPC) downstream
            PCE or a child PCE.";
          reference
-           "RFC5441, RFC8685";
+           "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+           Procedure to Compute Shortest Constrained Inter-Domain
+           Traffic Engineering Label Switched Paths
+
+           RFC 8685: Path Computation Element Communication Protocol
+           (PCEP) Extensions for the Hierarchical Path Computation
+           Element (H-PCE) Architecture";
        }
 
        identity path-computation-error-pce-unavailable {
@@ -3488,13 +3746,22 @@ Internet-Draft            TE Common YANG Types              January 2024
          description
            "Path computation has failed because PCE is not available.
 
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 67]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            It corresponds to bit 31 of the Flags field of the
            NO-PATH-VECTOR TLV.";
          reference
-           "RFC5440: Path Computation Element (PCE) Communication
-           Protocol (PCEP);
+           "RFC 5440: Path Computation Element (PCE) Communication
+           Protocol (PCEP)
 
-           https://www.iana.org/assignments/pcep/pcep.xhtml";
+           https://www.iana.org/assignments/pcep
+           /pcep.xhtml#no-path-vector-tlv";
        }
 
        identity path-computation-error-no-inclusion-hop {
@@ -3513,31 +3780,37 @@ Internet-Draft            TE Common YANG Types              January 2024
            It corresponds to bit 19 of the Flags field of the
            NO-PATH-VECTOR TLV.";
          reference
-           "RFC8685;
+           "RFC 8685: Path Computation Element Communication Protocol
+           (PCEP) Extensions for the Hierarchical Path Computation
+           Element (H-PCE) Architecture
 
-           https://www.iana.org/assignments/pcep/pcep.xhtml";
+           https://www.iana.org/assignments/pcep
+           /pcep.xhtml#no-path-vector-tlv";
        }
 
        identity path-computation-error-no-resource {
          base path-computation-error-reason;
          description
            "Path computation has failed because there is no
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 63]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
            available resource in one or more domains.
 
            It corresponds to bit 20 of the Flags field of the
            NO-PATH-VECTOR TLV.";
          reference
-           "RFC8685;
+           "RFC 8685: Path Computation Element Communication Protocol
+           (PCEP) Extensions for the Hierarchical Path Computation
+           Element (H-PCE) Architecture
 
-           https://www.iana.org/assignments/pcep/pcep.xhtml";
+           https://www.iana.org/assignments/pcep
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 68]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+           /pcep.xhtml#no-path-vector-tlv";
        }
 
        identity path-computation-error-child-pce-unresponsive {
@@ -3549,9 +3822,12 @@ Internet-Draft            TE Common YANG Types              January 2024
            It corresponds to bit 21 of the Flags field of the
            NO-PATH-VECTOR TLV.";
          reference
-           "RFC8685;
+           "RFC 8685: Path Computation Element Communication Protocol
+           (PCEP) Extensions for the Hierarchical Path Computation
+           Element (H-PCE) Architecture
 
-           https://www.iana.org/assignments/pcep/pcep.xhtml";
+           https://www.iana.org/assignments/pcep
+           /pcep.xhtml#no-path-vector-tlv";
        }
 
        identity path-computation-error-destination-domain-unknown {
@@ -3563,9 +3839,12 @@ Internet-Draft            TE Common YANG Types              January 2024
            It corresponds to bit 22 of the Flags field of the
            NO-PATH-VECTOR TLV.";
          reference
-           "RFC8685;
+           "RFC 8685: Path Computation Element Communication Protocol
+           (PCEP) Extensions for the Hierarchical Path Computation
+           Element (H-PCE) Architecture
 
-           https://www.iana.org/assignments/pcep/pcep.xhtml";
+           https://www.iana.org/assignments/pcep
+           /pcep.xhtml#no-path-vector-tlv";
        }
 
        identity path-computation-error-p2mp {
@@ -3577,16 +3856,20 @@ Internet-Draft            TE Common YANG Types              January 2024
            It corresponds to bit 24 of the Flags field of the
            NO-PATH-VECTOR TLV.";
          reference
-           "RFC8306;
+           "RFC 8306: Extensions to the Path Computation Element
+           Communication Protocol (PCEP) for Point-to-Multipoint
 
 
 
-Busi, et al.              Expires 1 August 2024                [Page 64]
+Busi, et al.             Expires 20 August 2024                [Page 69]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
-           https://www.iana.org/assignments/pcep/pcep.xhtml";
+           Traffic Engineering Label Switched Paths
+
+           https://www.iana.org/assignments/pcep
+           /pcep.xhtml#no-path-vector-tlv";
        }
 
        identity path-computation-error-no-gco-migration {
@@ -3598,9 +3881,12 @@ Internet-Draft            TE Common YANG Types              January 2024
            It corresponds to bit 26 of the Flags field of the
            NO-PATH-VECTOR TLV.";
          reference
-           "RFC5557;
+           "RFC 5557: Path Computation Element Communication Protocol
+           (PCEP) Requirements and Protocol Extensions in Support of
+           Global Concurrent Optimization
 
-           https://www.iana.org/assignments/pcep/pcep.xhtml";
+           https://www.iana.org/assignments/pcep
+           /pcep.xhtml#no-path-vector-tlv";
        }
 
        identity path-computation-error-no-gco-solution {
@@ -3612,9 +3898,12 @@ Internet-Draft            TE Common YANG Types              January 2024
            It corresponds to bit 25 of the Flags field of the
            NO-PATH-VECTOR TLV.";
          reference
-           "RFC5557;
+           "RFC 5557: Path Computation Element Communication Protocol
+           (PCEP) Requirements and Protocol Extensions in Support of
+           Global Concurrent Optimization
 
-           https://www.iana.org/assignments/pcep/pcep.xhtml";
+           https://www.iana.org/assignments/pcep
+           /pcep.xhtml#no-path-vector-tlv";
        }
 
        identity path-computation-error-pks-expansion {
@@ -3625,32 +3914,38 @@ Internet-Draft            TE Common YANG Types              January 2024
 
            It corresponds to bit 27 of the Flags field of the
            NO-PATH-VECTOR TLV.";
-         reference
-           "RFC5520;
 
-           https://www.iana.org/assignments/pcep/pcep.xhtml";
+
+
+Busi, et al.             Expires 20 August 2024                [Page 70]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+         reference
+           "RFC 5520: Preserving Topology Confidentiality in
+           Inter-Domain Path Computation Using a Path-Key-Based
+           Mechanism
+
+           https://www.iana.org/assignments/pcep
+           /pcep.xhtml#no-path-vector-tlv";
        }
 
        identity path-computation-error-brpc-chain-unavailable {
          base path-computation-error-no-dependent-server;
          description
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 65]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
            "Path computation has failed because PCE BRPC chain
            unavailable.
 
            It corresponds to bit 28 of the Flags field of the
            NO-PATH-VECTOR TLV.";
          reference
-           "RFC5441;
+           "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+           Procedure to Compute Shortest Constrained Inter-Domain
+           Traffic Engineering Label Switched Paths
 
-           https://www.iana.org/assignments/pcep/pcep.xhtml";
+           https://www.iana.org/assignments/pcep
+           /pcep.xhtml#no-path-vector-tlv";
        }
 
        identity path-computation-error-source-unknown {
@@ -3662,10 +3957,11 @@ Internet-Draft            TE Common YANG Types              January 2024
            It corresponds to bit 29 of the Flags field of the
            NO-PATH-VECTOR TLV.";
          reference
-           "RFC5440: Path Computation Element (PCE) Communication
+           "RFC 5440: Path Computation Element (PCE) Communication
            Protocol (PCEP);
 
-           https://www.iana.org/assignments/pcep/pcep.xhtml";
+           https://www.iana.org/assignments/pcep
+           /pcep.xhtml#no-path-vector-tlv";
        }
 
        identity path-computation-error-destination-unknown {
@@ -3674,13 +3970,22 @@ Internet-Draft            TE Common YANG Types              January 2024
            "Path computation has failed because destination node is
            unknown.
 
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 71]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            It corresponds to bit 30 of the Flags field of the
            NO-PATH-VECTOR TLV.";
          reference
-           "RFC5440: Path Computation Element (PCE) Communication
+           "RFC 5440: Path Computation Element (PCE) Communication
            Protocol (PCEP);
 
-           https://www.iana.org/assignments/pcep/pcep.xhtml";
+           https://www.iana.org/assignments/pcep
+           /pcep.xhtml#no-path-vector-tlv";
        }
 
        identity path-computation-error-no-server {
@@ -3689,18 +3994,11 @@ Internet-Draft            TE Common YANG Types              January 2024
            "Path computation has failed because path computation
            server is unavailable.";
          reference
-           "RFC5440: Path Computation Element (PCE) Communication
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 66]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
+           "RFC 5440: Path Computation Element (PCE) Communication
            Protocol (PCEP);
 
-           https://www.iana.org/assignments/pcep/pcep.xhtml";
+           https://www.iana.org/assignments/pcep
+           /pcep.xhtml#no-path-vector-tlv";
        }
 
      // CHANGE NOTE: The base identity protocol-origin-type and
@@ -3725,15 +4023,22 @@ Internet-Draft            TE Common YANG Types              January 2024
            "Protocol origin is Path Computation Engine Protocol
            (PCEP).";
          reference
-           "RFC5440: Path Computation Element (PCE) Communication
+           "RFC 5440: Path Computation Element (PCE) Communication
            Protocol (PCEP)";
        }
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 72]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
        identity protocol-origin-bgp {
          base protocol-origin-type;
          description
            "Protocol origin is Border Gateway Protocol (BGP).";
-         reference "RFC9012";
+         reference "RFC 9012";
        }
 
      // CHANGE NOTE: The base identity svec-objective-function-type
@@ -3744,16 +4049,8 @@ Internet-Draft            TE Common YANG Types              January 2024
        description
          "Base identity for SVEC objective function type.";
        reference
-         "RFC5541: Encoding of Objective Functions in the Path
-          Computation Element Communication Protocol (PCEP).";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 67]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
+         "RFC 5541: Encoding of Objective Functions in the Path
+          Computation Element Communication Protocol (PCEP)";
      }
 
        identity svec-of-minimize-agg-bandwidth-consumption {
@@ -3762,8 +4059,8 @@ Internet-Draft            TE Common YANG Types              January 2024
            "Objective function for minimizing aggregate bandwidth
            consumption (MBC).";
          reference
-           "RFC5541: Encoding of Objective Functions in the Path
-           Computation Element Communication Protocol (PCEP).";
+           "RFC 5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP)";
        }
 
        identity svec-of-minimize-load-most-loaded-link {
@@ -3772,8 +4069,8 @@ Internet-Draft            TE Common YANG Types              January 2024
            "Objective function for minimizing the load on the link that
            is carrying the highest load (MLL).";
          reference
-           "RFC5541: Encoding of Objective Functions in the Path
-           Computation Element Communication Protocol (PCEP).";
+           "RFC 5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP)";
        }
 
        identity svec-of-minimize-cost-path-set {
@@ -3782,9 +4079,16 @@ Internet-Draft            TE Common YANG Types              January 2024
            "Objective function for minimizing the cost on a path set
            (MCC).";
          reference
-           "RFC5541: Encoding of Objective Functions in the Path
-           Computation Element Communication Protocol (PCEP).";
+           "RFC 5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP)";
        }
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 73]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
        identity svec-of-minimize-common-transit-domain {
          base svec-objective-function-type;
@@ -3792,9 +4096,9 @@ Internet-Draft            TE Common YANG Types              January 2024
            "Objective function for minimizing the number of common
            transit domains (MCTD).";
          reference
-           "RFC8685: Path Computation Element Communication Protocol
+           "RFC 8685: Path Computation Element Communication Protocol
            (PCEP) Extensions for the Hierarchical Path Computation
-           Element (H-PCE) Architecture.";
+           Element (H-PCE) Architecture";
        }
 
        identity svec-of-minimize-shared-link {
@@ -3802,16 +4106,8 @@ Internet-Draft            TE Common YANG Types              January 2024
          description
            "Objective function for minimizing the number of shared
            links (MSL).";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 68]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
          reference
-           "RFC8685: Path Computation Element Communication Protocol
+           "RFC 8685: Path Computation Element Communication Protocol
            (PCEP) Extensions for the Hierarchical Path Computation
            Element (H-PCE) Architecture.";
        }
@@ -3822,7 +4118,7 @@ Internet-Draft            TE Common YANG Types              January 2024
            "Objective function for minimizing the number of shared
            Shared Risk Link Groups (SRLG) (MSS).";
          reference
-           "RFC8685: Path Computation Element Communication Protocol
+           "RFC 8685: Path Computation Element Communication Protocol
            (PCEP) Extensions for the Hierarchical Path Computation
            Element (H-PCE) Architecture.";
        }
@@ -3833,7 +4129,7 @@ Internet-Draft            TE Common YANG Types              January 2024
            "Objective function for minimizing the number of shared
            nodes (MSN).";
          reference
-           "RFC8685: Path Computation Element Communication Protocol
+           "RFC 8685: Path Computation Element Communication Protocol
            (PCEP) Extensions for the Hierarchical Path Computation
            Element (H-PCE) Architecture.";
        }
@@ -3842,46 +4138,47 @@ Internet-Draft            TE Common YANG Types              January 2024
      // its derived identities below have been
      // added in this module revision
      // RFC Editor: remove the note above and this note
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 74]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
      identity svec-metric-type {
        description
          "Base identity for SVEC metric type.";
        reference
-         "RFC5541: Encoding of Objective Functions in the Path
-          Computation Element Communication Protocol (PCEP).";
+         "RFC 5541: Encoding of Objective Functions in the Path
+          Computation Element Communication Protocol (PCEP)";
      }
 
-       identity svec-metric-cumul-te {
+       identity svec-metric-cumulative-te {
          base svec-metric-type;
          description
            "Cumulative TE cost.";
          reference
-           "RFC5541: Encoding of Objective Functions in the Path
-           Computation Element Communication Protocol (PCEP).";
+           "RFC 5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP)";
        }
 
-
-
-Busi, et al.              Expires 1 August 2024                [Page 69]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
-       identity svec-metric-cumul-igp {
+       identity svec-metric-cumulative-igp {
          base svec-metric-type;
          description
            "Cumulative IGP cost.";
          reference
-           "RFC5541: Encoding of Objective Functions in the Path
-           Computation Element Communication Protocol (PCEP).";
+           "RFC 5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP)";
        }
 
-       identity svec-metric-cumul-hop {
+       identity svec-metric-cumulative-hop {
          base svec-metric-type;
          description
            "Cumulative Hop path metric.";
          reference
-           "RFC5541: Encoding of Objective Functions in the Path
-           Computation Element Communication Protocol (PCEP).";
+           "RFC 5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP)";
        }
 
        identity svec-metric-aggregate-bandwidth-consumption {
@@ -3889,17 +4186,25 @@ Internet-Draft            TE Common YANG Types              January 2024
          description
            "Aggregate bandwidth consumption.";
          reference
-           "RFC5541: Encoding of Objective Functions in the Path
-           Computation Element Communication Protocol (PCEP).";
+           "RFC 5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP)";
        }
 
        identity svec-metric-load-of-the-most-loaded-link {
          base svec-metric-type;
          description
            "Load of the most loaded link.";
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 75]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          reference
-           "RFC5541: Encoding of Objective Functions in the Path
-           Computation Element Communication Protocol (PCEP).";
+           "RFC 5541: Encoding of Objective Functions in the Path
+           Computation Element Communication Protocol (PCEP)";
        }
 
      /**
@@ -3914,14 +4219,6 @@ Internet-Draft            TE Common YANG Types              January 2024
           type is used for unspecified technologies.
           The modeling structure can be augmented later for other
           technologies.";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 70]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        container te-bandwidth {
          description
            "Container that specifies TE bandwidth.  The choices
@@ -3953,6 +4250,14 @@ Internet-Draft            TE Common YANG Types              January 2024
           is used.";
        container te-label {
          description
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 76]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            "Container that specifies the TE label.  The choices can
             be augmented for specific data-plane technologies.";
          choice technology {
@@ -3970,14 +4275,6 @@ Internet-Draft            TE Common YANG Types              January 2024
          leaf direction {
            type te-label-direction;
            default "forward";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 71]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
            description
              "Label direction.";
          }
@@ -4009,6 +4306,14 @@ Internet-Draft            TE Common YANG Types              January 2024
          leaf topology-id {
            type te-topology-id;
            default "";
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 77]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            description
              "When the datastore contains several topologies,
               'topology-id' distinguishes between them.  If omitted,
@@ -4026,21 +4331,15 @@ Internet-Draft            TE Common YANG Types              January 2024
          "Performance Metrics (PM) information in real time that can
           be applicable to links or connections.  PM defined in this
           grouping are applicable to generic TE PM as well as packet TE
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 72]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
           PM.";
        reference
-         "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions
-          RFC 7823: Performance-Based Path Selection for Explicitly
-          Routed Label Switched Paths (LSPs) Using TE Metric
-          Extensions
-          RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
+         "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensionsù
+
+         RFC 7823: Performance-Based Path Selection for Explicitly
+         Routed Label Switched Paths (LSPs) Using TE Metric
+         Extensions
+
+         RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
        leaf one-way-delay {
          type uint32 {
            range "0..16777215";
@@ -4063,6 +4362,14 @@ Internet-Draft            TE Common YANG Types              January 2024
        reference
          "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions
           RFC 7823: Performance-Based Path Selection for Explicitly
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 78]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
           Routed Label Switched Paths (LSPs) Using TE Metric
           Extensions
           RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
@@ -4082,14 +4389,6 @@ Internet-Draft            TE Common YANG Types              January 2024
 
      grouping performance-metrics-one-way-bandwidth {
        description
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 73]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
          "PM information in real time that can be applicable to links.
           PM defined in this grouping are applicable to generic TE PM
           as well as packet TE PM.";
@@ -4119,6 +4418,14 @@ Internet-Draft            TE Common YANG Types              January 2024
        }
        leaf one-way-available-bandwidth {
          type rt-types:bandwidth-ieee-float32;
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 79]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          units "bytes per second";
          default "0x0p0";
          description
@@ -4138,14 +4445,6 @@ Internet-Draft            TE Common YANG Types              January 2024
          type rt-types:bandwidth-ieee-float32;
          units "bytes per second";
          default "0x0p0";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 74]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
          description
            "Bandwidth utilization that represents the actual
             utilization of the link (i.e., as measured in the router).
@@ -4175,6 +4474,14 @@ Internet-Draft            TE Common YANG Types              January 2024
          type rt-types:bandwidth-ieee-float32;
          units "bytes per second";
          default "0x0p0";
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 80]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          description
            "Residual bandwidth that subtracts tunnel reservations from
             Maximum Bandwidth (or link capacity) (RFC 3630) and
@@ -4194,14 +4501,6 @@ Internet-Draft            TE Common YANG Types              January 2024
             bundled link, available bandwidth is defined to be the
             sum of the component link available bandwidths.";
        }
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 75]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        leaf one-way-utilized-bandwidth {
          type rt-types:bandwidth-ieee-float32;
          units "bytes per second";
@@ -4231,6 +4530,14 @@ Internet-Draft            TE Common YANG Types              January 2024
        description
          "Grouping for configurable thresholds for measured
           attributes.";
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 81]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        uses one-way-performance-metrics;
        uses two-way-performance-metrics;
      }
@@ -4250,14 +4557,6 @@ Internet-Draft            TE Common YANG Types              January 2024
          uses performance-metrics-one-way-delay-loss;
          uses performance-metrics-one-way-bandwidth;
        }
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 76]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        container performance-metrics-two-way {
          description
            "Two-way link performance information in real time.";
@@ -4287,6 +4586,14 @@ Internet-Draft            TE Common YANG Types              January 2024
             Routed Label Switched Paths (LSPs) Using TE Metric
             Extensions
             RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 82]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          leaf one-way-delay-offset {
            type uint32 {
              range "0..16777215";
@@ -4306,14 +4613,6 @@ Internet-Draft            TE Common YANG Types              January 2024
            type uint32;
            default "0";
            description
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 77]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
              "Interval, in seconds, to advertise the extended metric
               values.";
          }
@@ -4343,6 +4642,14 @@ Internet-Draft            TE Common YANG Types              January 2024
            description
              "If the measured parameter falls inside an upper bound
               for all but the minimum-delay metric (or a lower bound
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 83]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
               for the minimum-delay metric only) and the advertised
               value is not already inside that bound, a 'normal'
               announcement (anomalous bit cleared) will be triggered.";
@@ -4361,14 +4668,6 @@ Internet-Draft            TE Common YANG Types              January 2024
      /**
       * TE tunnel generic groupings
       **/
-
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 78]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
 
      // CHANGE NOTE: The explicit-route-hop grouping below has been
      // updated in this module revision
@@ -4399,6 +4698,14 @@ Internet-Draft            TE Common YANG Types              January 2024
                type te-hop-type;
                default "strict";
                description
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 84]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
                  "Strict or loose hop.";
              }
              description
@@ -4418,14 +4725,6 @@ Internet-Draft            TE Common YANG Types              January 2024
                description
                  "TE Link Termination Point (LTP) identifier.";
              }
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 79]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
              leaf hop-type {
                type te-hop-type;
                default "strict";
@@ -4455,6 +4754,14 @@ Internet-Draft            TE Common YANG Types              January 2024
                  "At least one node identifier and at least one Link
                  Termination Point (LTP) identifier MUST be present.";
              }
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 85]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
              leaf link-tp-id-uri {
                type nt:tp-id;
                description
@@ -4474,14 +4781,6 @@ Internet-Draft            TE Common YANG Types              January 2024
              }
              leaf node-id {
                type te-node-id;
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 80]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
                description
                  "The identifier of a node in the TE topology.";
              }
@@ -4511,6 +4810,14 @@ Internet-Draft            TE Common YANG Types              January 2024
              leaf as-number {
                type inet:as-number;
                mandatory true;
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 86]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
                description
                  "The Autonomous System (AS) number.";
              }
@@ -4530,20 +4837,15 @@ Internet-Draft            TE Common YANG Types              January 2024
                "Label hop type.";
              uses te-label;
            }
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 81]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
            description
              "The label explicit route hop type.";
          }
        }
      }
 
+     // CHANGE NOTE: The explicit-route-hop grouping below has been
+     // updated in this module revision
+     // RFC Editor: remove the note above and this note
      grouping record-route-state {
        description
          "The Record Route grouping.";
@@ -4564,6 +4866,14 @@ Internet-Draft            TE Common YANG Types              January 2024
                  "At least one node identifier MUST be present.";
              }
              description
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 87]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
                "Numbered node route hop container.";
              leaf node-id-uri {
                type nw:node-id;
@@ -4586,14 +4896,6 @@ Internet-Draft            TE Common YANG Types              January 2024
                   RFC 4561: Definition of a Record Route Object (RRO)
                   Node-Id Sub-Object";
              }
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 82]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
            }
            description
              "Numbered node route hop.";
@@ -4620,6 +4922,14 @@ Internet-Draft            TE Common YANG Types              January 2024
                   Node-Id Sub-Object";
              }
            }
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 88]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            description
              "Numbered link route hop.";
          }
@@ -4642,14 +4952,6 @@ Internet-Draft            TE Common YANG Types              January 2024
                  "TE LTP identifier.  The combination of the TE link ID
                   and the TE node ID is used to identify an unnumbered
                   TE link.";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 83]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
              }
              leaf node-id-uri {
                type nw:node-id;
@@ -4676,6 +4978,14 @@ Internet-Draft            TE Common YANG Types              January 2024
                "Unnumbered link Record Route hop.";
              reference
                "RFC 3477: Signalling Unnumbered Links in Resource
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 89]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
                 ReSerVation Protocol - Traffic Engineering (RSVP-TE)";
            }
            description
@@ -4698,14 +5008,6 @@ Internet-Draft            TE Common YANG Types              January 2024
                   Node-Id Sub-Object";
              }
            }
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 84]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
            description
              "The label Record Route entry types.";
          }
@@ -4732,6 +5034,14 @@ Internet-Draft            TE Common YANG Types              January 2024
        }
        leaf index {
          type uint32;
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 90]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          description
            "The index of the label restriction list entry.";
        }
@@ -4754,14 +5064,6 @@ Internet-Draft            TE Common YANG Types              January 2024
             This is the label value if a single label is specified,
             in which case the 'label-end' attribute is not set.";
          uses te-label;
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 85]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        }
        container label-end {
          must "(not(../label-start/te-label/direction) and"
@@ -4788,6 +5090,14 @@ Internet-Draft            TE Common YANG Types              January 2024
             The label start/end values will have to be consistent
             with the sign of label step.  For example,
             'label-start' < 'label-end' enforces 'label-step' > 0
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 91]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
             'label-start' > 'label-end' enforces 'label-step' < 0.";
          choice technology {
            default "generic";
@@ -4810,14 +5120,6 @@ Internet-Draft            TE Common YANG Types              January 2024
             this attribute is used to specify the positions
             of the used labels.  This is represented in big endian as
             'hex-string'.
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 86]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
             The most significant byte in the hex-string is the farthest
             to the left in the byte sequence.  Leading zero bytes in the
             configured value may be omitted for brevity.
@@ -4844,6 +5146,14 @@ Internet-Draft            TE Common YANG Types              January 2024
          description
            "The label restrictions container.";
          list label-restriction {
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 92]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            key "index";
            description
              "The absence of the label restrictions container implies
@@ -4857,23 +5167,18 @@ Internet-Draft            TE Common YANG Types              January 2024
        }
      }
 
+     // CHANGE NOTE: The grouping optimization-metric-entry below has
+     // been updated in this module revision
+     // RFC Editor: remove the note above and this note
      grouping optimization-metric-entry {
        description
          "Optimization metrics configuration grouping.";
        leaf metric-type {
          type identityref {
-           base path-metric-type;
+           base path-metric-optimization-type;
          }
          description
            "Identifies the 'metric-type' that the path computation
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 87]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
             process uses for optimization.";
        }
        leaf weight {
@@ -4897,6 +5202,13 @@ Internet-Draft            TE Common YANG Types              January 2024
          uses path-route-include-objects;
        }
      }
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 93]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
      grouping common-constraints {
        description
@@ -4922,14 +5234,6 @@ Internet-Draft            TE Common YANG Types              January 2024
          type uint8 {
            range "0..7";
          }
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 88]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
          default "7";
          description
            "TE LSP requested setup priority.";
@@ -4954,8 +5258,19 @@ Internet-Draft            TE Common YANG Types              January 2024
          description
            "TE tunnel path signaling type.";
        }
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 94]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
      }
 
+     // CHANGE NOTE: The grouping tunnel-constraints below has
+     // been updated in this module revision
+     // RFC Editor: remove the note above and this note
      grouping tunnel-constraints {
        description
          "Tunnel constraints grouping that can be set on
@@ -4969,23 +5284,15 @@ Internet-Draft            TE Common YANG Types              January 2024
        uses common-constraints;
      }
 
+     // CHANGE NOTE: The grouping path-constraints-route-objects below
+     // has been updated in this module revision
+     // RFC Editor: remove the note above and this note
      grouping path-constraints-route-objects {
        description
          "List of route entries to be included or excluded when
           performing the path computation.";
-       // CHANGE NOTE: The explicit-route-objects container below has
-       // been updated in this module revision
-       // RFC Editor: remove the note above and this note
        container explicit-route-objects {
          description
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 89]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
            "Container for the explicit route object lists.";
          list route-object-exclude-always {
            key "index";
@@ -5007,6 +5314,14 @@ Internet-Draft            TE Common YANG Types              January 2024
            ordered-by user;
            description
              "List of route objects to include or exclude in the path
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 95]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
               computation.";
            leaf explicit-route-usage {
              type identityref {
@@ -5034,14 +5349,6 @@ Internet-Draft            TE Common YANG Types              January 2024
                      type uint32;
                      description
                        "SRLG value.";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 90]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
                    }
                  }
                  description
@@ -5063,6 +5370,14 @@ Internet-Draft            TE Common YANG Types              January 2024
        list route-object-include-object {
          key "index";
          ordered-by user;
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 96]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          description
            "List of Explicit Route Objects to be included in the
             path computation.";
@@ -5090,14 +5405,6 @@ Internet-Draft            TE Common YANG Types              January 2024
          leaf index {
            type uint32;
            description
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 91]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
              "Route object entry index.  The index is used to
               identify an entry in the list.  The order of entries
               is defined by the user without relying on key values.";
@@ -5119,25 +5426,44 @@ Internet-Draft            TE Common YANG Types              January 2024
              }
              description
                "Augmentation for a generic explicit route for SRLG
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 97]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
                 exclusion.";
            }
          }
        }
      }
 
+     // CHANGE NOTE: The grouping generic-path-metric-bounds below
+     // has been updated in this module revision
+     // RFC Editor: remove the note above and this note
      grouping generic-path-metric-bounds {
        description
          "TE path metric bounds grouping.";
        container path-metric-bounds {
          description
-           "TE path metric bounds container.";
+           "Top-level container for the list of path metric bounds.";
          list path-metric-bound {
            key "metric-type";
            description
-             "List of TE path metric bounds.";
+             "List of path metric bounds, which can apply to link and
+             path metrics.
+
+             TE paths which have at least one path metric which
+             exceeds the specified bounds MUST NOT be selected.
+
+             TE paths that traverse TE links which have at least one
+             link metric which exceeds the specified bounds MUST NOT
+             be selected.";
            leaf metric-type {
              type identityref {
-               base path-metric-type;
+               base link-path-metric-type;
              }
              description
                "Identifies an entry in the list of 'metric-type' items
@@ -5146,27 +5472,30 @@ Internet-Draft            TE Common YANG Types              January 2024
            leaf upper-bound {
              type uint64;
              default "0";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 92]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
              description
-               "Upper bound on the end-to-end TE path metric.
+               "Upper bound on the specified 'metric-type'.
 
                A zero indicates an unbounded upper limit for the
-               specific 'metric-type'.
+               specificied 'metric-type'.
 
                The unit of is interpreted in the context of the
-               path-metric-type.";
+               'metric-type' identity.";
            }
          }
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 98]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        }
      }
 
+     // CHANGE NOTE: The grouping generic-path-metric-bounds below
+     // has been updated in this module revision
+     // RFC Editor: remove the note above and this note
      grouping generic-path-optimization {
        description
          "TE generic path optimization grouping.";
@@ -5189,7 +5518,11 @@ Internet-Draft            TE Common YANG Types              January 2024
              /* Tiebreakers */
              container tiebreakers {
                description
-                 "Container for the list of tiebreakers.";
+                 "Container for the list of tiebreakers.
+
+                 This container has been obsoleted by the tiebreaker
+                 leaf.";
+               status deprecated;
                list tiebreaker {
                  key "tiebreaker-type";
                  description
@@ -5202,17 +5535,17 @@ Internet-Draft            TE Common YANG Types              January 2024
                    }
                    description
                      "Identifies an entry in the list of tiebreakers.";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 93]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
                  }
                }
              }
+
+
+
+Busi, et al.             Expires 20 August 2024                [Page 99]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            }
            case objective-function {
              if-feature "path-optimization-objective-function";
@@ -5233,6 +5566,15 @@ Internet-Draft            TE Common YANG Types              January 2024
            }
          }
        }
+       leaf tiebreaker {
+         type identityref {
+           base path-tiebreaker-type;
+         }
+         default "te-types:path-tiebreaker-random";
+         description
+           "The tiebreaker criteria to apply on an equally favored set
+           of paths, in order to pick the best.";
+       }
      }
 
      grouping generic-path-affinities {
@@ -5252,20 +5594,20 @@ Internet-Draft            TE Common YANG Types              January 2024
              description
                "Identifies an entry in the list of value affinity
                 constraints.";
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 100]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            }
            leaf value {
              type admin-groups;
              default "";
              description
                "The affinity value.  The default is empty.";
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 94]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
            }
          }
        }
@@ -5308,20 +5650,20 @@ Internet-Draft            TE Common YANG Types              January 2024
            key "usage";
            description
              "List of SRLG values to be included or excluded.";
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 101]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            leaf usage {
              type identityref {
                base route-usage-type;
              }
              description
                "Identifies an entry in a list of SRLGs to either
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 95]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
                 include or exclude.";
            }
            leaf-list values {
@@ -5364,20 +5706,20 @@ Internet-Draft            TE Common YANG Types              January 2024
            "The type of resource disjointness.
             When configured for a primary path, the disjointness level
             applies to all secondary LSPs.  When configured for a
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 102]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
             secondary path, the disjointness level overrides the level
             configured for the primary path.";
        }
      }
 
      grouping common-path-constraints-attributes {
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 96]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        description
          "Common path constraints configuration grouping.";
        uses common-constraints;
@@ -5420,20 +5762,20 @@ Internet-Draft            TE Common YANG Types              January 2024
              description
                "TE path metric accumulative value.";
            }
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 103]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          }
          uses generic-path-affinities;
          uses generic-path-srlgs;
          container path-route-objects {
            description
              "Container for the list of route objects either returned by
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 97]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
               the computation engine or actually used by an LSP.";
            list path-route-object {
              key "index";
@@ -5469,26 +5811,26 @@ Internet-Draft            TE Common YANG Types              January 2024
          description
            "LSP encoding type.";
          reference
-           "RFC3945";
+           "RFC 3945";
        }
        leaf switching-type {
          type identityref {
            base te-types:switching-capabilities;
          }
          description
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 104]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            "LSP switching type.";
          reference
-           "RFC3945";
+           "RFC 3945";
        }
      }
-
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 98]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
 
      // CHANGE NOTE: The typedef te-gen-node-id below has been
      // added in this module revision
@@ -5531,20 +5873,19 @@ Internet-Draft            TE Common YANG Types              January 2024
    The "ietf-te-packet-types" module imports from the "ietf-te-types"
    module defined in Section 4 of this document.
 
+
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 105]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
    CHANGE NOTE: Please focus your review only on the updates to the YANG
    model: see also Appendix A.1.
 
    RFC Editor: remove the CHANGE NOTE above and this note
-
-
-
-
-
-
-Busi, et al.              Expires 1 August 2024                [Page 99]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
 
    <CODE BEGINS> file "ietf-te-packet-types@2024-01-25.yang"
    module ietf-te-packet-types {
@@ -5589,19 +5930,19 @@ Internet-Draft            TE Common YANG Types              January 2024
         (TE).
 
         The model fully conforms to the Network Management Datastore
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 106]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
         Architecture (NMDA).
 
         The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
         NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
         'MAY', and 'OPTIONAL' in this document are to be interpreted as
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 100]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
         described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
         they appear in all capitals, as shown here.
 
@@ -5618,18 +5959,20 @@ Internet-Draft            TE Common YANG Types              January 2024
         This version of this YANG module is part of RFC XXXX
         (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
         for full legal notices.";
-     revision 2024-01-25 {
+     revision 2024-02-16 {
        description
-         "Added common TE packet identities:
+         "This revision adds the following new identities:
           - bandwidth-profile-type;
-          - path-metric-loss;
-          - path-metric-delay-variation.
+          - link-metric-delay-variation;
+          - link-metric-loss;
+          - path-metric-delay-variation;
+          - path-metric-loss.
 
-          Added common TE packet groupings:
+         This revision adds the following new groupings:
           - te-packet-path-bandwidth;
           - te-packet-link-bandwidth.
 
-          Updated module description.";
+         This revision provides also few editorial changes.";
        reference
          "RFC XXXX: Common YANG Data Types for Traffic Engineering";
      }
@@ -5643,6 +5986,14 @@ Internet-Draft            TE Common YANG Types              January 2024
          "RFC 8776: Common YANG Data Types for Traffic Engineering";
      }
 
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 107]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
      /*
       * Identities
       */
@@ -5650,14 +6001,6 @@ Internet-Draft            TE Common YANG Types              January 2024
      // CHANGE NOTE: The base identity bandwidth-profile-type and
      // its derived identities below have been
      // added in this module revision
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 101]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
      // RFC Editor: remove the note above and this note
      identity bandwidth-profile-type {
        description
@@ -5697,64 +6040,80 @@ Internet-Draft            TE Common YANG Types              January 2024
            Marker with Efficient Handling of in-Profile Traffic";
        }
 
-     // CHANGE NOTE: The identity path-metric-loss below has
-     // been added in this module revision
-     // RFC Editor: remove the note above and this note
-     identity path-metric-loss {
-       base te-types:path-metric-type;
-       description
-         "The path loss (as a packet percentage) metric type
-         encodes a function of the unidirectional loss metrics of all
-         links traversed by a P2P path.
+       // CHANGE NOTE: The identity link-metric-delay-variation
+       // below has been added in this module revision
 
 
 
-Busi, et al.              Expires 1 August 2024               [Page 102]
+Busi, et al.             Expires 20 August 2024               [Page 108]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
-         The basic unit is 0.000003%,
-         where (2^24 - 2) or 50.331642% is the maximum value of the
-         path loss percentage that can be expressed.
+       // RFC Editor: remove the note above and this note
+       identity link-metric-delay-variation {
+         base te-types:link-metric-type;
+         description
+           "The Unidirectional Delay Variation Metric,
+           measured in units of microseconds.";
+         reference
+           "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+           section 4.3
 
-         Values that are larger than the maximum value SHOULD be
-         encoded as the maximum value.";
-       reference
-         "RFC8233: Extensions to the Path Computation Element
-         Communication Protocol (PCEP) to Compute Service-Aware Label
-         Switched Paths (LSPs);
+           RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+           section 4.3";
+       }
 
-         RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
+       // CHANGE NOTE: The identity link-metric-loss below has
+       // been added in this module revision
+       // RFC Editor: remove the note above and this note
+       identity link-metric-loss {
+         base te-types:link-metric-type;
+         description
+           "The Unidirectional Link Loss Metric,
+           measured in units of 0.000003%.";
+         reference
+           "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+           section 4.4
 
-         RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
-     }
+           RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+           section 4.4";
+       }
 
-     // CHANGE NOTE: The identity path-metric-delay-variation below has
-     // been added in this module revision
-     // RFC Editor: remove the note above and this note
-     identity path-metric-delay-variation {
-       base te-types:path-metric-type;
-       description
-         "The path delay variation encodes the sum of the unidirectional
-         delay variation metrics of all links traversed by a P2P path.
+       // CHANGE NOTE: The identity path-metric-delay-variation
+       // below has been added in this module revision
+       // RFC Editor: remove the note above and this note
+       identity path-metric-delay-variation {
+         base te-types:path-metric-type;
+         description
+           "The Path Delay Variation Metric,
+           measured in units of microseconds.";
+         reference
+           "RFC8233: Extensions to the Path Computation Element
+           Communication Protocol (PCEP) to Compute Service-Aware Label
+           Switched Paths (LSPs), section 3.1.2";
+       }
 
-         The path delay variation metric unit is in microseconds, where
-         (2^24 - 1) or 16,777,215 microseconds (16.777215 sec) is the
-         maximum value of the path delay variation that can be
-         expressed.
+       // CHANGE NOTE: The identity path-metric-loss below has
+       // been added in this module revision
+       // RFC Editor: remove the note above and this note
+       identity path-metric-loss {
 
-         Values that are larger than the maximum value SHOULD be
-         encoded as the maximum value.";
-       reference
-         "RFC8233: Extensions to the Path Computation Element
-         Communication Protocol (PCEP) to Compute Service-Aware Label
-         Switched Paths (LSPs);
 
-         RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
 
-         RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
-     }
+Busi, et al.             Expires 20 August 2024               [Page 109]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+         base te-types:path-metric-type;
+         description
+           "The Path Loss Metric, measured in units of 0.000003%.";
+         reference
+           "RFC8233: Extensions to the Path Computation Element
+           Communication Protocol (PCEP) to Compute Service-Aware Label
+           Switched Paths (LSPs), section 3.1.3";
+       }
 
      /*
       * Typedefs
@@ -5762,14 +6121,6 @@ Internet-Draft            TE Common YANG Types              January 2024
 
      typedef te-bandwidth-requested-type {
        type enumeration {
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 103]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
          enum specified {
            description
              "Bandwidth is explicitly specified.";
@@ -5803,6 +6154,14 @@ Internet-Draft            TE Common YANG Types              January 2024
        }
        description
          "Diffserv-TE bandwidth constraints as defined in RFC 4124.";
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 110]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        reference
          "RFC 4124: Protocol Extensions for Support of Diffserv-aware
           MPLS Traffic Engineering";
@@ -5818,14 +6177,6 @@ Internet-Draft            TE Common YANG Types              January 2024
      typedef bandwidth-mbps {
        type uint64;
        units "Mbps";
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 104]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        description
          "Bandwidth values, expressed in megabits per second.";
      }
@@ -5859,6 +6210,14 @@ Internet-Draft            TE Common YANG Types              January 2024
          "Base identity for the Diffserv-TE Bandwidth Constraints
           Model type.";
        reference
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 111]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          "RFC 4124: Protocol Extensions for Support of Diffserv-aware
           MPLS Traffic Engineering";
      }
@@ -5874,14 +6233,6 @@ Internet-Draft            TE Common YANG Types              January 2024
 
      identity bc-model-mam {
        base bc-model-type;
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 105]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
        description
          "Maximum Allocation Bandwidth Constraints Model type.";
        reference
@@ -5915,6 +6266,14 @@ Internet-Draft            TE Common YANG Types              January 2024
              }
              description
                "One-way minimum delay or latency in microseconds.";
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 112]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            }
            leaf one-way-min-delay-normality {
              type te-types:performance-metrics-normality;
@@ -5930,14 +6289,6 @@ Internet-Draft            TE Common YANG Types              January 2024
                "One-way maximum delay or latency in microseconds.";
            }
            leaf one-way-max-delay-normality {
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 106]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
              type te-types:performance-metrics-normality;
              default "normal";
              description
@@ -5971,6 +6322,14 @@ Internet-Draft            TE Common YANG Types              January 2024
              type decimal64 {
                fraction-digits 6;
                range "0..50.331642";
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 113]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
              }
              description
                "One-way packet loss as a percentage of the total traffic
@@ -5986,14 +6345,6 @@ Internet-Draft            TE Common YANG Types              January 2024
              description
                "Packet loss normality.";
              reference
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 107]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
                "RFC 7471: OSPF Traffic Engineering (TE) Metric
                 Extensions
                 RFC 7823: Performance-Based Path Selection for
@@ -6027,6 +6378,14 @@ Internet-Draft            TE Common YANG Types              January 2024
                 Explicitly Routed Label Switched Paths (LSPs) Using
                 TE Metric Extensions
                 RFC 8570: IS-IS Traffic Engineering (TE) Metric
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 114]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
                 Extensions";
            }
            leaf two-way-max-delay {
@@ -6042,14 +6401,6 @@ Internet-Draft            TE Common YANG Types              January 2024
              default "normal";
              description
                "Two-way maximum delay or latency normality.";
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 108]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
              reference
                "RFC 7471: OSPF Traffic Engineering (TE) Metric
                 Extensions
@@ -6083,6 +6434,14 @@ Internet-Draft            TE Common YANG Types              January 2024
                 TE Metric Extensions
                 RFC 8570: IS-IS Traffic Engineering (TE) Metric
                 Extensions";
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 115]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            }
            leaf two-way-packet-loss {
              type decimal64 {
@@ -6098,14 +6457,6 @@ Internet-Draft            TE Common YANG Types              January 2024
            leaf two-way-packet-loss-normality {
              type te-types:performance-metrics-normality;
              default "normal";
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 109]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
              description
                "Two-way packet loss normality.";
            }
@@ -6139,6 +6490,14 @@ Internet-Draft            TE Common YANG Types              January 2024
            range "0..16777215";
          }
          default "0";
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 116]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          description
            "One-way maximum delay or latency in microseconds.";
        }
@@ -6154,14 +6513,6 @@ Internet-Draft            TE Common YANG Types              January 2024
          type decimal64 {
            fraction-digits 6;
            range "0..50.331642";
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 110]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
          }
          default "0";
          description
@@ -6195,6 +6546,14 @@ Internet-Draft            TE Common YANG Types              January 2024
            range "0..16777215";
          }
          default "0";
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 117]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
          description
            "Two-way delay variation in microseconds.";
        }
@@ -6210,13 +6569,6 @@ Internet-Draft            TE Common YANG Types              January 2024
             0.000003%.";
        }
      }
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 111]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
 
      grouping performance-metrics-throttle-container-packet {
        description
@@ -6250,6 +6602,14 @@ Internet-Draft            TE Common YANG Types              January 2024
      // added in this module revision
      // RFC Editor: remove the note above and this note
      grouping te-packet-path-bandwidth {
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 118]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
        description
          "Path bandwidth for Packet. ";
        leaf bandwidth-profile-name {
@@ -6266,14 +6626,6 @@ Internet-Draft            TE Common YANG Types              January 2024
          type uint64;
          units "bits/second";
          mandatory true;
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 112]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
          description
            "Committed Information Rate (CIR).";
        }
@@ -6306,6 +6658,14 @@ Internet-Draft            TE Common YANG Types              January 2024
          type uint64;
          units "bytes";
          description
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 119]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
            "Peak Burst Size (PBS).";
        }
      }
@@ -6322,14 +6682,6 @@ Internet-Draft            TE Common YANG Types              January 2024
          description
            "Available bandwith value.";
        }
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 113]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
      }
    }
    <CODE ENDS>
@@ -6362,6 +6714,14 @@ Internet-Draft            TE Common YANG Types              January 2024
          prefix:    te-packet-types
          reference: RFC XXXX
 
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 120]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
    RFC Editor: Please replace XXXX with the RFC number assigned to this
    document.
 
@@ -6374,17 +6734,6 @@ Internet-Draft            TE Common YANG Types              January 2024
    transport is Secure Shell (SSH) [RFC6242].  The lowest RESTCONF layer
    is HTTPS, and the mandatory-to-implement secure transport is TLS
    [RFC8446].
-
-
-
-
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 114]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
 
    The Network Configuration Access Control Model (NACM) [RFC8341]
    provides the means to restrict access for particular NETCONF or
@@ -6422,6 +6771,13 @@ Internet-Draft            TE Common YANG Types              January 2024
               DOI 10.17487/RFC5440, March 2009,
               <https://www.rfc-editor.org/info/rfc5440>.
 
+
+
+Busi, et al.             Expires 20 August 2024               [Page 121]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
    [RFC5441]  Vasseur, JP., Ed., Zhang, R., Bitar, N., and JL. Le Roux,
               "A Backward-Recursive PCE-Based Computation (BRPC)
               Procedure to Compute Shortest Constrained Inter-Domain
@@ -6434,13 +6790,6 @@ Internet-Draft            TE Common YANG Types              January 2024
               Computation Using a Path-Key-Based Mechanism", RFC 5520,
               DOI 10.17487/RFC5520, April 2009,
               <https://www.rfc-editor.org/info/rfc5520>.
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 115]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
 
    [RFC5541]  Le Roux, JL., Vasseur, JP., and Y. Lee, "Encoding of
               Objective Functions in the Path Computation Element
@@ -6476,6 +6825,15 @@ Internet-Draft            TE Common YANG Types              January 2024
               RFC 7950, DOI 10.17487/RFC7950, August 2016,
               <https://www.rfc-editor.org/info/rfc7950>.
 
+
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 122]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
    [RFC8040]  Bierman, A., Bjorklund, M., and K. Watsen, "RESTCONF
               Protocol", RFC 8040, DOI 10.17487/RFC8040, January 2017,
               <https://www.rfc-editor.org/info/rfc8040>.
@@ -6488,15 +6846,6 @@ Internet-Draft            TE Common YANG Types              January 2024
               "Common YANG Data Types for the Routing Area", RFC 8294,
               DOI 10.17487/RFC8294, December 2017,
               <https://www.rfc-editor.org/info/rfc8294>.
-
-
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 116]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
 
    [RFC8306]  Zhao, Q., Dhody, D., Ed., Palleti, R., and D. King,
               "Extensions to the Path Computation Element Communication
@@ -6531,6 +6880,16 @@ Internet-Draft            TE Common YANG Types              January 2024
               RFC 8776, DOI 10.17487/RFC8776, June 2020,
               <https://www.rfc-editor.org/info/rfc8776>.
 
+
+
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 123]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
    [RFC8800]  Litkowski, S., Sivabalan, S., Barth, C., and M. Negi,
               "Path Computation Element Communication Protocol (PCEP)
               Extension for Label Switched Path (LSP) Diversity
@@ -6543,40 +6902,6 @@ Internet-Draft            TE Common YANG Types              January 2024
               <https://www.rfc-editor.org/info/rfc9012>.
 
 8.2.  Informative References
-
-
-
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 117]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
-   [I-D.ietf-teas-yang-l3-te-topo]
-              Liu, X., Bryskin, I., Beeram, V. P., Saad, T., Shah, H.
-              C., and O. G. de Dios, "YANG Data Model for Layer 3 TE
-              Topologies", Work in Progress, Internet-Draft, draft-ietf-
-              teas-yang-l3-te-topo-15, 21 October 2023,
-              <https://datatracker.ietf.org/doc/html/draft-ietf-teas-
-              yang-l3-te-topo-15>.
-
-   [I-D.ietf-teas-yang-path-computation]
-              Busi, I., Belotti, S., de Dios, O. G., Sharma, A., and Y.
-              Shi, "A YANG Data Model for requesting path computation",
-              Work in Progress, Internet-Draft, draft-ietf-teas-yang-
-              path-computation-21, 7 July 2023,
-              <https://datatracker.ietf.org/doc/html/draft-ietf-teas-
-              yang-path-computation-21>.
-
-   [I-D.ietf-teas-yang-te]
-              Saad, T., Gandhi, R., Liu, X., Beeram, V. P., and I.
-              Bryskin, "A YANG Data Model for Traffic Engineering
-              Tunnels, Label Switched Paths and Interfaces", Work in
-              Progress, Internet-Draft, draft-ietf-teas-yang-te-35, 12
-              January 2024, <https://datatracker.ietf.org/doc/html/
-              draft-ietf-teas-yang-te-35>.
 
    [I-D.ietf-teas-yang-te-mpls]
               Saad, T., Gandhi, R., Liu, X., Beeram, V. P., and I.
@@ -6601,15 +6926,6 @@ Internet-Draft            TE Common YANG Types              January 2024
               Marker", RFC 2698, DOI 10.17487/RFC2698, September 1999,
               <https://www.rfc-editor.org/info/rfc2698>.
 
-
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 118]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
    [RFC2702]  Awduche, D., Malcolm, J., Agogbua, J., O'Dell, M., and J.
               McManus, "Requirements for Traffic Engineering Over MPLS",
               RFC 2702, DOI 10.17487/RFC2702, September 1999,
@@ -6619,6 +6935,16 @@ Internet-Draft            TE Common YANG Types              January 2024
               and G. Swallow, "RSVP-TE: Extensions to RSVP for LSP
               Tunnels", RFC 3209, DOI 10.17487/RFC3209, December 2001,
               <https://www.rfc-editor.org/info/rfc3209>.
+
+
+
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 124]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
    [RFC3272]  Awduche, D., Chiu, A., Elwalid, A., Widjaja, I., and X.
               Xiao, "Overview and Principles of Internet Traffic
@@ -6655,17 +6981,6 @@ Internet-Draft            TE Common YANG Types              January 2024
               DOI 10.17487/RFC4090, May 2005,
               <https://www.rfc-editor.org/info/rfc4090>.
 
-
-
-
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 119]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
    [RFC4115]  Aboul-Magd, O. and S. Rabie, "A Differentiated Service
               Two-Rate, Three-Color Marker with Efficient Handling of
               in-Profile Traffic", RFC 4115, DOI 10.17487/RFC4115, July
@@ -6675,6 +6990,17 @@ Internet-Draft            TE Common YANG Types              January 2024
               Diffserv-aware MPLS Traffic Engineering", RFC 4124,
               DOI 10.17487/RFC4124, June 2005,
               <https://www.rfc-editor.org/info/rfc4124>.
+
+
+
+
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 125]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
    [RFC4125]  Le Faucheur, F. and W. Lai, "Maximum Allocation Bandwidth
               Constraints Model for Diffserv-aware MPLS Traffic
@@ -6714,14 +7040,6 @@ Internet-Draft            TE Common YANG Types              January 2024
               DOI 10.17487/RFC4427, March 2006,
               <https://www.rfc-editor.org/info/rfc4427>.
 
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 120]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
    [RFC4561]  Vasseur, J.-P., Ed., Ali, Z., and S. Sivabalan,
               "Definition of a Record Route Object (RRO) Node-Id Sub-
               Object", RFC 4561, DOI 10.17487/RFC4561, June 2006,
@@ -6731,6 +7049,14 @@ Internet-Draft            TE Common YANG Types              January 2024
               Element (PCE) Communication Protocol Generic
               Requirements", RFC 4657, DOI 10.17487/RFC4657, September
               2006, <https://www.rfc-editor.org/info/rfc4657>.
+
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 126]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
    [RFC4736]  Vasseur, JP., Ed., Ikejiri, Y., and R. Zhang,
               "Reoptimization of Multiprotocol Label Switching (MPLS)
@@ -6771,13 +7097,6 @@ Internet-Draft            TE Common YANG Types              January 2024
               TE)", RFC 5150, DOI 10.17487/RFC5150, February 2008,
               <https://www.rfc-editor.org/info/rfc5150>.
 
-
-
-Busi, et al.              Expires 1 August 2024               [Page 121]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
    [RFC5151]  Farrel, A., Ed., Ayyangar, A., and JP. Vasseur, "Inter-
               Domain MPLS and GMPLS Traffic Engineering -- Resource
               Reservation Protocol-Traffic Engineering (RSVP-TE)
@@ -6787,6 +7106,13 @@ Internet-Draft            TE Common YANG Types              January 2024
    [RFC5305]  Li, T. and H. Smit, "IS-IS Extensions for Traffic
               Engineering", RFC 5305, DOI 10.17487/RFC5305, October
               2008, <https://www.rfc-editor.org/info/rfc5305>.
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 127]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
    [RFC5307]  Kompella, K., Ed. and Y. Rekhter, Ed., "IS-IS Extensions
               in Support of Generalized Multi-Protocol Label Switching
@@ -6824,16 +7150,6 @@ Internet-Draft            TE Common YANG Types              January 2024
               DOI 10.17487/RFC6370, September 2011,
               <https://www.rfc-editor.org/info/rfc6370>.
 
-
-
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 122]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
    [RFC6378]  Weingarten, Y., Ed., Bryant, S., Osborne, E., Sprecher,
               N., and A. Fulignoli, Ed., "MPLS Transport Profile (MPLS-
               TP) Linear Protection", RFC 6378, DOI 10.17487/RFC6378,
@@ -6843,6 +7159,16 @@ Internet-Draft            TE Common YANG Types              January 2024
               Hop Popping Behavior and Out-of-Band Mapping for RSVP-TE
               Label Switched Paths", RFC 6511, DOI 10.17487/RFC6511,
               February 2012, <https://www.rfc-editor.org/info/rfc6511>.
+
+
+
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 128]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
    [RFC6780]  Berger, L., Le Faucheur, F., and A. Narayanan, "RSVP
               ASSOCIATION Object Extensions", RFC 6780,
@@ -6881,15 +7207,6 @@ Internet-Draft            TE Common YANG Types              January 2024
               Extensions", RFC 7471, DOI 10.17487/RFC7471, March 2015,
               <https://www.rfc-editor.org/info/rfc7471>.
 
-
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 123]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
    [RFC7551]  Zhang, F., Ed., Jing, R., and R. Gandhi, Ed., "RSVP-TE
               Extensions for Associated Bidirectional Label Switched
               Paths (LSPs)", RFC 7551, DOI 10.17487/RFC7551, May 2015,
@@ -6900,6 +7217,14 @@ Internet-Draft            TE Common YANG Types              January 2024
               Explicit Route Object (ERO)", RFC 7570,
               DOI 10.17487/RFC7570, July 2015,
               <https://www.rfc-editor.org/info/rfc7570>.
+
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 129]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
 
    [RFC7571]  Dong, J., Chen, M., Li, Z., and D. Ceccarelli, "GMPLS
               RSVP-TE Extensions for Lock Instruct and Loopback",
@@ -6935,17 +7260,6 @@ Internet-Draft            TE Common YANG Types              January 2024
               Networks", RFC 8169, DOI 10.17487/RFC8169, May 2017,
               <https://www.rfc-editor.org/info/rfc8169>.
 
-
-
-
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 124]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
    [RFC8233]  Dhody, D., Wu, Q., Manral, V., Ali, Z., and K. Kumaki,
               "Extensions to the Path Computation Element Communication
               Protocol (PCEP) to Compute Service-Aware Label Switched
@@ -6957,6 +7271,17 @@ Internet-Draft            TE Common YANG Types              January 2024
               Metric Extensions", RFC 8570, DOI 10.17487/RFC8570, March
               2019, <https://www.rfc-editor.org/info/rfc8570>.
 
+
+
+
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 130]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
    [RFC9314]  Jethanandani, M., Ed., Rahman, R., Ed., Zheng, L., Ed.,
               Pallagatti, S., and G. Mirsky, "YANG Data Model for
               Bidirectional Forwarding Detection (BFD)", RFC 9314,
@@ -6965,7 +7290,258 @@ Internet-Draft            TE Common YANG Types              January 2024
 
 Appendix A.  Changes from RFC 8776
 
-   To be added in a future revision of this draft.
+   This version adds new common data types, identities, and groupings to
+   the YANG modules.  It also updates some of the existing data types,
+   identities, and groupings in the YANG modules and fixes few bugs in
+   [RFC8776].
+
+   The following new identities have been added to the 'ietf-te-types'
+   module:
+
+   *  lsp-provisioning-error-reason;
+
+   *  association-type-diversity;
+
+   *  tunnel-admin-state-auto;
+
+   *  lsp-restoration-restore-none;
+
+   *  restoration-scheme-rerouting;
+
+   *  path-metric-optimization-type;
+
+   *  link-path-metric-type;
+
+   *  link-metric-type and its derived identities;
+
+   *  path-computation-error-reason and its derived identities;
+
+   *  protocol-origin-type and its derived identities;
+
+   *  svec-objective-function-type and its derived identities;
+
+   *  svec-metric-type and its derived identities.
+
+   The following new data types have been added to the 'ietf-te-types'
+   module:
+
+   *  path-type;
+
+   *  te-gen-node-id.
+
+
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 131]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+   The following new groupings have been added to the 'ietf-te-types'
+   module:
+
+   *  encoding-and-switching-type;
+
+   *  te-generic-node-id.
+
+   The following new identities have been added to the 'ietf-te-packet-
+   types' module:
+
+   *  bandwidth-profile-type;
+
+   *  link-metric-delay-variation;
+
+   *  link-metric-loss;
+
+   *  path-metric-delay-variation;
+
+   *  path-metric-loss.
+
+   The following new groupings have been added to the 'ietf-te-packet-
+   types' module:
+
+   *  te-packet-path-bandwidth;
+
+   *  te-packet-link-bandwidth.
+
+   The following identities, already defined in [RFC8776], have been
+   updated in the 'ietf-te-types' module:
+
+   *  objective-function-type (editorial);
+
+   *  action-exercise (bug fix);
+
+   *  path-metric-type:
+
+      new base identities have been added;
+
+   *  path-metric-te (bug fix);
+
+   *  path-metric-igp (bug fix);
+
+   *  path-metric-hop (bug fix);
+
+   *  path-metric-delay-average (bug fix);
+
+   *  path-metric-delay-minimum (bug fix);
+
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 132]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+   *  path-metric-residual-bandwidth (bug fix);
+
+   *  path-metric-optimize-includes (bug fix);
+
+   *  path-metric-optimize-excludes (bug fix);
+
+   *  te-optimization-criterion (editorial).
+
+   The following data type, already defined in [RFC8776], has been
+   updated in the 'ietf-te-types' module:
+
+   *  te-node-id;
+
+      The data type has been changed to be a union.
+
+   The following groupings, already defined in [RFC8776], have been
+   updated in the 'ietf-te-types' module:
+
+   *  explicit-route-hop
+
+      The following new leaves have been added to the 'explicit-route-
+      hop' grouping:
+
+      -  node-id-uri;
+
+      -  link-tp-id-uri;
+
+      The following leaves, already defined in [RFC8776], have been
+      updated in the 'explicit-route-hop':
+
+      -  node-id;
+
+      -  link-tp-id.
+
+         The mandatory true statements for the node-id and link-tp-id
+         have been replaced by must statements that requires at least
+         the presence of:
+
+         o  node-id or node-id-uri;
+
+         o  link-tp-id or link-tp-id-uri.
+
+   *  explicit-route-hop
+
+      The following new leaves have been added to the 'explicit-route-
+      hop' grouping:
+
+      -  node-id-uri;
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 133]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+      -  link-tp-id-uri;
+
+      The following leaves, already defined in [RFC8776], have been
+      updated in the 'explicit-route-hop':
+
+      -  node-id;
+
+      -  link-tp-id.
+
+         The mandatory true statements for the node-id and link-tp-id
+         have been replaced by must statements that requires at least
+         the presence of:
+
+         o  node-id or node-id-uri;
+
+         o  link-tp-id or link-tp-id-uri.
+
+   *  optimization-metric-entry:
+
+      The following leaves, already defined in [RFC8776], have been
+      updated in the 'optimization-metric-entry':
+
+      -  metric-type;
+
+         The base identity has been updated without impacting the set of
+         derived identities that are allowed.
+
+   *  tunnel-constraints;
+
+      The following new leaf have been added to the 'tunnel-constraints'
+      grouping:
+
+      -  network-id;
+
+   *  path-constraints-route-objects:
+
+      The following container, already defined in [RFC8776], has been
+      updated in the 'path-constraints-route-objects':
+
+      -  explicit-route-objects-always;
+
+         The container has been renamed as 'explicit-route-objects'.
+         This change is not affecting any IETF standard YANG models
+         since this grouping has not yet been used by any YANG model
+         defined in existing IETF RFCs.
+
+   *  generic-path-metric-bounds:
+
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 134]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+      The following leaves, already defined in [RFC8776], have been
+      updated in the 'optimization-metric-entry':
+
+      -  metric-type;
+
+         The base identity has been updated to:
+
+         o  increase the set of derived identities that are allowed and;
+
+         o  remove from this set the 'path-metric-optimize-includes' and
+            the 'path-metric-optimize-excludes' identities (bug fixing)
+
+   *  generic-path-optimization
+
+      The following new leaf have been added to the 'generic-path-
+      optimization' grouping:
+
+      -  tiebreaker;
+
+      The following container, already defined in [RFC8776], has been
+      deprecated:
+
+      -  tiebreakers.
+
+   The following identities, already defined in [RFC8776], have been
+   obsoletes in the 'ietf-te-types' module for bug fixing:
+
+   *  of-minimize-agg-bandwidth-consumption;
+
+   *  of-minimize-load-most-loaded-link;
+
+   *  of-minimize-cost-path-set;
+
+   *  lsp-protection-reroute-extra;
+
+   *  lsp-protection-reroute.
 
 A.1.  TE Types YANG Diffs
 
@@ -6978,6 +7554,14 @@ A.1.  TE Types YANG Diffs
    of the YANG model in Section 4 to the changes compared with the YANG
    model in [RFC8776].
 
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 135]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
    This diff has been generated using the following UNIX commands to
    compare the YANG module revisions in section 3.1 of [RFC8776] and in
    Section 4:
@@ -6989,18 +7573,6 @@ A.1.  TE Types YANG Diffs
        > model-updates.txt
 
    The output (model-updates.txt) is reported here:
-
-
-
-
-
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 125]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
 
  21a22,31
  >   import ietf-network {
@@ -7025,69 +7597,158 @@ Internet-Draft            TE Common YANG Types              January 2024
  <      the license terms contained in, the Simplified BSD License set
  ---
  >      the license terms contained in, the Revised BSD License set
- 65,66c75,113
+ 65,66c75,164
  <      This version of this YANG module is part of RFC 8776; see the
  <      RFC itself for full legal notices.";
  ---
  >      This version of this YANG module is part of RFC XXXX
  >      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
  >      for full legal notices.";
- >   revision 2024-01-29 {
+ >   revision 2024-02-16 {
  >     description
- >       "Added:
- >       - base identity lsp-provisioning-error-reason;
- >       - identity association-type-diversity;
- >       - identity tunnel-admin-state-auto;
- >       - identity lsp-restoration-restore-none;
- >       - identity restoration-scheme-rerouting;
- >       - base identity path-computation-error-reason and
- >         its derived identities;
- >       - base identity protocol-origin-type and
- >         its derived identities;
- >       - base identity svec-objective-function-type and its derived
- >         identities;
- >       - base identity svec-metric-type and its derived identities;
- >       - grouping encoding-and-switching-type.
- >
- >       Updated:
+ >       "This revision adds the following new identities:
+ >       - lsp-provisioning-error-reason;
+ >       - association-type-diversity;
+ >       - tunnel-admin-state-auto;
 
 
 
-Busi, et al.              Expires 1 August 2024               [Page 126]
+Busi, et al.             Expires 20 August 2024               [Page 136]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
- >       - description of the base identity objective-function-type;
- >       - description and reference of identity action-exercise;
- >       - typedef te-node-id to support also 16 octects TE identifiers.
+ >       - lsp-restoration-restore-none;
+ >       - restoration-scheme-rerouting;
+ >       - path-metric-optimization-type;
+ >       - link-path-metric-type;
+ >       - link-metric-type and its derived identities;
+ >       - path-computation-error-reason and its derived identities;
+ >       - protocol-origin-type and its derived identities;
+ >       - svec-objective-function-type and its derived identities;
+ >       - svec-metric-type and its derived identities.
  >
- >       Obsoleted:
- >       - identity of-minimize-agg-bandwidth-consumption;
- >       - identity of-minimize-load-most-loaded-link;
- >       - identity of-minimize-cost-path-set;
- >       - identity lsp-protection-reroute-extra;
- >       - identity lsp-protection-reroute.
+ >       This revision adds the following new data types:
+ >       - path-type;
+ >       - te-gen-node-id.
  >
- >       Container explicit-route-objects-always renamed as
- >       explicit-route-objects.";
+ >       This revision adds the following new groupings:
+ >       - encoding-and-switching-type;
+ >       - te-generic-node-id.
+ >
+ >       This revision updates the following identities:
+ >       - objective-function-type;
+ >       - action-exercise;
+ >       - path-metric-type;
+ >       - path-metric-te;
+ >       - path-metric-igp;
+ >       - path-metric-hop;
+ >       - path-metric-delay-average;
+ >       - path-metric-delay-minimum;
+ >       - path-metric-residual-bandwidth;
+ >       - path-metric-optimize-includes;
+ >       - path-metric-optimize-excludes;
+ >       - te-optimization-criterion.
+ >
+ >       This revision updates the following data types:
+ >       - te-node-id.
+ >
+ >       This revision updates the following groupings:
+ >       - explicit-route-hop:
+ >         - adds the following leaves:
+ >           - node-id-uri;
+ >           - link-tp-id-uri;
+ >         - updates the following leaves:
+ >           - node-id;
+ >           - link-tp-id;
+ >       - record-route-state:
+ >         - adds the following leaves:
+ >           - node-id-uri;
+ >           - link-tp-id-uri;
+ >         - updates the following leaves:
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 137]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ >           - node-id;
+ >           - link-tp-id;
+ >       - optimization-metric-entry:
+ >         - updates the following leaves:
+ >           - metric-type;
+ >       - tunnel-constraints;
+ >         - adds the following leaves:
+ >           - network-id;
+ >       - path-constraints-route-objects:
+ >         - updates the following containers:
+ >           - explicit-route-objects-always;
+ >       - generic-path-metric-bounds:
+ >         - updates the following leaves:
+ >           - metric-type;
+ >       - generic-path-optimization
+ >         - adds the following leaves:
+ >           - tiebreaker;
+ >         - deprecate the following containers:
+ >           - tiebreakers.
+ >
+ >       This revision obsoletes the following identities:
+ >       - of-minimize-agg-bandwidth-consumption;
+ >       - of-minimize-load-most-loaded-link;
+ >       - of-minimize-cost-path-set;
+ >       - lsp-protection-reroute-extra;
+ >       - lsp-protection-reroute.
+ >
+ >       This revision provides also few editorial changes.";
  >     reference
  >       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
  >   }
  >   // RFC Editor: replace XXXX with actual RFC number, update date
  >   // information and remove this note
- 351a399,401
+ 70c168
+ <       "Latest revision of TE types.";
+ ---
+ >       "Initial Version of TE types.";
+ 86a185
+ >
+ 92a192
+ >
+ 93a194
+ >
+ 111a213
+ >
+ 155a258
+ >
+ 158a262
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 138]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ >
+ 263a368
+ >
+ 264a370
+ >
+ 269a376
+ >
+ 351a459,461
  >   // CHANGE NOTE: The typedef te-node-id below has been
  >   // updated in this module revision
  >   // RFC Editor: remove the note above and this note
- 353c403,406
+ 353c463,466
  <     type yang:dotted-quad;
  ---
  >     type union {
  >       type yang:dotted-quad;
  >       type inet:ipv6-address-no-zone;
  >     }
- 357,358c410,414
+ 357,358c470,474
  <        The identifier is represented as 4 octets in dotted-quad
  <        notation.
  ---
@@ -7096,7 +7757,7 @@ Internet-Draft            TE Common YANG Types              January 2024
  >        dotted-quad notation or 16 octets in full, mixed, shortened,
  >        or shortened-mixed IPv6 address notation.
  >
- 362,363c418,421
+ 362,363c478,481
  <        Router ID TLV described in Section 4.3 of RFC 5305, or the
  <        TE Router ID TLV described in Section 3.2.1 of RFC 6119.
  ---
@@ -7104,23 +7765,27 @@ Internet-Draft            TE Common YANG Types              January 2024
  >        Router ID TLV described in Section 3.2.1 of RFC 6119, or the
  >        IPv6 TE Router ID TLV described in Section 4.1 of RFC 6119.
  >
- 368a427
+ 368a487
  >
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 127]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
- 370a430
+ 370a490
  >
- 371a432
+ 371a492
  >
- 545a607,647
+ 519a641
+ >
+ 537a660
+ >
+ 545a669,709
  >   // CHANGE NOTE: The typedef path-type below has been
  >   // added in this module revision
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 139]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
  >   // RFC Editor: remove the note above and this note
  >   typedef path-type {
  >     type enumeration {
@@ -7160,16 +7825,8 @@ Internet-Draft            TE Common YANG Types              January 2024
  >       "Generic type that identifies a node in a TE topology.";
  >   }
  >
- 606a709,716
+ 606a771,778
  >   // CHANGE NOTE: The base identity lsp-provisioning-error-reason
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 128]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
  >   // has been added in this module revision
  >   // RFC Editor: remove the note above and this note
  >   identity lsp-provisioning-error-reason {
@@ -7177,7 +7834,15 @@ Internet-Draft            TE Common YANG Types              January 2024
  >       "Base identity for LSP provisioning errors.";
  >   }
  >
- 982a1093,1110
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 140]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ 982a1155,1172
  >   // CHANGE NOTE: The identity association-type-diversity below has
  >   // been added in this module revision
  >   // RFC Editor: remove the note above and this note
@@ -7187,7 +7852,7 @@ Internet-Draft            TE Common YANG Types              January 2024
  >       "Association Type diversity used to associate LSPs whose
  >       paths are to be diverse from each other.";
  >     reference
- >       "RFC8800: Path Computation Element Communication Protocol
+ >       "RFC 8800: Path Computation Element Communication Protocol
  >       (PCEP) Extension for Label Switched Path (LSP) Diversity
  >       Constraint Signaling";
  >   }
@@ -7196,53 +7861,108 @@ Internet-Draft            TE Common YANG Types              January 2024
  >   // objective-function-type has been updated
  >   // in this module revision
  >   // RFC Editor: remove the note above and this note
- 985c1113
+ 985c1175
  <       "Base objective function type.";
  ---
- >       "Base identity for path objective function type.";
- 1015a1144,1146
+ >       "Base identity for path objective function types.";
+ 1015a1206,1208
  >   // CHANGE NOTE: The identity of-minimize-agg-bandwidth-consumption
  >   // below has been obsoleted in this module revision
  >   // RFC Editor: remove the note above and this note
- 1017a1149
+ 1017a1211
  >     status obsolete;
- 1020c1152
+ 1020c1214,1218
  <        consumption.";
  ---
- >       consumption.";
- 1023c1155
+ >       consumption.
+ >
+ >       This identity has been obsoleted: the
+ >       'svec-of-minimize-agg-bandwidth-consumption' identity SHOULD
+ >       be used instead.";
+ 1023c1221
  <        Computation Element Communication Protocol (PCEP)";
  ---
  >       Computation Element Communication Protocol (PCEP)";
- 1025a1158,1160
+ 1025a1224,1226
  >   // CHANGE NOTE: The identity of-minimize-load-most-loaded-link
  >   // below has been obsoleted in this module revision
  >   // RFC Editor: remove the note above and this note
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 129]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
- 1027a1163
+ 1027a1229
  >     status obsolete;
- 1030c1166
+ 1030c1232,1236
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 141]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
  <        is carrying the highest load.";
  ---
- >       is carrying the highest load.";
- 1033c1169
+ >       is carrying the highest load.
+ >
+ >       This identity has been obsoleted: the
+ >       'svec-of-minimize-load-most-loaded-link' identity SHOULD
+ >       be used instead.";
+ 1033c1239
  <        Computation Element Communication Protocol (PCEP)";
  ---
  >       Computation Element Communication Protocol (PCEP)";
- 1035a1172,1174
+ 1035a1242,1244
  >   // CHANGE NOTE: The identity of-minimize-cost-path-set
  >   // below has been obsoleted in this module revision
  >   // RFC Editor: remove the note above and this note
- 1037a1177
+ 1037a1247
  >     status obsolete;
- 1216a1357,1368
+ 1039c1249,1253
+ <       "Objective function for minimizing the cost on a path set.";
+ ---
+ >       "Objective function for minimizing the cost on a path set.
+ >
+ >       This identity has been obsoleted: the
+ >       'svec-of-minimize-cost-path-set' identity SHOULD
+ >       be used instead.";
+ 1049a1264,1266
+ >   // CHANGE NOTE: The reference of the identity path-locally-computed
+ >   // below has been updated in this module revision
+ >   // RFC Editor: remove the note above and this note
+ 1056,1057c1273,1274
+ <       "RFC 3272: Overview and Principles of Internet Traffic
+ <        Engineering, Section 5.4";
+ ---
+ >       "RFC 9522: Overview and Principles of Internet Traffic
+ >       Engineering, Section 4.4";
+ 1059a1277,1280
+ >   // CHANGE NOTE: The reference of the identity
+ >   // path-externally-queried below has been updated
+ >   // in this module revision
+ >   // RFC Editor: remove the note above and this note
+ 1071c1292
+ <       "RFC 3272: Overview and Principles of Internet Traffic
+ ---
+ >       "RFC 9522: Overview and Principles of Internet Traffic
+ 1072a1294
+ >
+ 1076a1299,1302
+ >   // CHANGE NOTE: The reference of the identity
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 142]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ >   // path-explicitly-defined below has been updated
+ >   // in this module revision
+ >   // RFC Editor: remove the note above and this note
+ 1085c1311,1312
+ <        RFC 3272: Overview and Principles of Internet Traffic
+ ---
+ >
+ >        RFC 9522: Overview and Principles of Internet Traffic
+ 1216a1444,1455
  >   // CHANGE NOTE: The identity tunnel-admin-state-auto below
  >   // has been added in this module revision
  >   // RFC Editor: remove the note above and this note
@@ -7255,7 +7975,7 @@ Internet-Draft            TE Common YANG Types              January 2024
  >       when it is not used by the client layer.";
  >   }
  >
- 1321a1474,1482
+ 1321a1561,1569
  >     // CHANGE NOTE: The identity lsp-restoration-restore-none
  >     // below has been added in this module revision
  >     // RFC Editor: remove the note above and this note
@@ -7265,7 +7985,7 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         "No LSP affected by a failure is restored.";
  >     }
  >
- 1339a1501,1515
+ 1339a1588,1602
  >     // CHANGE NOTE: The identity restoration-scheme-rerouting
  >     // below has been added in this module revision
  >     // RFC Editor: remove the note above and this note
@@ -7274,14 +7994,6 @@ Internet-Draft            TE Common YANG Types              January 2024
  >       description
  >         "Restoration LSP is computed after the failure detection.
  >
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 130]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
  >         This restoration scheme is also known as
  >         'Full LSP Re-routing.'";
  >       reference
@@ -7289,13 +8001,21 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         for Generalized Multi-Protocol Label Switching (GMPLS)";
  >     }
  >
- 1383a1560,1562
+ 1383a1647,1649
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 143]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
  >   // CHANGE NOTE: The identity lsp-protection-reroute-extra
  >   // below has been obsoleted in this module revision
  >   // RFC Editor: remove the note above and this note
- 1385a1565
+ 1385a1652
  >     status obsolete;
- 1387c1567,1571
+ 1387c1654,1658
  <       "'(Full) Rerouting' LSP protection type.";
  ---
  >       "'(Full) Rerouting' LSP protection type.
@@ -7303,13 +8023,13 @@ Internet-Draft            TE Common YANG Types              January 2024
  >       This identity has been obsoleted: the
  >       'restoration-scheme-rerouting' identity SHOULD be used
  >       instead.";
- 1392a1577,1579
+ 1392a1664,1666
  >   // CHANGE NOTE: The identity lsp-protection-reroute
  >   // below has been obsoleted in this module revision
  >   // RFC Editor: remove the note above and this note
- 1394a1582
+ 1394a1669
  >     status obsolete;
- 1396c1584,1588
+ 1396c1671,1675
  <       "'Rerouting without Extra-Traffic' LSP protection type.";
  ---
  >       "'Rerouting without Extra-Traffic' LSP protection type.
@@ -7317,54 +8037,383 @@ Internet-Draft            TE Common YANG Types              January 2024
  >       This identity has been obsoleted: the
  >       'restoration-scheme-rerouting' identity SHOULD be used
  >       instead.";
- 1628a1821,1824
+ 1628a1908,1911
  >   // CHANGE NOTE: The description and reference of the
  >   // identity action-exercise have been updated in this module
  >   // revision
  >   // RFC Editor: remove the note above and this note
- 1632,1633c1828,1830
+ 1632,1633c1915,1917
  <       "An action that starts testing whether or not APS communication
  <        is operating correctly.  It is of lower priority than any
  ---
  >       "An action that starts testing whether or not Automatic
  >        Protection Switching (APS) communication is operating
  >        correctly.  It is of lower priority than any
- 1636,1637c1833,1834
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 131]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
+ 1636,1637c1920,1921
  <       "RFC 4427: Recovery (Protection and Restoration) Terminology
  <        for Generalized Multi-Protocol Label Switching (GMPLS)";
  ---
  >       "ITU-T G.808.1 v4.0 (05/2014): Generic protection switching -
  >       Linear trail and subnetwork protection";
- 1916a2114,2116
- >   // CHANGE NOTE: The description of the identity path-metric-type
- >   // has been updated in this module revision
- >   // RFC Editor: remove the note above and this note
- 1919c2119,2122
- <       "Base identity for the path metric type.";
+ 1917c2201,2204
+ <   identity path-metric-type {
  ---
- >       "Base identity for the path metric type.
- >
- >       Derived identities SHOULD describe the unit and maximum value
- >       of the path metric types they define.";
- 1939a2143,2145
- >   // CHANGE NOTE: The reference for the identity path-metric-hop
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 144]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ >   // CHANGE NOTE: The path-metric-optimization-type base identity
  >   // has been added in this module revision
  >   // RFC Editor: remove the note above and this note
- 1943a2150,2152
- >     reference
- >       "RFC5440: Path Computation Element (PCE) Communication
- >       Protocol (PCEP)";
- 1945a2155
+ >   identity path-metric-optimization-type {
+ 1919c2206,2207
+ <       "Base identity for the path metric type.";
+ ---
+ >       "Base identity used to define the path metric optimization
+ >       types.";
+ 1922,1923c2210,2213
+ <   identity path-metric-te {
+ <     base path-metric-type;
+ ---
+ >   // CHANGE NOTE: The link-path-metric-type base identity
+ >   // has been added in this module revision
+ >   // RFC Editor: remove the note above and this note
+ >   identity link-path-metric-type {
+ 1925,1928c2215,2221
+ <       "TE path metric.";
+ <     reference
+ <       "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+ <        second MPLS Traffic Engineering (TE) Metric";
+ ---
+ >       "Base identity used to define the link and the path metric
+ >       types.
  >
- 2110a2321,2724
+ >       The unit of the path metric value is interpreted in the
+ >       context of the path metric type and the derived identities
+ >       SHOULD describe the unit of the path metric types they
+ >       define.";
+ 1931,1938c2224,2232
+ <   identity path-metric-igp {
+ <     base path-metric-type;
+ <     description
+ <       "IGP path metric.";
+ <     reference
+ <       "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+ <        second MPLS Traffic Engineering (TE) Metric";
+ <   }
+ ---
+ >     // CHANGE NOTE: The link-metric-type base identity
+ >     // and its derived identities
+ >     // have been added in this module revision
+ >     // RFC Editor: remove the note above and this note
+ >     identity link-metric-type {
+ >       base link-path-metric-type;
+ >       description
+ >         "Base identity for the link metric types.";
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 145]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ >     }
+ 1940,1944c2234,2240
+ <   identity path-metric-hop {
+ <     base path-metric-type;
+ <     description
+ <       "Hop path metric.";
+ <   }
+ ---
+ >       identity link-metric-te {
+ >         base link-metric-type;
+ >         description
+ >           "Traffic Engineering (TE) Link Metric.";
+ >         reference
+ >           "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+ >           Version 2, section 2.5.5
+ 1946,1952c2242,2244
+ <   identity path-metric-delay-average {
+ <     base path-metric-type;
+ <     description
+ <       "Average unidirectional link delay.";
+ <     reference
+ <       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+ <   }
+ ---
+ >           RFC 5305: IS-IS Extensions for Traffic Engineering,
+ >           section 3.7";
+ >       }
+ 1954,1960c2246,2253
+ <   identity path-metric-delay-minimum {
+ <     base path-metric-type;
+ <     description
+ <       "Minimum unidirectional link delay.";
+ <     reference
+ <       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+ <   }
+ ---
+ >       identity link-metric-igp {
+ >         base link-metric-type;
+ >         description
+ >           "Interior Gateway Protocol (IGP) Link Metric.";
+ >         reference
+ >           "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric
+ >           as a second MPLS Traffic Engineering (TE) Metric";
+ >       }
+ 1962,1972c2255,2266
+ <   identity path-metric-residual-bandwidth {
+ <     base path-metric-type;
+ <     description
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 146]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ <       "Unidirectional Residual Bandwidth, which is defined to be
+ <        Maximum Bandwidth (RFC 3630) minus the bandwidth currently
+ <        allocated to LSPs.";
+ <     reference
+ <       "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+ <        Version 2
+ <        RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+ <   }
+ ---
+ >       identity link-metric-delay-average {
+ >         base link-metric-type;
+ >         description
+ >           "Unidirectional Link Delay, measured in units of
+ >           microseconds.";
+ >         reference
+ >           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+ >           Extensions, section 4.1
+ >
+ >           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+ >           Extensions, section 4.1";
+ >       }
+ 1974,1979c2268,2279
+ <   identity path-metric-optimize-includes {
+ <     base path-metric-type;
+ <     description
+ <       "A metric that optimizes the number of included resources
+ <        specified in a set.";
+ <   }
+ ---
+ >       identity link-metric-delay-minimum {
+ >         base link-metric-type;
+ >         description
+ >           "Minimum unidirectional Link Delay, measured in units of
+ >           microseconds.";
+ >         reference
+ >           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+ >           Extensions, section 4.2
+ >
+ >           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+ >           Extensions, section 4.2";
+ >       }
+ 1981,1986c2281,2425
+ <   identity path-metric-optimize-excludes {
+ <     base path-metric-type;
+ <     description
+ <       "A metric that optimizes to a maximum the number of excluded
+ <        resources specified in a set.";
+ <   }
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 147]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ ---
+ >       identity link-metric-delay-maximum {
+ >         base link-metric-type;
+ >         description
+ >           "Maximum unidirectional Link Delay, measured in units of
+ >           microseconds.";
+ >         reference
+ >           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+ >           Extensions, section 4.2
+ >
+ >           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+ >           Extensions, section 4.2";
+ >       }
+ >
+ >       identity link-metric-residual-bandwidth {
+ >         base link-metric-type;
+ >         description
+ >           "Unidirectional Residual Bandwidth, measured in units of
+ >           bytes per second.
+ >
+ >           It is defined to be Maximum Bandwidth minus the bandwidth
+ >           currently allocated to LSPs.";
+ >         reference
+ >           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+ >           Extensions, section 4.5
+ >
+ >           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+ >           Extensions, section 4.5";
+ >       }
+ >
+ >     // CHANGE NOTE: The base and the description of the
+ >     // path-metric-type identity
+ >     // has been updated in this module revision
+ >     // RFC Editor: remove the note above and this note
+ >     identity path-metric-type {
+ >       base link-path-metric-type;
+ >       base path-metric-optimization-type;
+ >       description
+ >         "Base identity for the path metric types.";
+ >     }
+ >
+ >       // CHANGE NOTE: The description and the reference of the
+ >       // path-metric-te identity have been updated
+ >       // in this module revision
+ >       // RFC Editor: remove the note above and this note
+ >       identity path-metric-te {
+ >         base path-metric-type;
+ >         description
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 148]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ >           "Traffic Engineering (TE) Path Metric.";
+ >         reference
+ >           "RFC 5440: Path Computation Element (PCE) Communication
+ >           Protocol (PCEP), section 7.8";
+ >       }
+ >
+ >       // CHANGE NOTE: The description and the reference of the
+ >       // path-metric-igp identity have been updated
+ >       // in this module revision
+ >       // RFC Editor: remove the note above and this note
+ >       identity path-metric-igp {
+ >         base path-metric-type;
+ >         description
+ >           "Interior Gateway Protocol (IGP) Path Metric.";
+ >         reference
+ >           "RFC 5440: Path Computation Element (PCE) Communication
+ >           Protocol (PCEP), section 7.8";
+ >       }
+ >
+ >       // CHANGE NOTE: The description and the reference of the
+ >       // path-metric-hop identity have been updated
+ >       // in this module revision
+ >       // RFC Editor: remove the note above and this note
+ >       identity path-metric-hop {
+ >         base path-metric-type;
+ >         description
+ >           "Hop Count Path Metric.";
+ >         reference
+ >           "RFC 5440: Path Computation Element (PCE) Communication
+ >           Protocol (PCEP), section 7.8";
+ >       }
+ >
+ >       // CHANGE NOTE: The description and the reference of the
+ >       // path-metric-delay-average identity have been updated
+ >       // in this module revision
+ >       // RFC Editor: remove the note above and this note
+ >       identity path-metric-delay-average {
+ >         base path-metric-type;
+ >         description
+ >           "The Path Delay Metric, measured in units of
+ >           microseconds.";
+ >         reference
+ >           "RFC8233: Extensions to the Path Computation Element
+ >           Communication Protocol (PCEP) to Compute Service-Aware
+ >           Label Switched Paths (LSPs), section 3.1.1";
+ >       }
+ >
+ >       // CHANGE NOTE: The description and the reference of the
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 149]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ >       // path-metric-delay-minimum identity have been updated
+ >       // in this module revision
+ >       // RFC Editor: remove the note above and this note
+ >       identity path-metric-delay-minimum {
+ >         base path-metric-type;
+ >         description
+ >           "The Path Min Delay Metric, measured in units of
+ >           microseconds.";
+ >         reference
+ >           "I-D.ietf-pce-sid-algo: Carrying SR-Algorithm information
+ >           in PCE-based Networks, section 3.5.1";
+ >       }
+ >
+ >       // CHANGE NOTE: The description and the reference of the
+ >       // path-metric-residual-bandwidth identity have been updated
+ >       // in this module revision
+ >       // RFC Editor: remove the note above and this note
+ >       identity path-metric-residual-bandwidth {
+ >         base path-metric-type;
+ >         description
+ >           "The Path Residual Bandwidth, defined as the minimum Link
+ >           Residual Bandwidth all the links along the path.
+ >
+ >           The Path Residual Bandwidth can be seen as the path
+ >           metric associated with the Maximum residual Bandwidth Path
+ >           (MBP) objective function.";
+ >         reference
+ >           "RFC 5541: Encoding of Objective Functions in the Path
+ >           Computation Element Communication Protocol (PCEP)";
+ >       }
+ >
+ >     // CHANGE NOTE: The base of the path-metric-optimize-includes
+ >     // identity has been updated in this module revision
+ >     // RFC Editor: remove the note above and this note
+ >     identity path-metric-optimize-includes {
+ >       base path-metric-optimization-type;
+ >       description
+ >         "A metric that optimizes the number of included resources
+ >         specified in a set.";
+ >     }
+ >
+ >     // CHANGE NOTE: The base of the path-metric-optimize-excludes
+ >     // identity has been updated in this module revision
+ >     // RFC Editor: remove the note above and this note
+ >     identity path-metric-optimize-excludes {
+ >       base path-metric-optimization-type;
+ >       description
+ >         "A metric that optimizes to a maximum the number of excluded
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 150]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ >         resources specified in a set.";
+ >     }
+ 2049a2489,2492
+ >   // CHANGE NOTE: The reference of the identity
+ >   // te-optimization-criterion below has been updated
+ >   // in this module revision
+ >   // RFC Editor: remove the note above and this note
+ 2054c2497
+ <       "RFC 3272: Overview and Principles of Internet Traffic
+ ---
+ >       "RFC 9522: Overview and Principles of Internet Traffic
+ 2110a2554,2994
  >   // CHANGE NOTE: The base identity path-computation-error-reason
  >   // and its derived identities below have been
  >   // added in this module revision
@@ -7380,20 +8429,12 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         "Path computation has failed because of an unspecified
  >         reason.";
  >       reference
- >         "Section 7.5 of RFC5440: Path Computation Element (PCE)
- >         Communication Protocol (PCEP)";
+ >         "RFC 5440: Path Computation Element (PCE) Communication
+ >         Protocol (PCEP), section 7.5";
  >     }
  >
  >     identity path-computation-error-no-topology {
  >       base path-computation-error-reason;
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 132]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
  >       description
  >         "Path computation has failed because there is no topology
  >         with the provided topology-identifier.";
@@ -7409,7 +8450,21 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         a Backward-Recursive Path Computation (BRPC) downstream
  >         PCE or a child PCE.";
  >       reference
- >         "RFC5441, RFC8685";
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 151]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ >         "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+ >         Procedure to Compute Shortest Constrained Inter-Domain
+ >         Traffic Engineering Label Switched Paths
+ >
+ >         RFC 8685: Path Computation Element Communication Protocol
+ >         (PCEP) Extensions for the Hierarchical Path Computation
+ >         Element (H-PCE) Architecture";
  >     }
  >
  >     identity path-computation-error-pce-unavailable {
@@ -7420,10 +8475,11 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         It corresponds to bit 31 of the Flags field of the
  >         NO-PATH-VECTOR TLV.";
  >       reference
- >         "RFC5440: Path Computation Element (PCE) Communication
- >         Protocol (PCEP);
+ >         "RFC 5440: Path Computation Element (PCE) Communication
+ >         Protocol (PCEP)
  >
- >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+ >         https://www.iana.org/assignments/pcep
+ >         /pcep.xhtml#no-path-vector-tlv";
  >     }
  >
  >     identity path-computation-error-no-inclusion-hop {
@@ -7442,19 +8498,22 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         It corresponds to bit 19 of the Flags field of the
  >         NO-PATH-VECTOR TLV.";
  >       reference
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 133]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
- >         "RFC8685;
+ >         "RFC 8685: Path Computation Element Communication Protocol
+ >         (PCEP) Extensions for the Hierarchical Path Computation
+ >         Element (H-PCE) Architecture
  >
- >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+ >         https://www.iana.org/assignments/pcep
+ >         /pcep.xhtml#no-path-vector-tlv";
  >     }
  >
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 152]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
  >     identity path-computation-error-no-resource {
  >       base path-computation-error-reason;
  >       description
@@ -7464,9 +8523,12 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         It corresponds to bit 20 of the Flags field of the
  >         NO-PATH-VECTOR TLV.";
  >       reference
- >         "RFC8685;
+ >         "RFC 8685: Path Computation Element Communication Protocol
+ >         (PCEP) Extensions for the Hierarchical Path Computation
+ >         Element (H-PCE) Architecture
  >
- >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+ >         https://www.iana.org/assignments/pcep
+ >         /pcep.xhtml#no-path-vector-tlv";
  >     }
  >
  >     identity path-computation-error-child-pce-unresponsive {
@@ -7478,9 +8540,12 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         It corresponds to bit 21 of the Flags field of the
  >         NO-PATH-VECTOR TLV.";
  >       reference
- >         "RFC8685;
+ >         "RFC 8685: Path Computation Element Communication Protocol
+ >         (PCEP) Extensions for the Hierarchical Path Computation
+ >         Element (H-PCE) Architecture
  >
- >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+ >         https://www.iana.org/assignments/pcep
+ >         /pcep.xhtml#no-path-vector-tlv";
  >     }
  >
  >     identity path-computation-error-destination-domain-unknown {
@@ -7492,20 +8557,23 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         It corresponds to bit 22 of the Flags field of the
  >         NO-PATH-VECTOR TLV.";
  >       reference
- >         "RFC8685;
+ >         "RFC 8685: Path Computation Element Communication Protocol
+ >         (PCEP) Extensions for the Hierarchical Path Computation
+ >         Element (H-PCE) Architecture
  >
- >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+ >         https://www.iana.org/assignments/pcep
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 153]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ >         /pcep.xhtml#no-path-vector-tlv";
  >     }
  >
  >     identity path-computation-error-p2mp {
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 134]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
  >       base path-computation-error-reason;
  >       description
  >         "Path computation has failed because of P2MP reachability
@@ -7514,9 +8582,12 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         It corresponds to bit 24 of the Flags field of the
  >         NO-PATH-VECTOR TLV.";
  >       reference
- >         "RFC8306;
+ >         "RFC 8306: Extensions to the Path Computation Element
+ >         Communication Protocol (PCEP) for Point-to-Multipoint
+ >         Traffic Engineering Label Switched Paths
  >
- >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+ >         https://www.iana.org/assignments/pcep
+ >         /pcep.xhtml#no-path-vector-tlv";
  >     }
  >
  >     identity path-computation-error-no-gco-migration {
@@ -7528,9 +8599,12 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         It corresponds to bit 26 of the Flags field of the
  >         NO-PATH-VECTOR TLV.";
  >       reference
- >         "RFC5557;
+ >         "RFC 5557: Path Computation Element Communication Protocol
+ >         (PCEP) Requirements and Protocol Extensions in Support of
+ >         Global Concurrent Optimization
  >
- >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+ >         https://www.iana.org/assignments/pcep
+ >         /pcep.xhtml#no-path-vector-tlv";
  >     }
  >
  >     identity path-computation-error-no-gco-solution {
@@ -7542,9 +8616,20 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         It corresponds to bit 25 of the Flags field of the
  >         NO-PATH-VECTOR TLV.";
  >       reference
- >         "RFC5557;
+ >         "RFC 5557: Path Computation Element Communication Protocol
+ >         (PCEP) Requirements and Protocol Extensions in Support of
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 154]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ >         Global Concurrent Optimization
  >
- >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+ >         https://www.iana.org/assignments/pcep
+ >         /pcep.xhtml#no-path-vector-tlv";
  >     }
  >
  >     identity path-computation-error-pks-expansion {
@@ -7554,19 +8639,14 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         (PKS)  expansion failure.
  >
  >         It corresponds to bit 27 of the Flags field of the
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 135]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
  >         NO-PATH-VECTOR TLV.";
  >       reference
- >         "RFC5520;
+ >         "RFC 5520: Preserving Topology Confidentiality in
+ >         Inter-Domain Path Computation Using a Path-Key-Based
+ >         Mechanism
  >
- >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+ >         https://www.iana.org/assignments/pcep
+ >         /pcep.xhtml#no-path-vector-tlv";
  >     }
  >
  >     identity path-computation-error-brpc-chain-unavailable {
@@ -7578,9 +8658,12 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         It corresponds to bit 28 of the Flags field of the
  >         NO-PATH-VECTOR TLV.";
  >       reference
- >         "RFC5441;
+ >         "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+ >         Procedure to Compute Shortest Constrained Inter-Domain
+ >         Traffic Engineering Label Switched Paths
  >
- >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+ >         https://www.iana.org/assignments/pcep
+ >         /pcep.xhtml#no-path-vector-tlv";
  >     }
  >
  >     identity path-computation-error-source-unknown {
@@ -7591,11 +8674,20 @@ Internet-Draft            TE Common YANG Types              January 2024
  >
  >         It corresponds to bit 29 of the Flags field of the
  >         NO-PATH-VECTOR TLV.";
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 155]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
  >       reference
- >         "RFC5440: Path Computation Element (PCE) Communication
+ >         "RFC 5440: Path Computation Element (PCE) Communication
  >         Protocol (PCEP);
  >
- >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+ >         https://www.iana.org/assignments/pcep
+ >         /pcep.xhtml#no-path-vector-tlv";
  >     }
  >
  >     identity path-computation-error-destination-unknown {
@@ -7607,18 +8699,11 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         It corresponds to bit 30 of the Flags field of the
  >         NO-PATH-VECTOR TLV.";
  >       reference
- >         "RFC5440: Path Computation Element (PCE) Communication
+ >         "RFC 5440: Path Computation Element (PCE) Communication
  >         Protocol (PCEP);
  >
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 136]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
- >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+ >         https://www.iana.org/assignments/pcep
+ >         /pcep.xhtml#no-path-vector-tlv";
  >     }
  >
  >     identity path-computation-error-no-server {
@@ -7627,10 +8712,11 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         "Path computation has failed because path computation
  >         server is unavailable.";
  >       reference
- >         "RFC5440: Path Computation Element (PCE) Communication
+ >         "RFC 5440: Path Computation Element (PCE) Communication
  >         Protocol (PCEP);
  >
- >         https://www.iana.org/assignments/pcep/pcep.xhtml";
+ >         https://www.iana.org/assignments/pcep
+ >         /pcep.xhtml#no-path-vector-tlv";
  >     }
  >
  >   // CHANGE NOTE: The base identity protocol-origin-type and
@@ -7644,6 +8730,14 @@ Internet-Draft            TE Common YANG Types              January 2024
  >
  >     identity protocol-origin-api {
  >       base protocol-origin-type;
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 156]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
  >       description
  >         "Protocol origin is via Application Programmable Interface
  >         (API).";
@@ -7655,7 +8749,7 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         "Protocol origin is Path Computation Engine Protocol
  >         (PCEP).";
  >       reference
- >         "RFC5440: Path Computation Element (PCE) Communication
+ >         "RFC 5440: Path Computation Element (PCE) Communication
  >         Protocol (PCEP)";
  >     }
  >
@@ -7663,17 +8757,9 @@ Internet-Draft            TE Common YANG Types              January 2024
  >       base protocol-origin-type;
  >       description
  >         "Protocol origin is Border Gateway Protocol (BGP).";
- >       reference "RFC9012";
+ >       reference "RFC 9012";
  >     }
  >
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 137]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
  >   // CHANGE NOTE: The base identity svec-objective-function-type
  >   // and its derived identities below have been
  >   // added in this module revision
@@ -7682,8 +8768,8 @@ Internet-Draft            TE Common YANG Types              January 2024
  >     description
  >       "Base identity for SVEC objective function type.";
  >     reference
- >       "RFC5541: Encoding of Objective Functions in the Path
- >        Computation Element Communication Protocol (PCEP).";
+ >       "RFC 5541: Encoding of Objective Functions in the Path
+ >        Computation Element Communication Protocol (PCEP)";
  >   }
  >
  >     identity svec-of-minimize-agg-bandwidth-consumption {
@@ -7692,18 +8778,26 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         "Objective function for minimizing aggregate bandwidth
  >         consumption (MBC).";
  >       reference
- >         "RFC5541: Encoding of Objective Functions in the Path
- >         Computation Element Communication Protocol (PCEP).";
+ >         "RFC 5541: Encoding of Objective Functions in the Path
+ >         Computation Element Communication Protocol (PCEP)";
  >     }
  >
  >     identity svec-of-minimize-load-most-loaded-link {
  >       base svec-objective-function-type;
  >       description
  >         "Objective function for minimizing the load on the link that
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 157]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
  >         is carrying the highest load (MLL).";
  >       reference
- >         "RFC5541: Encoding of Objective Functions in the Path
- >         Computation Element Communication Protocol (PCEP).";
+ >         "RFC 5541: Encoding of Objective Functions in the Path
+ >         Computation Element Communication Protocol (PCEP)";
  >     }
  >
  >     identity svec-of-minimize-cost-path-set {
@@ -7712,8 +8806,8 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         "Objective function for minimizing the cost on a path set
  >         (MCC).";
  >       reference
- >         "RFC5541: Encoding of Objective Functions in the Path
- >         Computation Element Communication Protocol (PCEP).";
+ >         "RFC 5541: Encoding of Objective Functions in the Path
+ >         Computation Element Communication Protocol (PCEP)";
  >     }
  >
  >     identity svec-of-minimize-common-transit-domain {
@@ -7722,17 +8816,9 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         "Objective function for minimizing the number of common
  >         transit domains (MCTD).";
  >       reference
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 138]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
- >         "RFC8685: Path Computation Element Communication Protocol
+ >         "RFC 8685: Path Computation Element Communication Protocol
  >         (PCEP) Extensions for the Hierarchical Path Computation
- >         Element (H-PCE) Architecture.";
+ >         Element (H-PCE) Architecture";
  >     }
  >
  >     identity svec-of-minimize-shared-link {
@@ -7741,7 +8827,7 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         "Objective function for minimizing the number of shared
  >         links (MSL).";
  >       reference
- >         "RFC8685: Path Computation Element Communication Protocol
+ >         "RFC 8685: Path Computation Element Communication Protocol
  >         (PCEP) Extensions for the Hierarchical Path Computation
  >         Element (H-PCE) Architecture.";
  >     }
@@ -7752,10 +8838,18 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         "Objective function for minimizing the number of shared
  >         Shared Risk Link Groups (SRLG) (MSS).";
  >       reference
- >         "RFC8685: Path Computation Element Communication Protocol
+ >         "RFC 8685: Path Computation Element Communication Protocol
  >         (PCEP) Extensions for the Hierarchical Path Computation
  >         Element (H-PCE) Architecture.";
  >     }
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 158]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
  >
  >     identity svec-of-minimize-shared-nodes {
  >       base svec-objective-function-type;
@@ -7763,7 +8857,7 @@ Internet-Draft            TE Common YANG Types              January 2024
  >         "Objective function for minimizing the number of shared
  >         nodes (MSN).";
  >       reference
- >         "RFC8685: Path Computation Element Communication Protocol
+ >         "RFC 8685: Path Computation Element Communication Protocol
  >         (PCEP) Extensions for the Hierarchical Path Computation
  >         Element (H-PCE) Architecture.";
  >     }
@@ -7776,43 +8870,43 @@ Internet-Draft            TE Common YANG Types              January 2024
  >     description
  >       "Base identity for SVEC metric type.";
  >     reference
- >       "RFC5541: Encoding of Objective Functions in the Path
- >        Computation Element Communication Protocol (PCEP).";
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 139]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
+ >       "RFC 5541: Encoding of Objective Functions in the Path
+ >        Computation Element Communication Protocol (PCEP)";
  >   }
  >
- >     identity svec-metric-cumul-te {
+ >     identity svec-metric-cumulative-te {
  >       base svec-metric-type;
  >       description
  >         "Cumulative TE cost.";
  >       reference
- >         "RFC5541: Encoding of Objective Functions in the Path
- >         Computation Element Communication Protocol (PCEP).";
+ >         "RFC 5541: Encoding of Objective Functions in the Path
+ >         Computation Element Communication Protocol (PCEP)";
  >     }
  >
- >     identity svec-metric-cumul-igp {
+ >     identity svec-metric-cumulative-igp {
  >       base svec-metric-type;
  >       description
  >         "Cumulative IGP cost.";
  >       reference
- >         "RFC5541: Encoding of Objective Functions in the Path
- >         Computation Element Communication Protocol (PCEP).";
+ >         "RFC 5541: Encoding of Objective Functions in the Path
+ >         Computation Element Communication Protocol (PCEP)";
  >     }
  >
- >     identity svec-metric-cumul-hop {
+ >     identity svec-metric-cumulative-hop {
  >       base svec-metric-type;
  >       description
  >         "Cumulative Hop path metric.";
  >       reference
- >         "RFC5541: Encoding of Objective Functions in the Path
- >         Computation Element Communication Protocol (PCEP).";
+ >         "RFC 5541: Encoding of Objective Functions in the Path
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 159]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ >         Computation Element Communication Protocol (PCEP)";
  >     }
  >
  >     identity svec-metric-aggregate-bandwidth-consumption {
@@ -7820,8 +8914,8 @@ Internet-Draft            TE Common YANG Types              January 2024
  >       description
  >         "Aggregate bandwidth consumption.";
  >       reference
- >         "RFC5541: Encoding of Objective Functions in the Path
- >         Computation Element Communication Protocol (PCEP).";
+ >         "RFC 5541: Encoding of Objective Functions in the Path
+ >         Computation Element Communication Protocol (PCEP)";
  >     }
  >
  >     identity svec-metric-load-of-the-most-loaded-link {
@@ -7829,23 +8923,29 @@ Internet-Draft            TE Common YANG Types              January 2024
  >       description
  >         "Load of the most loaded link.";
  >       reference
- >         "RFC5541: Encoding of Objective Functions in the Path
- >         Computation Element Communication Protocol (PCEP).";
+ >         "RFC 5541: Encoding of Objective Functions in the Path
+ >         Computation Element Communication Protocol (PCEP)";
  >     }
  >
- 2506a3121,3123
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 140]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
+ 2221,2225c3105,3111
+ <       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions
+ <        RFC 7823: Performance-Based Path Selection for Explicitly
+ <        Routed Label Switched Paths (LSPs) Using TE Metric
+ <        Extensions
+ <        RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
+ ---
+ >       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensionsù
+ >
+ >       RFC 7823: Performance-Based Path Selection for Explicitly
+ >       Routed Label Switched Paths (LSPs) Using TE Metric
+ >       Extensions
+ >
+ >       RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
+ 2506a3393,3395
  >   // CHANGE NOTE: The explicit-route-hop grouping below has been
  >   // updated in this module revision
  >   // RFC Editor: remove the note above and this note
- 2514a3132,3140
+ 2514a3404,3412
  >           must "node-id-uri or node-id" {
  >             description
  >               "At least one node identifier MUST be present.";
@@ -7854,10 +8954,18 @@ Internet-Draft            TE Common YANG Types              January 2024
  >             type nw:node-id;
  >             description
  >               "The identifier of a node in the topology.";
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 160]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
  >           }
- 2517d3142
+ 2517d3414
  <             mandatory true;
- 2566a3192,3202
+ 2566a3464,3474
  >           must "(link-tp-id-uri or link-tp-id) and " +
  >                 "(node-id-uri or node-id)" {
  >             description
@@ -7869,95 +8977,166 @@ Internet-Draft            TE Common YANG Types              January 2024
  >             description
  >               "Link Termination Point (LTP) identifier.";
  >           }
- 2569d3204
+ 2569d3476
  <             mandatory true;
- 2574a3210,3214
+ 2574a3482,3486
  >           leaf node-id-uri {
  >             type nw:node-id;
  >             description
  >               "The identifier of a node in the topology.";
  >           }
- 2577d3216
+ 2577d3488
  <             mandatory true;
- 2646a3286,3289
+ 2631a3543,3545
+ >   // CHANGE NOTE: The explicit-route-hop grouping below has been
+ >   // updated in this module revision
+ >   // RFC Editor: remove the note above and this note
+ 2646a3561,3564
  >           must "node-id-uri or node-id" {
  >             description
  >               "At least one node identifier MUST be present.";
  >           }
- 2648a3292,3296
+ 2648a3567,3571
  >           leaf node-id-uri {
  >             type nw:node-id;
  >             description
  >               "The identifier of a node in the topology.";
  >           }
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 141]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
- 2651d3298
+ 2651d3573
  <             mandatory true;
- 2696a3344,3354
+ 2696a3619,3629
  >           must "(link-tp-id-uri or link-tp-id) and " +
  >               "(node-id-uri or node-id)" {
  >             description
  >               "At least one node identifier and at least one Link
  >               Termination Point (LTP) identifier MUST be present.";
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 161]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
  >           }
  >           leaf link-tp-id-uri {
  >             type nt:tp-id;
  >             description
  >               "Link Termination Point (LTP) identifier.";
  >           }
- 2699d3356
+ 2699d3631
  <             mandatory true;
- 2704a3362,3366
+ 2704a3637,3641
  >           leaf node-id-uri {
  >             type nw:node-id;
  >             description
  >               "The identifier of a node in the topology.";
  >           }
- 2968a3631,3635
+ 2881a3819,3821
+ >   // CHANGE NOTE: The grouping optimization-metric-entry below has
+ >   // been updated in this module revision
+ >   // RFC Editor: remove the note above and this note
+ 2887c3827
+ <         base path-metric-type;
+ ---
+ >         base path-metric-optimization-type;
+ 2964a3905,3907
+ >   // CHANGE NOTE: The grouping tunnel-constraints below has
+ >   // been updated in this module revision
+ >   // RFC Editor: remove the note above and this note
+ 2968a3912,3916
  >     leaf network-id {
  >       type nw:network-id;
  >       description
  >         "The network topology identifier.";
  >     }
- 2977c3644,3647
+ 2972a3921,3923
+ >   // CHANGE NOTE: The grouping path-constraints-route-objects below
+ >   // has been updated in this module revision
+ >   // RFC Editor: remove the note above and this note
+ 2977c3928
  <     container explicit-route-objects-always {
  ---
- >     // CHANGE NOTE: The explicit-route-objects container below has
- >     // been updated in this module revision
- >     // RFC Editor: remove the note above and this note
  >     container explicit-route-objects {
- 2979c3649
+ 2979c3930
  <         "Container for the 'exclude route' object list.";
  ---
  >         "Container for the explicit route object lists.";
- 3124,3126c3794,3800
+ 3101a4053,4055
+ >   // CHANGE NOTE: The grouping generic-path-metric-bounds below
+ >   // has been updated in this module revision
+ >   // RFC Editor: remove the note above and this note
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 162]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ 3107c4061
+ <         "TE path metric bounds container.";
+ ---
+ >         "Top-level container for the list of path metric bounds.";
+ 3111c4065,4073
+ <           "List of TE path metric bounds.";
+ ---
+ >           "List of path metric bounds, which can apply to link and
+ >           path metrics.
+ >
+ >           TE paths which have at least one path metric which
+ >           exceeds the specified bounds MUST NOT be selected.
+ >
+ >           TE paths that traverse TE links which have at least one
+ >           link metric which exceeds the specified bounds MUST NOT
+ >           be selected.";
+ 3114c4076
+ <             base path-metric-type;
+ ---
+ >             base link-path-metric-type;
+ 3124,3126c4086,4092
  <             "Upper bound on the end-to-end TE path metric.  A zero
  <              indicates an unbounded upper limit for the specific
  <              'metric-type'.";
  ---
- >             "Upper bound on the end-to-end TE path metric.
+ >             "Upper bound on the specified 'metric-type'.
  >
  >             A zero indicates an unbounded upper limit for the
- >             specific 'metric-type'.
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 142]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
+ >             specificied 'metric-type'.
  >
  >             The unit of is interpreted in the context of the
- >             path-metric-type.";
- 3379c4053,4112
+ >             'metric-type' identity.";
+ 3131a4098,4100
+ >   // CHANGE NOTE: The grouping generic-path-metric-bounds below
+ >   // has been updated in this module revision
+ >   // RFC Editor: remove the note above and this note
+ 3154c4123,4127
+ <               "Container for the list of tiebreakers.";
+ ---
+ >               "Container for the list of tiebreakers.
+ >
+ >               This container has been obsoleted by the tiebreaker
+ >               leaf.";
+ >             status deprecated;
+ 3189a4163,4171
+ >     leaf tiebreaker {
+ >       type identityref {
+ >         base path-tiebreaker-type;
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 163]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
+ >       }
+ >       default "te-types:path-tiebreaker-random";
+ >       description
+ >         "The tiebreaker criteria to apply on an equally favored set
+ >         of paths, in order to pick the best.";
+ >     }
+ 3379c4361,4420
  < }
  \ No newline at end of file
  ---
@@ -7976,7 +9155,7 @@ Internet-Draft            TE Common YANG Types              January 2024
  >       description
  >         "LSP encoding type.";
  >       reference
- >         "RFC3945";
+ >         "RFC 3945";
  >     }
  >     leaf switching-type {
  >       type identityref {
@@ -7985,7 +9164,7 @@ Internet-Draft            TE Common YANG Types              January 2024
  >       description
  >         "LSP switching type.";
  >       reference
- >         "RFC3945";
+ >         "RFC 3945";
  >     }
  >   }
  >
@@ -7999,17 +9178,17 @@ Internet-Draft            TE Common YANG Types              January 2024
  >       type te-gen-node-id;
  >       description
  >         "The identifier of the node. Can be represented as IP
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 164]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
  >          address or dotted quad address or as an URI.";
  >     }
  >     leaf type {
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 143]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
-
  >       type enumeration {
  >         enum ip {
  >           description
@@ -8058,293 +9237,297 @@ A.2.  Packet TE Types YANG Diffs
 
 
 
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 144]
+Busi, et al.             Expires 20 August 2024               [Page 165]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
- 11c11
- <       "RFC 8776: Common YANG Data Types for Traffic Engineering";
- ---
- >       "RFCXXXX: Common YANG Data Types for Traffic Engineering";
- 12a13,14
- >   // RFC Editor: replace XXXX with actual RFC number
- >   // and remove this note
- 22c24
- <                <mailto:tsaad@juniper.net>
- ---
- >                <mailto:tsaad.net@gmail.com>
- 37,39c39,49
- <      data type definitions specific to MPLS TE.  The model fully
- <      conforms to the Network Management Datastore Architecture
- <      (NMDA).
- ---
- >      data type definitions specific to Packet Traffic Enginnering
- >      (TE).
- >
- >      The model fully conforms to the Network Management Datastore
- >      Architecture (NMDA).
- >
- >      The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
- >      NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
- >      'MAY', and 'OPTIONAL' in this document are to be interpreted as
- >      described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
- >      they appear in all capitals, as shown here.
- 41c51
- <      Copyright (c) 2020 IETF Trust and the persons identified as
- ---
- >      Copyright (c) 2024 IETF Trust and the persons identified as
- 46c56
- <      the license terms contained in, the Simplified BSD License set
- ---
- >      the license terms contained in, the Revised BSD License set
- 51,52c61,80
- <      This version of this YANG module is part of RFC 8776; see the
- <      RFC itself for full legal notices.";
- ---
- >      This version of this YANG module is part of RFC XXXX
- >      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
- >      for full legal notices.";
- >   revision 2024-01-25 {
- >     description
- >       "Added common TE packet identities:
- >        - bandwidth-profile-type;
- >        - path-metric-loss;
- >        - path-metric-delay-variation.
+  11c11
+  <       "RFC 8776: Common YANG Data Types for Traffic Engineering";
+  ---
+  >       "RFCXXXX: Common YANG Data Types for Traffic Engineering";
+  12a13,14
+  >   // RFC Editor: replace XXXX with actual RFC number
+  >   // and remove this note
+  22c24
+  <                <mailto:tsaad@juniper.net>
+  ---
+  >                <mailto:tsaad.net@gmail.com>
+  37,39c39,49
+  <      data type definitions specific to MPLS TE.  The model fully
+  <      conforms to the Network Management Datastore Architecture
+  <      (NMDA).
+  ---
+  >      data type definitions specific to Packet Traffic Enginnering
+  >      (TE).
+  >
+  >      The model fully conforms to the Network Management Datastore
+  >      Architecture (NMDA).
+  >
+  >      The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+  >      NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+  >      'MAY', and 'OPTIONAL' in this document are to be interpreted as
+  >      described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+  >      they appear in all capitals, as shown here.
+  41c51
+  <      Copyright (c) 2020 IETF Trust and the persons identified as
+  ---
+  >      Copyright (c) 2024 IETF Trust and the persons identified as
+  46c56
+  <      the license terms contained in, the Simplified BSD License set
+  ---
+  >      the license terms contained in, the Revised BSD License set
+  51,52c61,82
+  <      This version of this YANG module is part of RFC 8776; see the
+  <      RFC itself for full legal notices.";
+  ---
+  >      This version of this YANG module is part of RFC XXXX
+  >      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+  >      for full legal notices.";
+  >   revision 2024-02-16 {
+  >     description
+  >       "This revision adds the following new identities:
+  >        - bandwidth-profile-type;
+  >        - link-metric-delay-variation;
+  >        - link-metric-loss;
 
 
 
-Busi, et al.              Expires 1 August 2024               [Page 145]
+Busi, et al.             Expires 20 August 2024               [Page 166]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
- >
- >        Added common TE packet groupings:
- >        - te-packet-path-bandwidth;
- >        - te-packet-link-bandwidth.
- >
- >        Updated module description.";
- >     reference
- >       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
- >   }
- >   // RFC Editor: replace XXXX with actual RFC number, update date
- >   // information and remove this note
- 61c89,187
- <   /**
- ---
- >   /*
- >    * Identities
- >    */
- >
- >   // CHANGE NOTE: The base identity bandwidth-profile-type and
- >   // its derived identities below have been
- >   // added in this module revision
- >   // RFC Editor: remove the note above and this note
- >   identity bandwidth-profile-type {
- >     description
- >       "Bandwidth Profile Types";
- >   }
- >
- >     identity mef-10-bwp {
- >       base bandwidth-profile-type;
- >       description
- >         "MEF 10 Bandwidth Profile";
- >       reference
- >         "MEF 10.3: Ethernet Services Attributes Phase 3";
- >     }
- >
- >     identity rfc-2697-bwp {
- >       base bandwidth-profile-type;
- >       description
- >         "RFC 2697 Bandwidth Profile";
- >       reference
- >         "RFC2697: A Single Rate Three Color Marker";
- >     }
- >
- >     identity rfc-2698-bwp {
- >       base bandwidth-profile-type;
- >       description
- >         "RFC 2698 Bandwidth Profile";
- >       reference
+  >        - path-metric-delay-variation;
+  >        - path-metric-loss.
+  >
+  >       This revision adds the following new groupings:
+  >        - te-packet-path-bandwidth;
+  >        - te-packet-link-bandwidth.
+  >
+  >       This revision provides also few editorial changes.";
+  >     reference
+  >       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
+  >   }
+  >   // RFC Editor: replace XXXX with actual RFC number, update date
+  >   // information and remove this note
+  61c91,196
+  <   /**
+  ---
+  >   /*
+  >    * Identities
+  >    */
+  >
+  >   // CHANGE NOTE: The base identity bandwidth-profile-type and
+  >   // its derived identities below have been
+  >   // added in this module revision
+  >   // RFC Editor: remove the note above and this note
+  >   identity bandwidth-profile-type {
+  >     description
+  >       "Bandwidth Profile Types";
+  >   }
+  >
+  >     identity mef-10-bwp {
+  >       base bandwidth-profile-type;
+  >       description
+  >         "MEF 10 Bandwidth Profile";
+  >       reference
+  >         "MEF 10.3: Ethernet Services Attributes Phase 3";
+  >     }
+  >
+  >     identity rfc-2697-bwp {
+  >       base bandwidth-profile-type;
+  >       description
+  >         "RFC 2697 Bandwidth Profile";
+  >       reference
+  >         "RFC2697: A Single Rate Three Color Marker";
+  >     }
+  >
+  >     identity rfc-2698-bwp {
+  >       base bandwidth-profile-type;
+  >       description
 
 
 
-Busi, et al.              Expires 1 August 2024               [Page 146]
+Busi, et al.             Expires 20 August 2024               [Page 167]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
- >         "RFC2698: A Two Rate Three Color Marker";
- >     }
- >
- >     identity rfc-4115-bwp {
- >       base bandwidth-profile-type;
- >       description
- >         "RFC 4115 Bandwidth Profile";
- >       reference
- >         "RFC4115: A Differentiated Service Two-Rate, Three-Color
- >         Marker with Efficient Handling of in-Profile Traffic";
- >     }
- >
- >   // CHANGE NOTE: The identity path-metric-loss below has
- >   // been added in this module revision
- >   // RFC Editor: remove the note above and this note
- >   identity path-metric-loss {
- >     base te-types:path-metric-type;
- >     description
- >       "The path loss (as a packet percentage) metric type
- >       encodes a function of the unidirectional loss metrics of all
- >       links traversed by a P2P path.
- >
- >       The basic unit is 0.000003%,
- >       where (2^24 - 2) or 50.331642% is the maximum value of the
- >       path loss percentage that can be expressed.
- >
- >       Values that are larger than the maximum value SHOULD be
- >       encoded as the maximum value.";
- >     reference
- >       "RFC8233: Extensions to the Path Computation Element
- >       Communication Protocol (PCEP) to Compute Service-Aware Label
- >       Switched Paths (LSPs);
- >
- >       RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
- >
- >       RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
- >   }
- >
- >   // CHANGE NOTE: The identity path-metric-delay-variation below has
- >   // been added in this module revision
- >   // RFC Editor: remove the note above and this note
- >   identity path-metric-delay-variation {
- >     base te-types:path-metric-type;
- >     description
- >       "The path delay variation encodes the sum of the unidirectional
- >       delay variation metrics of all links traversed by a P2P path.
- >
- >       The path delay variation metric unit is in microseconds, where
+  >         "RFC 2698 Bandwidth Profile";
+  >       reference
+  >         "RFC2698: A Two Rate Three Color Marker";
+  >     }
+  >
+  >     identity rfc-4115-bwp {
+  >       base bandwidth-profile-type;
+  >       description
+  >         "RFC 4115 Bandwidth Profile";
+  >       reference
+  >         "RFC4115: A Differentiated Service Two-Rate, Three-Color
+  >         Marker with Efficient Handling of in-Profile Traffic";
+  >     }
+  >
+  >     // CHANGE NOTE: The identity link-metric-delay-variation
+  >     // below has been added in this module revision
+  >     // RFC Editor: remove the note above and this note
+  >     identity link-metric-delay-variation {
+  >       base te-types:link-metric-type;
+  >       description
+  >         "The Unidirectional Delay Variation Metric,
+  >         measured in units of microseconds.";
+  >       reference
+  >         "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+  >         section 4.3
+  >
+  >         RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+  >         section 4.3";
+  >     }
+  >
+  >     // CHANGE NOTE: The identity link-metric-loss below has
+  >     // been added in this module revision
+  >     // RFC Editor: remove the note above and this note
+  >     identity link-metric-loss {
+  >       base te-types:link-metric-type;
+  >       description
+  >         "The Unidirectional Link Loss Metric,
+  >         measured in units of 0.000003%.";
+  >       reference
+  >         "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+  >         section 4.4
+  >
+  >         RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+  >         section 4.4";
+  >     }
+  >
+  >     // CHANGE NOTE: The identity path-metric-delay-variation
+  >     // below has been added in this module revision
 
 
 
-Busi, et al.              Expires 1 August 2024               [Page 147]
+Busi, et al.             Expires 20 August 2024               [Page 168]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
- >       (2^24 - 1) or 16,777,215 microseconds (16.777215 sec) is the
- >       maximum value of the path delay variation that can be
- >       expressed.
- >
- >       Values that are larger than the maximum value SHOULD be
- >       encoded as the maximum value.";
- >     reference
- >       "RFC8233: Extensions to the Path Computation Element
- >       Communication Protocol (PCEP) to Compute Service-Aware Label
- >       Switched Paths (LSPs);
- >
- >       RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
- >
- >       RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
- >   }
- >
- >   /*
- 180a307,310
- >   /*
- >    * Groupings
- >    */
- >
- 472a603,672
- >     }
- >   }
- >
- >   // CHANGE NOTE: The te-packet-path-bandwidth below has been
- >   // added in this module revision
- >   // RFC Editor: remove the note above and this note
- >   grouping te-packet-path-bandwidth {
- >     description
- >       "Path bandwidth for Packet. ";
- >     leaf bandwidth-profile-name {
- >       type string;
- >       description "Name of Bandwidth Profile.";
- >     }
- >     leaf bandwidth-profile-type {
- >       type identityref {
- >         base bandwidth-profile-type;
- >       }
- >       description "Type of Bandwidth Profile.";
- >     }
- >     leaf cir {
- >       type uint64;
- >       units "bits/second";
- >       mandatory true;
- >       description
- >         "Committed Information Rate (CIR).";
+  >     // RFC Editor: remove the note above and this note
+  >     identity path-metric-delay-variation {
+  >       base te-types:path-metric-type;
+  >       description
+  >         "The Path Delay Variation Metric,
+  >         measured in units of microseconds.";
+  >       reference
+  >         "RFC8233: Extensions to the Path Computation Element
+  >         Communication Protocol (PCEP) to Compute Service-Aware Label
+  >         Switched Paths (LSPs), section 3.1.2";
+  >     }
+  >
+  >     // CHANGE NOTE: The identity path-metric-loss below has
+  >     // been added in this module revision
+  >     // RFC Editor: remove the note above and this note
+  >     identity path-metric-loss {
+  >       base te-types:path-metric-type;
+  >       description
+  >         "The Path Loss Metric, measured in units of 0.000003%.";
+  >       reference
+  >         "RFC8233: Extensions to the Path Computation Element
+  >         Communication Protocol (PCEP) to Compute Service-Aware Label
+  >         Switched Paths (LSPs), section 3.1.3";
+  >     }
+  >
+  >   /*
+  180a316,319
+  >   /*
+  >    * Groupings
+  >    */
+  >
+  472a612,681
+  >     }
+  >   }
+  >
+  >   // CHANGE NOTE: The te-packet-path-bandwidth below has been
+  >   // added in this module revision
+  >   // RFC Editor: remove the note above and this note
+  >   grouping te-packet-path-bandwidth {
+  >     description
+  >       "Path bandwidth for Packet. ";
+  >     leaf bandwidth-profile-name {
+  >       type string;
+  >       description "Name of Bandwidth Profile.";
+  >     }
+  >     leaf bandwidth-profile-type {
+  >       type identityref {
+  >         base bandwidth-profile-type;
 
 
 
-Busi, et al.              Expires 1 August 2024               [Page 148]
+Busi, et al.             Expires 20 August 2024               [Page 169]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
 
- >     }
- >     leaf cbs {
- >       type uint64;
- >       units "bits/second";
- >       mandatory true;
- >       description
- >         "Committed Burst Size (CBS).";
- >     }
- >     leaf eir {
- >       type uint64;
- >       units "bits/second";
- >       description
- >         "Excess Information Rate (EIR).";
- >     }
- >     leaf ebs {
- >       type uint64;
- >       units "bytes";
- >       description
- >         "Excess Burst Size (EBS).";
- >     }
- >     leaf pir {
- >       type uint64;
- >       units "bits/second";
- >       description
- >         "Peak Information Rate (PIR).";
- >     }
- >     leaf pbs {
- >       type uint64;
- >       units "bytes";
- >       description
- >         "Peak Burst Size (PBS).";
- >     }
- >   }
- >
- >   // CHANGE NOTE: The te-packet-path-bandwidth below has been
- >   // added in this module revision
- >   // RFC Editor: remove the note above and this note
- >   grouping te-packet-link-bandwidth {
- >     description
- >       "Link Bandwidth for Packet. ";
- >     leaf packet-bandwidth {
- >       type uint64;
- >       units "bits/second";
- >       description
- >         "Available bandwith value.";
+  >       }
+  >       description "Type of Bandwidth Profile.";
+  >     }
+  >     leaf cir {
+  >       type uint64;
+  >       units "bits/second";
+  >       mandatory true;
+  >       description
+  >         "Committed Information Rate (CIR).";
+  >     }
+  >     leaf cbs {
+  >       type uint64;
+  >       units "bits/second";
+  >       mandatory true;
+  >       description
+  >         "Committed Burst Size (CBS).";
+  >     }
+  >     leaf eir {
+  >       type uint64;
+  >       units "bits/second";
+  >       description
+  >         "Excess Information Rate (EIR).";
+  >     }
+  >     leaf ebs {
+  >       type uint64;
+  >       units "bytes";
+  >       description
+  >         "Excess Burst Size (EBS).";
+  >     }
+  >     leaf pir {
+  >       type uint64;
+  >       units "bits/second";
+  >       description
+  >         "Peak Information Rate (PIR).";
+  >     }
+  >     leaf pbs {
+  >       type uint64;
+  >       units "bytes";
+  >       description
+  >         "Peak Burst Size (PBS).";
+  >     }
+  >   }
+  >
+  >   // CHANGE NOTE: The te-packet-path-bandwidth below has been
+  >   // added in this module revision
+  >   // RFC Editor: remove the note above and this note
+  >   grouping te-packet-link-bandwidth {
+  >     description
 
 
 
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 149]
+Busi, et al.             Expires 20 August 2024               [Page 170]
 
-Internet-Draft            TE Common YANG Types              January 2024
+Internet-Draft            TE Common YANG Types             February 2024
 
+
+  >       "Link Bandwidth for Packet. ";
+  >     leaf packet-bandwidth {
+  >       type uint64;
+  >       units "bits/second";
+  >       description
+  >         "Available bandwith value.";
 
 Appendix B.  Option Considered for updating RFC8776
 
@@ -8387,6 +9570,14 @@ Appendix B.  Option Considered for updating RFC8776
       YANG model to focus the review only to the updates to the ietf-te-
       types YANG module proposed by this document.
 
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 171]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
    Based on the feedbacks from IETF 114 discussion, this version has
    been restructured to become an RFC8776-bis, with some notes, to be
    removed before publication, to focus the review only to the updates
@@ -8394,13 +9585,6 @@ Appendix B.  Option Considered for updating RFC8776
 
    During the Netmod WG session at IETF 114, an alternative process has
    been introduced:
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 150]
-
-Internet-Draft            TE Common YANG Types              January 2024
-
 
    https://datatracker.ietf.org/meeting/114/materials/slides-114-netmod-
    ad-topic-managing-the-evolution-of-ietf-yang-modules-00.pdf
@@ -8441,6 +9625,15 @@ Authors' Addresses
    Email: aihuaguo.ietf@gmail.com
 
 
+
+
+
+
+Busi, et al.             Expires 20 August 2024               [Page 172]
+
+Internet-Draft            TE Common YANG Types             February 2024
+
+
    Xufeng Liu
    Alef Edge
    Email: xufeng.liu.ietf@gmail.com
@@ -8449,13 +9642,6 @@ Authors' Addresses
    Tarek Saad
    Cisco Systems Inc.
    Email: tsaad.net@gmail.com
-
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 151]
-
-Internet-Draft            TE Common YANG Types              January 2024
 
 
    Igor Bryskin
@@ -8499,14 +9685,4 @@ Internet-Draft            TE Common YANG Types              January 2024
 
 
 
-
-
-
-
-
-
-
-
-
-
-Busi, et al.              Expires 1 August 2024               [Page 152]
+Busi, et al.             Expires 20 August 2024               [Page 173]

--- a/drafts/te-types-update/draft-ietf-teas-rfc8776-update.xml
+++ b/drafts/te-types-update/draft-ietf-teas-rfc8776-update.xml
@@ -13,7 +13,7 @@
 
 <?rfc comments="yes"?>
 
-<rfc ipr="trust200902" docName="draft-ietf-teas-rfc8776-update-09" category="std" consensus="true" submissionType="IETF" obsoletes="8776" tocInclude="true" sortRefs="true" symRefs="true">
+<rfc ipr="trust200902" docName="draft-ietf-teas-rfc8776-update-10" category="std" consensus="true" submissionType="IETF" obsoletes="8776" tocInclude="true" sortRefs="true" symRefs="true">
   <front>
     <title abbrev="TE Common YANG Types">Common YANG Data Types for Traffic Engineering</title>
 
@@ -48,7 +48,7 @@
       </address>
     </author>
 
-    <date year="2024" month="January" day="29"/>
+    <date year="2024" month="February" day="17"/>
 
     
     <workgroup>TEAS Working Group</workgroup>
@@ -57,7 +57,7 @@
     <abstract>
 
 
-<t>This document defines a collection of common data types and groupings in YANG data modeling language. These derived common types and groupings are intended to be imported by modules that model Traffic Engineering (TE) configuration and state capabilities. This document obsoletes RFC 8776.</t>
+<t>This document defines a collection of common data types, identities, and groupings in YANG data modeling language. These derived common types and groupings are intended to be imported by modules that model Traffic Engineering (TE) configuration and state capabilities. This document obsoletes RFC 8776.</t>
 
 
 
@@ -74,15 +74,9 @@
 
 <t>YANG <xref target="RFC6020"/> <xref target="RFC7950"/> is a data modeling language used to model configuration data, state data, Remote Procedure Calls, and notifications for network management protocols such as the Network Configuration Protocol (NETCONF) <xref target="RFC6241"/>. The YANG language supports a small set of built-in data types and provides mechanisms to derive other types from the built-in types.</t>
 
-<t>This document introduces a collection of common data types derived from the built-in YANG data types. The derived types and groupings are designed to be the common types applicable for modeling Traffic Engineering (TE) features in model(s) defined outside of this document.</t>
+<t>This document introduces a collection of common data types derived from the built-in YANG data types. The derived data types, identities, and groupings are designed to be the common definitions applicable for modeling Traffic Engineering (TE) features in model(s) defined outside of this document.</t>
 
-<t>This document adds few additional common data types, identities, and groupings to both the "ietf-te-types" and the "ietf-te-packet-types" YANG models and obsoletes <xref target="RFC8776"/>.</t>
-
-<t>For further details, see the revision statements of the YANG modules in Sections X and Y or the summary in Appendix A.</t>
-
-<t>CHANGE NOTE: These definitions have been developed in <xref target="I-D.ietf-teas-yang-te"/>, <xref target="I-D.ietf-teas-yang-path-computation"/> and <xref target="I-D.ietf-teas-yang-l3-te-topo"/> and are quite mature: <xref target="I-D.ietf-teas-yang-te"/> and <xref target="I-D.ietf-teas-yang-path-computation"/> in particular are in WG Last Call and some definitions have been moved to this document as part of WG LC comments resolution.</t>
-
-<t>RFC Editor: remove the CHANGE NOTE above and this note</t>
+<t>This document adds new common data types, identities, and groupings to both the "ietf-te-types" and the "ietf-te-packet-types" YANG models and obsoletes <xref target="RFC8776"/>. For further details, see the revision statements of the YANG modules in <xref target="te-yang-code"/> and <xref target="pkt-yang-code"/>, or the summary in <xref target="changes-bis"/>.</t>
 
 <section anchor="requirements-notation"><name>Requirements Notation</name>
 
@@ -694,37 +688,88 @@ module ietf-te-types {
      This version of this YANG module is part of RFC XXXX
      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
      for full legal notices.";
-  revision 2024-01-29 {
+  revision 2024-02-16 {
     description
-      "Added:
-      - base identity lsp-provisioning-error-reason;
-      - identity association-type-diversity;
-      - identity tunnel-admin-state-auto;
-      - identity lsp-restoration-restore-none;
-      - identity restoration-scheme-rerouting;
-      - base identity path-computation-error-reason and
-        its derived identities;
-      - base identity protocol-origin-type and
-        its derived identities;
-      - base identity svec-objective-function-type and its derived
-        identities;
-      - base identity svec-metric-type and its derived identities;
-      - grouping encoding-and-switching-type.
-      
-      Updated:
-      - description of the base identity objective-function-type;
-      - description and reference of identity action-exercise;
-      - typedef te-node-id to support also 16 octects TE identifiers.
-      
-      Obsoleted:
-      - identity of-minimize-agg-bandwidth-consumption;
-      - identity of-minimize-load-most-loaded-link;
-      - identity of-minimize-cost-path-set;
-      - identity lsp-protection-reroute-extra;
-      - identity lsp-protection-reroute.
+      "This revision adds the following new identities:
+      - lsp-provisioning-error-reason;
+      - association-type-diversity;
+      - tunnel-admin-state-auto;
+      - lsp-restoration-restore-none;
+      - restoration-scheme-rerouting;
+      - path-metric-optimization-type;
+      - link-path-metric-type;
+      - link-metric-type and its derived identities;
+      - path-computation-error-reason and its derived identities;
+      - protocol-origin-type and its derived identities;
+      - svec-objective-function-type and its derived identities;
+      - svec-metric-type and its derived identities.
 
-      Container explicit-route-objects-always renamed as
-      explicit-route-objects.";
+      This revision adds the following new data types:
+      - path-type;
+      - te-gen-node-id.
+
+      This revision adds the following new groupings:
+      - encoding-and-switching-type;
+      - te-generic-node-id.
+
+      This revision updates the following identities:
+      - objective-function-type;
+      - action-exercise;
+      - path-metric-type;
+      - path-metric-te;
+      - path-metric-igp;
+      - path-metric-hop;
+      - path-metric-delay-average;
+      - path-metric-delay-minimum;
+      - path-metric-residual-bandwidth;
+      - path-metric-optimize-includes;
+      - path-metric-optimize-excludes;
+      - te-optimization-criterion.
+
+      This revision updates the following data types:
+      - te-node-id.
+
+      This revision updates the following groupings:
+      - explicit-route-hop:
+        - adds the following leaves:
+          - node-id-uri;
+          - link-tp-id-uri;
+        - updates the following leaves:
+          - node-id;
+          - link-tp-id;
+      - record-route-state:
+        - adds the following leaves:
+          - node-id-uri;
+          - link-tp-id-uri;
+        - updates the following leaves:
+          - node-id;
+          - link-tp-id;
+      - optimization-metric-entry:
+        - updates the following leaves:
+          - metric-type;
+      - tunnel-constraints;
+        - adds the following leaves:
+          - network-id;
+      - path-constraints-route-objects:
+        - updates the following containers:
+          - explicit-route-objects-always;
+      - generic-path-metric-bounds:
+        - updates the following leaves:
+          - metric-type;
+      - generic-path-optimization
+        - adds the following leaves:
+          - tiebreaker;
+        - deprecate the following containers:
+          - tiebreakers.
+
+      This revision obsoletes the following identities:
+      - of-minimize-agg-bandwidth-consumption;
+      - of-minimize-load-most-loaded-link;
+      - of-minimize-cost-path-set;
+      - lsp-protection-reroute-extra;
+      - lsp-protection-reroute.
+
+      This revision provides also few editorial changes.";
     reference
       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
   }
@@ -733,7 +778,7 @@ module ietf-te-types {
 
   revision 2020-06-10 {
     description
-      "Latest revision of TE types.";
+      "Initial Version of TE types.";
     reference
       "RFC 8776: Common YANG Data Types for Traffic Engineering";
   }
@@ -750,13 +795,16 @@ module ietf-te-types {
     description
       "Administrative group / resource class / color representation
        in 'hex-string' type.
+
        The most significant byte in the hex-string is the farthest
        to the left in the byte sequence.  Leading zero bytes in the
        configured value may be omitted for brevity.";
     reference
       "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
        Version 2
+
        RFC 5305: IS-IS Extensions for Traffic Engineering
+       
        RFC 7308: Extended Administrative Groups in MPLS Traffic
        Engineering (MPLS-TE)";
   }
@@ -775,6 +823,7 @@ module ietf-te-types {
     description
       "Extended administrative group / resource class / color
        representation in 'hex-string' type.
+
        The most significant byte in the hex-string is the farthest
        to the left in the byte sequence.  Leading zero bytes in the
        configured value may be omitted for brevity.";
@@ -819,9 +868,11 @@ module ietf-te-types {
        bit not set), abnormal (anomalous bit set), or unknown.";
     reference
       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions
+
        RFC 7823: Performance-Based Path Selection for Explicitly
        Routed Label Switched Paths (LSPs) Using TE Metric
        Extensions
+
        RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
   }
 
@@ -927,12 +978,15 @@ module ietf-te-types {
     description
       "An identifier to uniquely identify an operator, which can be
        either a provider or a client.
+
        The definition of this type is taken from RFCs 6370 and 5003.
+
        This attribute type is used solely to provide a globally
        unique context for TE topologies.";
     reference
       "RFC 5003: Attachment Individual Identifier (AII) Types for
        Aggregation
+
        RFC 6370: MPLS Transport Profile (MPLS-TP) Identifiers";
   }
 
@@ -1197,6 +1251,7 @@ module ietf-te-types {
     }
     description
       "An identifier for a topology.
+
        It is optional to have one or more prefixes at the beginning,
        separated by colons.  The prefixes can be 'network-types' as
        defined in the 'ietf-network' module in RFC 8345, to help the
@@ -1215,6 +1270,7 @@ module ietf-te-types {
     }
     description
       "An identifier for a TE link endpoint on a node.
+
        This attribute is mapped to a local or remote link identifier
        as defined in RFCs 3630 and 5305.";
     reference
@@ -1718,7 +1774,7 @@ module ietf-te-types {
       "Association Type diversity used to associate LSPs whose 
       paths are to be diverse from each other.";
     reference
-      "RFC8800: Path Computation Element Communication Protocol 
+      "RFC 8800: Path Computation Element Communication Protocol 
       (PCEP) Extension for Label Switched Path (LSP) Diversity 
       Constraint Signaling";
   }
@@ -1729,7 +1785,7 @@ module ietf-te-types {
   // RFC Editor: remove the note above and this note
   identity objective-function-type {
     description
-      "Base identity for path objective function type.";
+      "Base identity for path objective function types.";
   }
 
   identity of-minimize-cost-path {
@@ -1768,7 +1824,11 @@ module ietf-te-types {
     status obsolete;
     description
       "Objective function for minimizing aggregate bandwidth
-      consumption.";
+      consumption.
+      
+      This identity has been obsoleted: the
+      'svec-of-minimize-agg-bandwidth-consumption' identity SHOULD
+      be used instead.";
     reference
       "RFC 5541: Encoding of Objective Functions in the Path
       Computation Element Communication Protocol (PCEP)";
@@ -1782,7 +1842,11 @@ module ietf-te-types {
     status obsolete;
     description
       "Objective function for minimizing the load on the link that
-      is carrying the highest load.";
+      is carrying the highest load.
+      
+      This identity has been obsoleted: the
+      'svec-of-minimize-load-most-loaded-link' identity SHOULD
+      be used instead.";
     reference
       "RFC 5541: Encoding of Objective Functions in the Path
       Computation Element Communication Protocol (PCEP)";
@@ -1795,7 +1859,11 @@ module ietf-te-types {
     base objective-function-type;
     status obsolete;
     description
-      "Objective function for minimizing the cost on a path set.";
+      "Objective function for minimizing the cost on a path set.
+      
+      This identity has been obsoleted: the
+      'svec-of-minimize-cost-path-set' identity SHOULD
+      be used instead.";
     reference
       "RFC 5541: Encoding of Objective Functions in the Path
        Computation Element Communication Protocol (PCEP)";
@@ -1806,16 +1874,23 @@ module ietf-te-types {
       "Base identity for supported path computation mechanisms.";
   }
 
+  // CHANGE NOTE: The reference of the identity path-locally-computed
+  // below has been updated in this module revision
+  // RFC Editor: remove the note above and this note
   identity path-locally-computed {
     base path-computation-method;
     description
       "Indicates a constrained-path LSP in which the
        path is computed by the local LER.";
     reference
-      "RFC 3272: Overview and Principles of Internet Traffic
-       Engineering, Section 5.4";
+      "RFC 9522: Overview and Principles of Internet Traffic
+      Engineering, Section 4.4";
   }
 
+  // CHANGE NOTE: The reference of the identity 
+  // path-externally-queried below has been updated
+  // in this module revision
+  // RFC Editor: remove the note above and this note
   identity path-externally-queried {
     base path-computation-method;
     description
@@ -1827,12 +1902,17 @@ module ietf-te-types {
        returned by the external source may require further local
        computation on the device.";
     reference
-      "RFC 3272: Overview and Principles of Internet Traffic
+      "RFC 9522: Overview and Principles of Internet Traffic
        Engineering
+
        RFC 4657: Path Computation Element (PCE) Communication
        Protocol Generic Requirements";
   }
 
+  // CHANGE NOTE: The reference of the identity 
+  // path-explicitly-defined below has been updated
+  // in this module revision
+  // RFC Editor: remove the note above and this note
   identity path-explicitly-defined {
     base path-computation-method;
     description
@@ -1841,7 +1921,8 @@ module ietf-te-types {
        hops.";
     reference
       "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels
-       RFC 3272: Overview and Principles of Internet Traffic
+
+       RFC 9522: Overview and Principles of Internet Traffic
        Engineering";
   }
 
@@ -2730,89 +2811,231 @@ module ietf-te-types {
        Protocol-Traffic Engineering (RSVP-TE)";
   }
 
-  // CHANGE NOTE: The description of the identity path-metric-type
-  // has been updated in this module revision
-  // RFC Editor: remove the note above and this note
-  identity path-metric-type {
-    description
-      "Base identity for the path metric type.
-      
-      Derived identities SHOULD describe the unit and maximum value
-      of the path metric types they define.";
-  }
-
-  identity path-metric-te {
-    base path-metric-type;
-    description
-      "TE path metric.";
-    reference
-      "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
-       second MPLS Traffic Engineering (TE) Metric";
-  }
-
-  identity path-metric-igp {
-    base path-metric-type;
-    description
-      "IGP path metric.";
-    reference
-      "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
-       second MPLS Traffic Engineering (TE) Metric";
-  }
-
-  // CHANGE NOTE: The reference for the identity path-metric-hop
+  // CHANGE NOTE: The path-metric-optimization-type base identity
   // has been added in this module revision
   // RFC Editor: remove the note above and this note
-  identity path-metric-hop {
-    base path-metric-type;
+  identity path-metric-optimization-type {
     description
-      "Hop path metric.";
-    reference
-      "RFC5440: Path Computation Element (PCE) Communication
-      Protocol (PCEP)";
+      "Base identity used to define the path metric optimization
+      types.";
   }
 
-
-  identity path-metric-delay-average {
-    base path-metric-type;
+  // CHANGE NOTE: The link-path-metric-type base identity
+  // has been added in this module revision
+  // RFC Editor: remove the note above and this note
+  identity link-path-metric-type {
     description
-      "Average unidirectional link delay.";
-    reference
-      "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+      "Base identity used to define the link and the path metric
+      types.
+      
+      The unit of the path metric value is interpreted in the
+      context of the path metric type and the derived identities
+      SHOULD describe the unit of the path metric types they
+      define.";
   }
 
-  identity path-metric-delay-minimum {
-    base path-metric-type;
-    description
-      "Minimum unidirectional link delay.";
-    reference
-      "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-  }
+    // CHANGE NOTE: The link-metric-type base identity
+    // and its derived identities
+    // have been added in this module revision
+    // RFC Editor: remove the note above and this note
+    identity link-metric-type {
+      base link-path-metric-type;
+      description
+        "Base identity for the link metric types.";
+    }
 
-  identity path-metric-residual-bandwidth {
-    base path-metric-type;
-    description
-      "Unidirectional Residual Bandwidth, which is defined to be
-       Maximum Bandwidth (RFC 3630) minus the bandwidth currently
-       allocated to LSPs.";
-    reference
-      "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
-       Version 2
-       RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-  }
+      identity link-metric-te {
+        base link-metric-type;
+        description
+          "Traffic Engineering (TE) Link Metric.";
+        reference
+          "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+          Version 2, section 2.5.5
 
-  identity path-metric-optimize-includes {
-    base path-metric-type;
-    description
-      "A metric that optimizes the number of included resources
-       specified in a set.";
-  }
+          RFC 5305: IS-IS Extensions for Traffic Engineering,
+          section 3.7";
+      }
 
-  identity path-metric-optimize-excludes {
-    base path-metric-type;
-    description
-      "A metric that optimizes to a maximum the number of excluded
-       resources specified in a set.";
-  }
+      identity link-metric-igp {
+        base link-metric-type;
+        description
+          "Interior Gateway Protocol (IGP) Link Metric.";
+        reference
+          "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric
+          as a second MPLS Traffic Engineering (TE) Metric";
+      }
+
+      identity link-metric-delay-average {
+        base link-metric-type;
+        description
+          "Unidirectional Link Delay, measured in units of
+          microseconds.";
+        reference
+          "RFC 7471: OSPF Traffic Engineering (TE) Metric
+          Extensions, section 4.1
+          
+          RFC 8570: IS-IS Traffic Engineering (TE) Metric
+          Extensions, section 4.1";
+      }
+
+      identity link-metric-delay-minimum {
+        base link-metric-type;
+        description
+          "Minimum unidirectional Link Delay, measured in units of
+          microseconds.";
+        reference
+          "RFC 7471: OSPF Traffic Engineering (TE) Metric
+          Extensions, section 4.2
+          
+          RFC 8570: IS-IS Traffic Engineering (TE) Metric
+          Extensions, section 4.2";
+      }
+
+      identity link-metric-delay-maximum {
+        base link-metric-type;
+        description
+          "Maximum unidirectional Link Delay, measured in units of
+          microseconds.";
+        reference
+          "RFC 7471: OSPF Traffic Engineering (TE) Metric
+          Extensions, section 4.2
+          
+          RFC 8570: IS-IS Traffic Engineering (TE) Metric
+          Extensions, section 4.2";
+      }
+
+      identity link-metric-residual-bandwidth {
+        base link-metric-type;
+        description
+          "Unidirectional Residual Bandwidth, measured in units of
+          bytes per second.
+          
+          It is defined to be Maximum Bandwidth minus the bandwidth
+          currently allocated to LSPs.";
+        reference
+          "RFC 7471: OSPF Traffic Engineering (TE) Metric
+          Extensions, section 4.5
+          
+          RFC 8570: IS-IS Traffic Engineering (TE) Metric
+          Extensions, section 4.5";
+      }
+
+    // CHANGE NOTE: The base and the description of the
+    // path-metric-type identity
+    // has been updated in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-type {
+      base link-path-metric-type;
+      base path-metric-optimization-type;
+      description
+        "Base identity for the path metric types.";
+    }
+
+      // CHANGE NOTE: The description and the reference of the
+      // path-metric-te identity have been updated
+      // in this module revision
+      // RFC Editor: remove the note above and this note
+      identity path-metric-te {
+        base path-metric-type;
+        description
+          "Traffic Engineering (TE) Path Metric.";
+        reference
+          "RFC 5440: Path Computation Element (PCE) Communication
+          Protocol (PCEP), section 7.8";
+      }
+
+      // CHANGE NOTE: The description and the reference of the
+      // path-metric-igp identity have been updated 
+      // in this module revision
+      // RFC Editor: remove the note above and this note
+      identity path-metric-igp {
+        base path-metric-type;
+        description
+          "Interior Gateway Protocol (IGP) Path Metric.";
+        reference
+          "RFC 5440: Path Computation Element (PCE) Communication
+          Protocol (PCEP), section 7.8";
+      }
+
+      // CHANGE NOTE: The description and the reference of the
+      // path-metric-hop identity have been updated
+      // in this module revision
+      // RFC Editor: remove the note above and this note
+      identity path-metric-hop {
+        base path-metric-type;
+        description
+          "Hop Count Path Metric.";
+        reference
+          "RFC 5440: Path Computation Element (PCE) Communication
+          Protocol (PCEP), section 7.8";
+      }
+
+      // CHANGE NOTE: The description and the reference of the
+      // path-metric-delay-average identity have been updated
+      // in this module revision
+      // RFC Editor: remove the note above and this note
+      identity path-metric-delay-average {
+        base path-metric-type;
+        description
+          "The Path Delay Metric, measured in units of
+          microseconds.";
+        reference
+          "RFC8233: Extensions to the Path Computation Element
+          Communication Protocol (PCEP) to Compute Service-Aware
+          Label Switched Paths (LSPs), section 3.1.1";
+      }
+
+      // CHANGE NOTE: The description and the reference of the
+      // path-metric-delay-minimum identity have been updated
+      // in this module revision
+      // RFC Editor: remove the note above and this note
+      identity path-metric-delay-minimum {
+        base path-metric-type;
+        description
+          "The Path Min Delay Metric, measured in units of
+          microseconds.";
+        reference
+          "I-D.ietf-pce-sid-algo: Carrying SR-Algorithm information
+          in PCE-based Networks, section 3.5.1";
+      }
+
+      // CHANGE NOTE: The description and the reference of the
+      // path-metric-residual-bandwidth identity have been updated
+      // in this module revision
+      // RFC Editor: remove the note above and this note
+      identity path-metric-residual-bandwidth {
+        base path-metric-type;
+        description
+          "The Path Residual Bandwidth, defined as the minimum Link
+          Residual Bandwidth all the links along the path.
+
+          The Path Residual Bandwidth can be seen as the path
+          metric associated with the Maximum residual Bandwidth Path
+          (MBP) objective function.";
+        reference
+          "RFC 5541: Encoding of Objective Functions in the Path
+          Computation Element Communication Protocol (PCEP)";
+      }
+
+    // CHANGE NOTE: The base of the path-metric-optimize-includes
+    // identity has been updated in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-optimize-includes {
+      base path-metric-optimization-type;
+      description
+        "A metric that optimizes the number of included resources
+        specified in a set.";
+    }
+
+    // CHANGE NOTE: The base of the path-metric-optimize-excludes
+    // identity has been updated in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-optimize-excludes {
+      base path-metric-optimization-type;
+      description
+        "A metric that optimizes to a maximum the number of excluded
+        resources specified in a set.";
+    }
 
   identity path-tiebreaker-type {
     description
@@ -2876,11 +3099,15 @@ module ietf-te-types {
        RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
   }
 
+  // CHANGE NOTE: The reference of the identity 
+  // te-optimization-criterion below has been updated
+  // in this module revision
+  // RFC Editor: remove the note above and this note
   identity te-optimization-criterion {
     description
       "Base identity for the TE optimization criteria.";
     reference
-      "RFC 3272: Overview and Principles of Internet Traffic
+      "RFC 9522: Overview and Principles of Internet Traffic
        Engineering";
   }
 
@@ -2952,8 +3179,8 @@ module ietf-te-types {
         "Path computation has failed because of an unspecified 
         reason.";
       reference
-        "Section 7.5 of RFC5440: Path Computation Element (PCE)
-        Communication Protocol (PCEP)";
+        "RFC 5440: Path Computation Element (PCE) Communication
+        Protocol (PCEP), section 7.5";
     }
 
     identity path-computation-error-no-topology {
@@ -2973,7 +3200,13 @@ module ietf-te-types {
         a Backward-Recursive Path Computation (BRPC) downstream
         PCE or a child PCE.";
       reference
-        "RFC5441, RFC8685";
+        "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+        Procedure to Compute Shortest Constrained Inter-Domain
+        Traffic Engineering Label Switched Paths
+        
+        RFC 8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture";
     }
 
     identity path-computation-error-pce-unavailable {
@@ -2984,10 +3217,11 @@ module ietf-te-types {
         It corresponds to bit 31 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC5440: Path Computation Element (PCE) Communication
-        Protocol (PCEP);
+        "RFC 5440: Path Computation Element (PCE) Communication
+        Protocol (PCEP)
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-no-inclusion-hop {
@@ -3006,9 +3240,12 @@ module ietf-te-types {
         It corresponds to bit 19 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC8685;
+        "RFC 8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-no-resource {
@@ -3020,9 +3257,12 @@ module ietf-te-types {
         It corresponds to bit 20 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC8685;
+        "RFC 8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-child-pce-unresponsive {
@@ -3034,9 +3274,12 @@ module ietf-te-types {
         It corresponds to bit 21 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC8685;
+        "RFC 8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-destination-domain-unknown {
@@ -3048,9 +3291,12 @@ module ietf-te-types {
         It corresponds to bit 22 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC8685;
+        "RFC 8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-p2mp {
@@ -3062,9 +3308,12 @@ module ietf-te-types {
         It corresponds to bit 24 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC8306;
+        "RFC 8306: Extensions to the Path Computation Element
+        Communication Protocol (PCEP) for Point-to-Multipoint
+        Traffic Engineering Label Switched Paths
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-no-gco-migration {
@@ -3076,9 +3325,12 @@ module ietf-te-types {
         It corresponds to bit 26 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC5557;
+        "RFC 5557: Path Computation Element Communication Protocol
+        (PCEP) Requirements and Protocol Extensions in Support of
+        Global Concurrent Optimization
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-no-gco-solution {
@@ -3090,9 +3342,12 @@ module ietf-te-types {
         It corresponds to bit 25 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC5557;
+        "RFC 5557: Path Computation Element Communication Protocol
+        (PCEP) Requirements and Protocol Extensions in Support of
+        Global Concurrent Optimization
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-pks-expansion {
@@ -3104,9 +3359,12 @@ module ietf-te-types {
         It corresponds to bit 27 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC5520;
+        "RFC 5520: Preserving Topology Confidentiality in
+        Inter-Domain Path Computation Using a Path-Key-Based
+        Mechanism
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-brpc-chain-unavailable {
@@ -3118,9 +3376,12 @@ module ietf-te-types {
         It corresponds to bit 28 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC5441;
+        "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+        Procedure to Compute Shortest Constrained Inter-Domain
+        Traffic Engineering Label Switched Paths
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-source-unknown {
@@ -3132,10 +3393,11 @@ module ietf-te-types {
         It corresponds to bit 29 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC5440: Path Computation Element (PCE) Communication
+        "RFC 5440: Path Computation Element (PCE) Communication
         Protocol (PCEP);
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-destination-unknown {
@@ -3147,10 +3409,11 @@ module ietf-te-types {
         It corresponds to bit 30 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC5440: Path Computation Element (PCE) Communication
+        "RFC 5440: Path Computation Element (PCE) Communication
         Protocol (PCEP);
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-no-server {
@@ -3159,10 +3422,11 @@ module ietf-te-types {
         "Path computation has failed because path computation
         server is unavailable.";
       reference
-        "RFC5440: Path Computation Element (PCE) Communication
+        "RFC 5440: Path Computation Element (PCE) Communication
         Protocol (PCEP);
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
   // CHANGE NOTE: The base identity protocol-origin-type and 
@@ -3187,7 +3451,7 @@ module ietf-te-types {
         "Protocol origin is Path Computation Engine Protocol 
         (PCEP).";
       reference
-        "RFC5440: Path Computation Element (PCE) Communication
+        "RFC 5440: Path Computation Element (PCE) Communication
         Protocol (PCEP)";
     }
 
@@ -3195,7 +3459,7 @@ module ietf-te-types {
       base protocol-origin-type;
       description
         "Protocol origin is Border Gateway Protocol (BGP).";
-      reference "RFC9012";
+      reference "RFC 9012";
     }
 
   // CHANGE NOTE: The base identity svec-objective-function-type 
@@ -3206,8 +3470,8 @@ module ietf-te-types {
     description
       "Base identity for SVEC objective function type.";
     reference
-      "RFC5541: Encoding of Objective Functions in the Path
-       Computation Element Communication Protocol (PCEP).";
+      "RFC 5541: Encoding of Objective Functions in the Path
+       Computation Element Communication Protocol (PCEP)";
   }
 
     identity svec-of-minimize-agg-bandwidth-consumption {
@@ -3216,8 +3480,8 @@ module ietf-te-types {
         "Objective function for minimizing aggregate bandwidth 
         consumption (MBC).";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
     }
 
     identity svec-of-minimize-load-most-loaded-link {
@@ -3226,8 +3490,8 @@ module ietf-te-types {
         "Objective function for minimizing the load on the link that 
         is carrying the highest load (MLL).";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
     }
 
     identity svec-of-minimize-cost-path-set {
@@ -3236,8 +3500,8 @@ module ietf-te-types {
         "Objective function for minimizing the cost on a path set 
         (MCC).";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
     }
 
     identity svec-of-minimize-common-transit-domain {
@@ -3246,9 +3510,9 @@ module ietf-te-types {
         "Objective function for minimizing the number of common 
         transit domains (MCTD).";
       reference
-        "RFC8685: Path Computation Element Communication Protocol 
+        "RFC 8685: Path Computation Element Communication Protocol 
         (PCEP) Extensions for the Hierarchical Path Computation 
-        Element (H-PCE) Architecture.";
+        Element (H-PCE) Architecture";
     }
 
     identity svec-of-minimize-shared-link {
@@ -3257,7 +3521,7 @@ module ietf-te-types {
         "Objective function for minimizing the number of shared 
         links (MSL).";
       reference
-        "RFC8685: Path Computation Element Communication Protocol 
+        "RFC 8685: Path Computation Element Communication Protocol 
         (PCEP) Extensions for the Hierarchical Path Computation 
         Element (H-PCE) Architecture.";
     }
@@ -3268,7 +3532,7 @@ module ietf-te-types {
         "Objective function for minimizing the number of shared 
         Shared Risk Link Groups (SRLG) (MSS).";
       reference
-        "RFC8685: Path Computation Element Communication Protocol 
+        "RFC 8685: Path Computation Element Communication Protocol 
         (PCEP) Extensions for the Hierarchical Path Computation 
         Element (H-PCE) Architecture.";
     }
@@ -3279,7 +3543,7 @@ module ietf-te-types {
         "Objective function for minimizing the number of shared 
         nodes (MSN).";
       reference
-        "RFC8685: Path Computation Element Communication Protocol 
+        "RFC 8685: Path Computation Element Communication Protocol 
         (PCEP) Extensions for the Hierarchical Path Computation 
         Element (H-PCE) Architecture.";
     }
@@ -3292,35 +3556,35 @@ module ietf-te-types {
     description
       "Base identity for SVEC metric type.";
     reference
-      "RFC5541: Encoding of Objective Functions in the Path
-       Computation Element Communication Protocol (PCEP).";
+      "RFC 5541: Encoding of Objective Functions in the Path
+       Computation Element Communication Protocol (PCEP)";
   }
 
-    identity svec-metric-cumul-te {
+    identity svec-metric-cumulative-te {
       base svec-metric-type;
       description
         "Cumulative TE cost.";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
     }
 
-    identity svec-metric-cumul-igp {
+    identity svec-metric-cumulative-igp {
       base svec-metric-type;
       description
         "Cumulative IGP cost.";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
     }
 
-    identity svec-metric-cumul-hop {
+    identity svec-metric-cumulative-hop {
       base svec-metric-type;
       description
         "Cumulative Hop path metric.";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
     }
 
     identity svec-metric-aggregate-bandwidth-consumption {
@@ -3328,8 +3592,8 @@ module ietf-te-types {
       description
         "Aggregate bandwidth consumption.";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
     }
 
     identity svec-metric-load-of-the-most-loaded-link {
@@ -3337,8 +3601,8 @@ module ietf-te-types {
       description
         "Load of the most loaded link.";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        "RFC 5541: Encoding of Objective Functions in the Path
+        Computation Element Communication Protocol (PCEP)";
     }
 
   /**
@@ -3451,11 +3715,13 @@ module ietf-te-types {
        grouping are applicable to generic TE PM as well as packet TE
        PM.";
     reference
-      "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions
-       RFC 7823: Performance-Based Path Selection for Explicitly
-       Routed Label Switched Paths (LSPs) Using TE Metric
-       Extensions
-       RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
+      "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensionsù
+      
+      RFC 7823: Performance-Based Path Selection for Explicitly
+      Routed Label Switched Paths (LSPs) Using TE Metric
+      Extensions
+
+      RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
     leaf one-way-delay {
       type uint32 {
         range "0..16777215";
@@ -3887,6 +4153,9 @@ module ietf-te-types {
     }
   }
 
+  // CHANGE NOTE: The explicit-route-hop grouping below has been
+  // updated in this module revision
+  // RFC Editor: remove the note above and this note
   grouping record-route-state {
     description
       "The Record Route grouping.";
@@ -4160,12 +4429,15 @@ module ietf-te-types {
     }
   }
 
+  // CHANGE NOTE: The grouping optimization-metric-entry below has
+  // been updated in this module revision
+  // RFC Editor: remove the note above and this note
   grouping optimization-metric-entry {
     description
       "Optimization metrics configuration grouping.";
     leaf metric-type {
       type identityref {
-        base path-metric-type;
+        base path-metric-optimization-type;
       }
       description
         "Identifies the 'metric-type' that the path computation
@@ -4243,6 +4515,9 @@ module ietf-te-types {
     }
   }
 
+  // CHANGE NOTE: The grouping tunnel-constraints below has
+  // been updated in this module revision
+  // RFC Editor: remove the note above and this note
   grouping tunnel-constraints {
     description
       "Tunnel constraints grouping that can be set on
@@ -4256,13 +4531,13 @@ module ietf-te-types {
     uses common-constraints;
   }
 
+  // CHANGE NOTE: The grouping path-constraints-route-objects below
+  // has been updated in this module revision
+  // RFC Editor: remove the note above and this note
   grouping path-constraints-route-objects {
     description
       "List of route entries to be included or excluded when
        performing the path computation.";
-    // CHANGE NOTE: The explicit-route-objects container below has
-    // been updated in this module revision
-    // RFC Editor: remove the note above and this note
     container explicit-route-objects {
       description
         "Container for the explicit route object lists.";
@@ -4388,19 +4663,30 @@ module ietf-te-types {
     }
   }
 
+  // CHANGE NOTE: The grouping generic-path-metric-bounds below
+  // has been updated in this module revision
+  // RFC Editor: remove the note above and this note
   grouping generic-path-metric-bounds {
     description
       "TE path metric bounds grouping.";
     container path-metric-bounds {
       description
-        "TE path metric bounds container.";
+        "Top-level container for the list of path metric bounds.";
       list path-metric-bound {
         key "metric-type";
         description
-          "List of TE path metric bounds.";
+          "List of path metric bounds, which can apply to link and
+          path metrics.
+          
+          TE paths which have at least one path metric which
+          exceeds the specified bounds MUST NOT be selected.
+          
+          TE paths that traverse TE links which have at least one
+          link metric which exceeds the specified bounds MUST NOT
+          be selected.";
         leaf metric-type {
           type identityref {
-            base path-metric-type;
+            base link-path-metric-type;
           }
           description
             "Identifies an entry in the list of 'metric-type' items
@@ -4410,18 +4696,21 @@ module ietf-te-types {
           type uint64;
           default "0";
           description
-            "Upper bound on the end-to-end TE path metric.
+            "Upper bound on the specified 'metric-type'.
             
             A zero indicates an unbounded upper limit for the
-            specific 'metric-type'.
+            specificied 'metric-type'.
             
             The unit of is interpreted in the context of the
-            path-metric-type.";
+            'metric-type' identity.";
         }
       }
     }
   }
 
+  // CHANGE NOTE: The grouping generic-path-metric-bounds below
+  // has been updated in this module revision
+  // RFC Editor: remove the note above and this note
   grouping generic-path-optimization {
     description
       "TE generic path optimization grouping.";
@@ -4444,7 +4733,11 @@ module ietf-te-types {
           /* Tiebreakers */
           container tiebreakers {
             description
-              "Container for the list of tiebreakers.";
+              "Container for the list of tiebreakers.
+              
+              This container has been obsoleted by the tiebreaker
+              leaf.";
+            status deprecated;
             list tiebreaker {
               key "tiebreaker-type";
               description
@@ -4479,6 +4772,15 @@ module ietf-te-types {
           }
         }
       }
+    }
+    leaf tiebreaker {
+      type identityref {
+        base path-tiebreaker-type;
+      }
+      default "te-types:path-tiebreaker-random";
+      description
+        "The tiebreaker criteria to apply on an equally favored set
+        of paths, in order to pick the best.";
     }
   }
 
@@ -4684,7 +4986,7 @@ module ietf-te-types {
       description
         "LSP encoding type.";
       reference
-        "RFC3945";
+        "RFC 3945";
     }
     leaf switching-type {
       type identityref {
@@ -4693,7 +4995,7 @@ module ietf-te-types {
       description
         "LSP switching type.";
       reference
-        "RFC3945";
+        "RFC 3945";
     }
   }
 
@@ -4804,18 +5106,20 @@ module ietf-te-packet-types {
      This version of this YANG module is part of RFC XXXX
      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
      for full legal notices.";
-  revision 2024-01-25 {
+  revision 2024-02-16 {
     description
-      "Added common TE packet identities:
+      "This revision adds the following new identities:
        - bandwidth-profile-type;
-       - path-metric-loss;
-       - path-metric-delay-variation.
+       - link-metric-delay-variation;
+       - link-metric-loss;
+       - path-metric-delay-variation;
+       - path-metric-loss.
 
-       Added common TE packet groupings:
+      This revision adds the following new groupings:
        - te-packet-path-bandwidth;
        - te-packet-link-bandwidth.
        
-       Updated module description.";
+      This revision provides also few editorial changes.";
     reference
       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
   }
@@ -4875,57 +5179,64 @@ module ietf-te-packet-types {
         Marker with Efficient Handling of in-Profile Traffic";
     }
 
-  // CHANGE NOTE: The identity path-metric-loss below has 
-  // been added in this module revision
-  // RFC Editor: remove the note above and this note
-  identity path-metric-loss {
-    base te-types:path-metric-type;
-    description
-      "The path loss (as a packet percentage) metric type
-      encodes a function of the unidirectional loss metrics of all
-      links traversed by a P2P path.
-       
-      The basic unit is 0.000003%,
-      where (2^24 - 2) or 50.331642% is the maximum value of the
-      path loss percentage that can be expressed.
-      
-      Values that are larger than the maximum value SHOULD be
-      encoded as the maximum value.";
-    reference
-      "RFC8233: Extensions to the Path Computation Element
-      Communication Protocol (PCEP) to Compute Service-Aware Label
-      Switched Paths (LSPs);
+    // CHANGE NOTE: The identity link-metric-delay-variation
+    // below has been added in this module revision
+    // RFC Editor: remove the note above and this note
+    identity link-metric-delay-variation {
+      base te-types:link-metric-type;
+      description
+        "The Unidirectional Delay Variation Metric,
+        measured in units of microseconds.";
+      reference
+        "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+        section 4.3
 
-      RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
+        RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+        section 4.3";
+    }
 
-      RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
-  }
+    // CHANGE NOTE: The identity link-metric-loss below has 
+    // been added in this module revision
+    // RFC Editor: remove the note above and this note
+    identity link-metric-loss {
+      base te-types:link-metric-type;
+      description
+        "The Unidirectional Link Loss Metric,
+        measured in units of 0.000003%.";
+      reference
+        "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+        section 4.4
 
-  // CHANGE NOTE: The identity path-metric-delay-variation below has 
-  // been added in this module revision
-  // RFC Editor: remove the note above and this note
-  identity path-metric-delay-variation {
-    base te-types:path-metric-type;
-    description
-      "The path delay variation encodes the sum of the unidirectional
-      delay variation metrics of all links traversed by a P2P path.
-      
-      The path delay variation metric unit is in microseconds, where
-      (2^24 - 1) or 16,777,215 microseconds (16.777215 sec) is the
-      maximum value of the path delay variation that can be
-      expressed.
-      
-      Values that are larger than the maximum value SHOULD be
-      encoded as the maximum value.";
-    reference
-      "RFC8233: Extensions to the Path Computation Element
-      Communication Protocol (PCEP) to Compute Service-Aware Label
-      Switched Paths (LSPs);
+        RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+        section 4.4";
+    }
 
-      RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
+    // CHANGE NOTE: The identity path-metric-delay-variation
+    // below has been added in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-delay-variation {
+      base te-types:path-metric-type;
+      description
+        "The Path Delay Variation Metric,
+        measured in units of microseconds.";
+      reference
+        "RFC8233: Extensions to the Path Computation Element
+        Communication Protocol (PCEP) to Compute Service-Aware Label
+        Switched Paths (LSPs), section 3.1.2";
+    }
 
-      RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
-  }
+    // CHANGE NOTE: The identity path-metric-loss below has 
+    // been added in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-loss {
+      base te-types:path-metric-type;
+      description
+        "The Path Loss Metric, measured in units of 0.000003%.";
+      reference
+        "RFC8233: Extensions to the Path Computation Element
+        Communication Protocol (PCEP) to Compute Service-Aware Label
+        Switched Paths (LSPs), section 3.1.3";
+    }
 
   /*
    * Typedefs
@@ -5871,123 +6182,6 @@ Names" registry <xref target="RFC7950"/>:</t>
   <seriesInfo name="ITU-T G.709" value=""/>
 </reference>
 
-
-
-<reference anchor='I-D.ietf-teas-yang-te' target='https://datatracker.ietf.org/doc/html/draft-ietf-teas-yang-te-35'>
-   <front>
-      <title>A YANG Data Model for Traffic Engineering Tunnels, Label Switched Paths and Interfaces</title>
-      <author fullname='Tarek Saad' initials='T.' surname='Saad'>
-         <organization>Cisco Systems Inc</organization>
-      </author>
-      <author fullname='Rakesh Gandhi' initials='R.' surname='Gandhi'>
-         <organization>Cisco Systems Inc</organization>
-      </author>
-      <author fullname='Xufeng Liu' initials='X.' surname='Liu'>
-         <organization>Alef Edge</organization>
-      </author>
-      <author fullname='Vishnu Pavan Beeram' initials='V. P.' surname='Beeram'>
-         <organization>Juniper Networks</organization>
-      </author>
-      <author fullname='Igor Bryskin' initials='I.' surname='Bryskin'>
-         <organization>Individual</organization>
-      </author>
-      <date day='12' month='January' year='2024'/>
-      <abstract>
-	 <t>   This document defines a YANG data model for the provisioning and
-   management of Traffic Engineering (TE) tunnels, Label Switched Paths
-   (LSPs), and interfaces.  The model covers data that is independent of
-   any technology or dataplane encapsulation and is divided into two
-   YANG modules that cover device-specific, and device independent data.
-
-   This model covers data for configuration, operational state, remote
-   procedural calls, and event notifications.
-
-	 </t>
-      </abstract>
-   </front>
-   <seriesInfo name='Internet-Draft' value='draft-ietf-teas-yang-te-35'/>
-   
-</reference>
-
-
-<reference anchor='I-D.ietf-teas-yang-path-computation' target='https://datatracker.ietf.org/doc/html/draft-ietf-teas-yang-path-computation-21'>
-   <front>
-      <title>A YANG Data Model for requesting path computation</title>
-      <author fullname='Italo Busi' initials='I.' surname='Busi'>
-         <organization>Huawei Technologies</organization>
-      </author>
-      <author fullname='Sergio Belotti' initials='S.' surname='Belotti'>
-         <organization>Nokia</organization>
-      </author>
-      <author fullname='Oscar Gonzalez de Dios' initials='O. G.' surname='de Dios'>
-         <organization>Telefonica</organization>
-      </author>
-      <author fullname='Anurag Sharma' initials='A.' surname='Sharma'>
-         <organization>Google</organization>
-      </author>
-      <author fullname='Yan Shi' initials='Y.' surname='Shi'>
-         <organization>China Unicom</organization>
-      </author>
-      <date day='7' month='July' year='2023'/>
-      <abstract>
-	 <t>   There are scenarios, typically in a hierarchical Software-Defined
-   Networking (SDN) context, where the topology information provided by
-   a Traffic Engineering (TE) network provider may be insufficient for
-   its client to perform multi-domain path computation.  In these cases
-   the client would need to request the TE network provider to compute
-   some intra-domain paths to be used by the client to choose the
-   optimal multi-domain paths.
-
-   This document provides a mechanism to request path computation by
-   augmenting the Remote Procedure Calls (RPCs) defined in RFC YYYY.
-
-   [RFC EDITOR NOTE: Please replace RFC YYYY with the RFC number of
-   draft-ietf-teas-yang-te once it has been published.
-
-   Moreover, this document describes some use cases where the path
-   computation request, via YANG-based protocols (e.g., NETCONF or
-   RESTCONF), can be needed.
-
-	 </t>
-      </abstract>
-   </front>
-   <seriesInfo name='Internet-Draft' value='draft-ietf-teas-yang-path-computation-21'/>
-   
-</reference>
-
-
-<reference anchor='I-D.ietf-teas-yang-l3-te-topo' target='https://datatracker.ietf.org/doc/html/draft-ietf-teas-yang-l3-te-topo-15'>
-   <front>
-      <title>YANG Data Model for Layer 3 TE Topologies</title>
-      <author fullname='Xufeng Liu' initials='X.' surname='Liu'>
-         <organization>Alef Edge</organization>
-      </author>
-      <author fullname='Igor Bryskin' initials='I.' surname='Bryskin'>
-         <organization>Individual</organization>
-      </author>
-      <author fullname='Vishnu Pavan Beeram' initials='V. P.' surname='Beeram'>
-         <organization>Juniper Networks</organization>
-      </author>
-      <author fullname='Tarek Saad' initials='T.' surname='Saad'>
-         <organization>Cisco Systems Inc</organization>
-      </author>
-      <author fullname='Himanshu C. Shah' initials='H. C.' surname='Shah'>
-         <organization>Ciena</organization>
-      </author>
-      <author fullname='Oscar Gonzalez de Dios' initials='O. G.' surname='de Dios'>
-         <organization>Telefonica</organization>
-      </author>
-      <date day='21' month='October' year='2023'/>
-      <abstract>
-	 <t>   This document defines a YANG data model for layer 3 traffic
-   engineering topologies.
-
-	 </t>
-      </abstract>
-   </front>
-   <seriesInfo name='Internet-Draft' value='draft-ietf-teas-yang-l3-te-topo-15'/>
-   
-</reference>
 
 <reference anchor='RFC7471' target='https://www.rfc-editor.org/info/rfc7471'>
   <front>
@@ -6946,7 +7140,150 @@ Names" registry <xref target="RFC7950"/>:</t>
 
 <section anchor="changes-bis"><name>Changes from RFC 8776</name>
 
-<t>To be added in a future revision of this draft.</t>
+<t>This version adds new common data types, identities, and groupings to the YANG modules. It also updates some of the existing data types, identities, and groupings in the YANG modules and fixes few bugs in <xref target="RFC8776"/>.</t>
+
+<t>The following new identities have been added to the 'ietf-te-types' module:</t>
+
+<t><list style="symbols">
+  <t>lsp-provisioning-error-reason;</t>
+  <t>association-type-diversity;</t>
+  <t>tunnel-admin-state-auto;</t>
+  <t>lsp-restoration-restore-none;</t>
+  <t>restoration-scheme-rerouting;</t>
+  <t>path-metric-optimization-type;</t>
+  <t>link-path-metric-type;</t>
+  <t>link-metric-type and its derived identities;</t>
+  <t>path-computation-error-reason and its derived identities;</t>
+  <t>protocol-origin-type and its derived identities;</t>
+  <t>svec-objective-function-type and its derived identities;</t>
+  <t>svec-metric-type and its derived identities.</t>
+</list></t>
+
+<t>The following new data types have been added to the 'ietf-te-types' module:</t>
+
+<t><list style="symbols">
+  <t>path-type;</t>
+  <t>te-gen-node-id.</t>
+</list></t>
+
+<t>The following new groupings have been added to the 'ietf-te-types' module:</t>
+
+<t><list style="symbols">
+  <t>encoding-and-switching-type;</t>
+  <t>te-generic-node-id.</t>
+</list></t>
+
+<t>The following new identities have been added to the 'ietf-te-packet-types' module:</t>
+
+<t><list style="symbols">
+  <t>bandwidth-profile-type;</t>
+  <t>link-metric-delay-variation;</t>
+  <t>link-metric-loss;</t>
+  <t>path-metric-delay-variation;</t>
+  <t>path-metric-loss.</t>
+</list></t>
+
+<t>The following new groupings have been added to the 'ietf-te-packet-types' module:</t>
+
+<t><list style="symbols">
+  <t>te-packet-path-bandwidth;</t>
+  <t>te-packet-link-bandwidth.</t>
+</list></t>
+
+<t>The following identities, already defined in <xref target="RFC8776"/>, have been updated in the 'ietf-te-types' module:</t>
+
+<t><list style="symbols">
+  <t>objective-function-type (editorial);</t>
+  <t>action-exercise (bug fix);</t>
+  <t>path-metric-type:  <vspace blankLines='1'/>
+new base identities have been added;</t>
+  <t>path-metric-te (bug fix);</t>
+  <t>path-metric-igp (bug fix);</t>
+  <t>path-metric-hop (bug fix);</t>
+  <t>path-metric-delay-average (bug fix);</t>
+  <t>path-metric-delay-minimum (bug fix);</t>
+  <t>path-metric-residual-bandwidth (bug fix);</t>
+  <t>path-metric-optimize-includes (bug fix);</t>
+  <t>path-metric-optimize-excludes (bug fix);</t>
+  <t>te-optimization-criterion (editorial).</t>
+</list></t>
+
+<t>The following data type, already defined in <xref target="RFC8776"/>, has been updated in the 'ietf-te-types' module:</t>
+
+<t><list style="symbols">
+  <t>te-node-id;  <vspace blankLines='1'/>
+The data type has been changed to be a union.</t>
+</list></t>
+
+<t>The following groupings, already defined in <xref target="RFC8776"/>, have been updated in the 'ietf-te-types' module:</t>
+
+<t><list style="symbols">
+  <t>explicit-route-hop  <vspace blankLines='1'/>
+The following new leaves have been added to the 'explicit-route-hop' grouping:  <list style="symbols">
+      <t>node-id-uri;</t>
+      <t>link-tp-id-uri;</t>
+    </list>
+The following leaves, already defined in <xref target="RFC8776"/>, have been updated in the 'explicit-route-hop':  <list style="symbols">
+      <t>node-id;</t>
+      <t>link-tp-id.      <vspace blankLines='1'/>
+The mandatory true statements for the node-id and link-tp-id have been replaced by must statements that requires at least the presence of:      <list style="symbols">
+          <t>node-id or node-id-uri;</t>
+          <t>link-tp-id or link-tp-id-uri.</t>
+        </list></t>
+    </list></t>
+  <t>explicit-route-hop  <vspace blankLines='1'/>
+The following new leaves have been added to the 'explicit-route-hop' grouping:  <list style="symbols">
+      <t>node-id-uri;</t>
+      <t>link-tp-id-uri;</t>
+    </list>
+The following leaves, already defined in <xref target="RFC8776"/>, have been updated in the 'explicit-route-hop':  <list style="symbols">
+      <t>node-id;</t>
+      <t>link-tp-id.      <vspace blankLines='1'/>
+The mandatory true statements for the node-id and link-tp-id have been replaced by must statements that requires at least the presence of:      <list style="symbols">
+          <t>node-id or node-id-uri;</t>
+          <t>link-tp-id or link-tp-id-uri.</t>
+        </list></t>
+    </list></t>
+  <t>optimization-metric-entry:  <vspace blankLines='1'/>
+The following leaves, already defined in <xref target="RFC8776"/>, have been updated in the 'optimization-metric-entry':  <list style="symbols">
+      <t>metric-type;      <vspace blankLines='1'/>
+The base identity has been updated without impacting the set of derived identities that are allowed.</t>
+    </list></t>
+  <t>tunnel-constraints;  <vspace blankLines='1'/>
+The following new leaf have been added to the 'tunnel-constraints' grouping:  <list style="symbols">
+      <t>network-id;</t>
+    </list></t>
+  <t>path-constraints-route-objects:  <vspace blankLines='1'/>
+The following container, already defined in <xref target="RFC8776"/>, has been updated in the 'path-constraints-route-objects':  <list style="symbols">
+      <t>explicit-route-objects-always;      <vspace blankLines='1'/>
+The container has been renamed as 'explicit-route-objects'. This change is not affecting any IETF standard YANG models since this grouping has not yet been used by any YANG model defined in existing IETF RFCs.</t>
+    </list></t>
+  <t>generic-path-metric-bounds:  <vspace blankLines='1'/>
+The following leaves, already defined in <xref target="RFC8776"/>, have been updated in the 'optimization-metric-entry':  <list style="symbols">
+      <t>metric-type;      <vspace blankLines='1'/>
+The base identity has been updated to:      <list style="symbols">
+          <t>increase the set of derived identities that are allowed and;</t>
+          <t>remove from this set the 'path-metric-optimize-includes' and the 'path-metric-optimize-excludes' identities (bug fixing)</t>
+        </list></t>
+    </list></t>
+  <t>generic-path-optimization  <vspace blankLines='1'/>
+The following new leaf have been added to the 'generic-path-optimization' grouping:  <list style="symbols">
+      <t>tiebreaker;</t>
+    </list>
+The following container, already defined in <xref target="RFC8776"/>, has been deprecated:  <list style="symbols">
+      <t>tiebreakers.</t>
+    </list></t>
+</list></t>
+
+<t>The following identities, already defined in <xref target="RFC8776"/>, have been obsoletes in the 'ietf-te-types' module for bug fixing:</t>
+
+<t><list style="symbols">
+  <t>of-minimize-agg-bandwidth-consumption;</t>
+  <t>of-minimize-load-most-loaded-link;</t>
+  <t>of-minimize-cost-path-set;</t>
+  <t>lsp-protection-reroute-extra;</t>
+  <t>lsp-protection-reroute.</t>
+</list></t>
 
 <section anchor="te-yang-diff"><name>TE Types YANG Diffs</name>
 
@@ -6992,61 +7329,134 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 <      the license terms contained in, the Simplified BSD License set
 ---
 >      the license terms contained in, the Revised BSD License set
-65,66c75,113
+65,66c75,164
 <      This version of this YANG module is part of RFC 8776; see the
 <      RFC itself for full legal notices.";
 ---
 >      This version of this YANG module is part of RFC XXXX
 >      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
 >      for full legal notices.";
->   revision 2024-01-29 {
+>   revision 2024-02-16 {
 >     description
->       "Added:
->       - base identity lsp-provisioning-error-reason;
->       - identity association-type-diversity;
->       - identity tunnel-admin-state-auto;
->       - identity lsp-restoration-restore-none;
->       - identity restoration-scheme-rerouting;
->       - base identity path-computation-error-reason and
->         its derived identities;
->       - base identity protocol-origin-type and
->         its derived identities;
->       - base identity svec-objective-function-type and its derived
->         identities;
->       - base identity svec-metric-type and its derived identities;
->       - grouping encoding-and-switching-type.
->       
->       Updated:
->       - description of the base identity objective-function-type;
->       - description and reference of identity action-exercise;
->       - typedef te-node-id to support also 16 octects TE identifiers.
->       
->       Obsoleted:
->       - identity of-minimize-agg-bandwidth-consumption;
->       - identity of-minimize-load-most-loaded-link;
->       - identity of-minimize-cost-path-set;
->       - identity lsp-protection-reroute-extra;
->       - identity lsp-protection-reroute.
+>       "This revision adds the following new identities:
+>       - lsp-provisioning-error-reason;
+>       - association-type-diversity;
+>       - tunnel-admin-state-auto;
+>       - lsp-restoration-restore-none;
+>       - restoration-scheme-rerouting;
+>       - path-metric-optimization-type;
+>       - link-path-metric-type;
+>       - link-metric-type and its derived identities;
+>       - path-computation-error-reason and its derived identities;
+>       - protocol-origin-type and its derived identities;
+>       - svec-objective-function-type and its derived identities;
+>       - svec-metric-type and its derived identities.
 > 
->       Container explicit-route-objects-always renamed as
->       explicit-route-objects.";
+>       This revision adds the following new data types:
+>       - path-type;
+>       - te-gen-node-id.
+> 
+>       This revision adds the following new groupings:
+>       - encoding-and-switching-type;
+>       - te-generic-node-id.
+> 
+>       This revision updates the following identities:
+>       - objective-function-type;
+>       - action-exercise;
+>       - path-metric-type;
+>       - path-metric-te;
+>       - path-metric-igp;
+>       - path-metric-hop;
+>       - path-metric-delay-average;
+>       - path-metric-delay-minimum;
+>       - path-metric-residual-bandwidth;
+>       - path-metric-optimize-includes;
+>       - path-metric-optimize-excludes;
+>       - te-optimization-criterion.
+> 
+>       This revision updates the following data types:
+>       - te-node-id.
+> 
+>       This revision updates the following groupings:
+>       - explicit-route-hop:
+>         - adds the following leaves:
+>           - node-id-uri;
+>           - link-tp-id-uri;
+>         - updates the following leaves:
+>           - node-id;
+>           - link-tp-id;
+>       - record-route-state:
+>         - adds the following leaves:
+>           - node-id-uri;
+>           - link-tp-id-uri;
+>         - updates the following leaves:
+>           - node-id;
+>           - link-tp-id;
+>       - optimization-metric-entry:
+>         - updates the following leaves:
+>           - metric-type;
+>       - tunnel-constraints;
+>         - adds the following leaves:
+>           - network-id;
+>       - path-constraints-route-objects:
+>         - updates the following containers:
+>           - explicit-route-objects-always;
+>       - generic-path-metric-bounds:
+>         - updates the following leaves:
+>           - metric-type;
+>       - generic-path-optimization
+>         - adds the following leaves:
+>           - tiebreaker;
+>         - deprecate the following containers:
+>           - tiebreakers.
+> 
+>       This revision obsoletes the following identities:
+>       - of-minimize-agg-bandwidth-consumption;
+>       - of-minimize-load-most-loaded-link;
+>       - of-minimize-cost-path-set;
+>       - lsp-protection-reroute-extra;
+>       - lsp-protection-reroute.
+> 
+>       This revision provides also few editorial changes.";
 >     reference
 >       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
 >   }
 >   // RFC Editor: replace XXXX with actual RFC number, update date
 >   // information and remove this note
-351a399,401
+70c168
+<       "Latest revision of TE types.";
+---
+>       "Initial Version of TE types.";
+86a185
+> 
+92a192
+> 
+93a194
+>        
+111a213
+> 
+155a258
+> 
+158a262
+> 
+263a368
+> 
+264a370
+> 
+269a376
+> 
+351a459,461
 >   // CHANGE NOTE: The typedef te-node-id below has been
 >   // updated in this module revision
 >   // RFC Editor: remove the note above and this note
-353c403,406
+353c463,466
 <     type yang:dotted-quad;
 ---
 >     type union {
 >       type yang:dotted-quad;
 >       type inet:ipv6-address-no-zone;
 >     }
-357,358c410,414
+357,358c470,474
 <        The identifier is represented as 4 octets in dotted-quad
 <        notation.
 ---
@@ -7055,7 +7465,7 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >        dotted-quad notation or 16 octets in full, mixed, shortened,
 >        or shortened-mixed IPv6 address notation.
 > 
-362,363c418,421
+362,363c478,481
 <        Router ID TLV described in Section 4.3 of RFC 5305, or the
 <        TE Router ID TLV described in Section 3.2.1 of RFC 6119.
 ---
@@ -7063,13 +7473,17 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >        Router ID TLV described in Section 3.2.1 of RFC 6119, or the
 >        IPv6 TE Router ID TLV described in Section 4.1 of RFC 6119.
 > 
-368a427
+368a487
 > 
-370a430
+370a490
 > 
-371a432
+371a492
 > 
-545a607,647
+519a641
+> 
+537a660
+> 
+545a669,709
 >   // CHANGE NOTE: The typedef path-type below has been
 >   // added in this module revision
 >   // RFC Editor: remove the note above and this note
@@ -7111,7 +7525,7 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >       "Generic type that identifies a node in a TE topology.";
 >   }
 > 
-606a709,716
+606a771,778
 >   // CHANGE NOTE: The base identity lsp-provisioning-error-reason 
 >   // has been added in this module revision
 >   // RFC Editor: remove the note above and this note
@@ -7120,7 +7534,7 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >       "Base identity for LSP provisioning errors.";
 >   }
 > 
-982a1093,1110
+982a1155,1172
 >   // CHANGE NOTE: The identity association-type-diversity below has 
 >   // been added in this module revision
 >   // RFC Editor: remove the note above and this note
@@ -7130,7 +7544,7 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >       "Association Type diversity used to associate LSPs whose 
 >       paths are to be diverse from each other.";
 >     reference
->       "RFC8800: Path Computation Element Communication Protocol 
+>       "RFC 8800: Path Computation Element Communication Protocol 
 >       (PCEP) Extension for Label Switched Path (LSP) Diversity 
 >       Constraint Signaling";
 >   }
@@ -7139,45 +7553,92 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >   // objective-function-type has been updated 
 >   // in this module revision
 >   // RFC Editor: remove the note above and this note
-985c1113
+985c1175
 <       "Base objective function type.";
 ---
->       "Base identity for path objective function type.";
-1015a1144,1146
+>       "Base identity for path objective function types.";
+1015a1206,1208
 >   // CHANGE NOTE: The identity of-minimize-agg-bandwidth-consumption
 >   // below has been obsoleted in this module revision
 >   // RFC Editor: remove the note above and this note
-1017a1149
+1017a1211
 >     status obsolete;
-1020c1152
+1020c1214,1218
 <        consumption.";
 ---
->       consumption.";
-1023c1155
+>       consumption.
+>       
+>       This identity has been obsoleted: the
+>       'svec-of-minimize-agg-bandwidth-consumption' identity SHOULD
+>       be used instead.";
+1023c1221
 <        Computation Element Communication Protocol (PCEP)";
 ---
 >       Computation Element Communication Protocol (PCEP)";
-1025a1158,1160
+1025a1224,1226
 >   // CHANGE NOTE: The identity of-minimize-load-most-loaded-link
 >   // below has been obsoleted in this module revision
 >   // RFC Editor: remove the note above and this note
-1027a1163
+1027a1229
 >     status obsolete;
-1030c1166
+1030c1232,1236
 <        is carrying the highest load.";
 ---
->       is carrying the highest load.";
-1033c1169
+>       is carrying the highest load.
+>       
+>       This identity has been obsoleted: the
+>       'svec-of-minimize-load-most-loaded-link' identity SHOULD
+>       be used instead.";
+1033c1239
 <        Computation Element Communication Protocol (PCEP)";
 ---
 >       Computation Element Communication Protocol (PCEP)";
-1035a1172,1174
+1035a1242,1244
 >   // CHANGE NOTE: The identity of-minimize-cost-path-set
 >   // below has been obsoleted in this module revision
 >   // RFC Editor: remove the note above and this note
-1037a1177
+1037a1247
 >     status obsolete;
-1216a1357,1368
+1039c1249,1253
+<       "Objective function for minimizing the cost on a path set.";
+---
+>       "Objective function for minimizing the cost on a path set.
+>       
+>       This identity has been obsoleted: the
+>       'svec-of-minimize-cost-path-set' identity SHOULD
+>       be used instead.";
+1049a1264,1266
+>   // CHANGE NOTE: The reference of the identity path-locally-computed
+>   // below has been updated in this module revision
+>   // RFC Editor: remove the note above and this note
+1056,1057c1273,1274
+<       "RFC 3272: Overview and Principles of Internet Traffic
+<        Engineering, Section 5.4";
+---
+>       "RFC 9522: Overview and Principles of Internet Traffic
+>       Engineering, Section 4.4";
+1059a1277,1280
+>   // CHANGE NOTE: The reference of the identity 
+>   // path-externally-queried below has been updated
+>   // in this module revision
+>   // RFC Editor: remove the note above and this note
+1071c1292
+<       "RFC 3272: Overview and Principles of Internet Traffic
+---
+>       "RFC 9522: Overview and Principles of Internet Traffic
+1072a1294
+> 
+1076a1299,1302
+>   // CHANGE NOTE: The reference of the identity 
+>   // path-explicitly-defined below has been updated
+>   // in this module revision
+>   // RFC Editor: remove the note above and this note
+1085c1311,1312
+<        RFC 3272: Overview and Principles of Internet Traffic
+---
+> 
+>        RFC 9522: Overview and Principles of Internet Traffic
+1216a1444,1455
 >   // CHANGE NOTE: The identity tunnel-admin-state-auto below
 >   // has been added in this module revision
 >   // RFC Editor: remove the note above and this note
@@ -7190,7 +7651,7 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >       when it is not used by the client layer.";
 >   }
 > 
-1321a1474,1482
+1321a1561,1569
 >     // CHANGE NOTE: The identity lsp-restoration-restore-none 
 >     // below has been added in this module revision
 >     // RFC Editor: remove the note above and this note
@@ -7200,7 +7661,7 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         "No LSP affected by a failure is restored.";
 >     }
 > 
-1339a1501,1515
+1339a1588,1602
 >     // CHANGE NOTE: The identity restoration-scheme-rerouting 
 >     // below has been added in this module revision
 >     // RFC Editor: remove the note above and this note
@@ -7216,13 +7677,13 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         for Generalized Multi-Protocol Label Switching (GMPLS)";
 >     }
 > 
-1383a1560,1562
+1383a1647,1649
 >   // CHANGE NOTE: The identity lsp-protection-reroute-extra
 >   // below has been obsoleted in this module revision
 >   // RFC Editor: remove the note above and this note
-1385a1565
+1385a1652
 >     status obsolete;
-1387c1567,1571
+1387c1654,1658
 <       "'(Full) Rerouting' LSP protection type.";
 ---
 >       "'(Full) Rerouting' LSP protection type.
@@ -7230,13 +7691,13 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >       This identity has been obsoleted: the
 >       'restoration-scheme-rerouting' identity SHOULD be used
 >       instead.";
-1392a1577,1579
+1392a1664,1666
 >   // CHANGE NOTE: The identity lsp-protection-reroute
 >   // below has been obsoleted in this module revision
 >   // RFC Editor: remove the note above and this note
-1394a1582
+1394a1669
 >     status obsolete;
-1396c1584,1588
+1396c1671,1675
 <       "'Rerouting without Extra-Traffic' LSP protection type.";
 ---
 >       "'Rerouting without Extra-Traffic' LSP protection type.
@@ -7244,46 +7705,327 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >       This identity has been obsoleted: the
 >       'restoration-scheme-rerouting' identity SHOULD be used
 >       instead.";
-1628a1821,1824
+1628a1908,1911
 >   // CHANGE NOTE: The description and reference of the 
 >   // identity action-exercise have been updated in this module 
 >   // revision
 >   // RFC Editor: remove the note above and this note
-1632,1633c1828,1830
+1632,1633c1915,1917
 <       "An action that starts testing whether or not APS communication
 <        is operating correctly.  It is of lower priority than any
 ---
 >       "An action that starts testing whether or not Automatic 
 >        Protection Switching (APS) communication is operating 
 >        correctly.  It is of lower priority than any
-1636,1637c1833,1834
+1636,1637c1920,1921
 <       "RFC 4427: Recovery (Protection and Restoration) Terminology
 <        for Generalized Multi-Protocol Label Switching (GMPLS)";
 ---
 >       "ITU-T G.808.1 v4.0 (05/2014): Generic protection switching - 
 >       Linear trail and subnetwork protection";
-1916a2114,2116
->   // CHANGE NOTE: The description of the identity path-metric-type
->   // has been updated in this module revision
->   // RFC Editor: remove the note above and this note
-1919c2119,2122
-<       "Base identity for the path metric type.";
+1917c2201,2204
+<   identity path-metric-type {
 ---
->       "Base identity for the path metric type.
->       
->       Derived identities SHOULD describe the unit and maximum value
->       of the path metric types they define.";
-1939a2143,2145
->   // CHANGE NOTE: The reference for the identity path-metric-hop
+>   // CHANGE NOTE: The path-metric-optimization-type base identity
 >   // has been added in this module revision
 >   // RFC Editor: remove the note above and this note
-1943a2150,2152
->     reference
->       "RFC5440: Path Computation Element (PCE) Communication
->       Protocol (PCEP)";
-1945a2155
+>   identity path-metric-optimization-type {
+1919c2206,2207
+<       "Base identity for the path metric type.";
+---
+>       "Base identity used to define the path metric optimization
+>       types.";
+1922,1923c2210,2213
+<   identity path-metric-te {
+<     base path-metric-type;
+---
+>   // CHANGE NOTE: The link-path-metric-type base identity
+>   // has been added in this module revision
+>   // RFC Editor: remove the note above and this note
+>   identity link-path-metric-type {
+1925,1928c2215,2221
+<       "TE path metric.";
+<     reference
+<       "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+<        second MPLS Traffic Engineering (TE) Metric";
+---
+>       "Base identity used to define the link and the path metric
+>       types.
+>       
+>       The unit of the path metric value is interpreted in the
+>       context of the path metric type and the derived identities
+>       SHOULD describe the unit of the path metric types they
+>       define.";
+1931,1938c2224,2232
+<   identity path-metric-igp {
+<     base path-metric-type;
+<     description
+<       "IGP path metric.";
+<     reference
+<       "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+<        second MPLS Traffic Engineering (TE) Metric";
+<   }
+---
+>     // CHANGE NOTE: The link-metric-type base identity
+>     // and its derived identities
+>     // have been added in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity link-metric-type {
+>       base link-path-metric-type;
+>       description
+>         "Base identity for the link metric types.";
+>     }
+1940,1944c2234,2240
+<   identity path-metric-hop {
+<     base path-metric-type;
+<     description
+<       "Hop path metric.";
+<   }
+---
+>       identity link-metric-te {
+>         base link-metric-type;
+>         description
+>           "Traffic Engineering (TE) Link Metric.";
+>         reference
+>           "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+>           Version 2, section 2.5.5
+1946,1952c2242,2244
+<   identity path-metric-delay-average {
+<     base path-metric-type;
+<     description
+<       "Average unidirectional link delay.";
+<     reference
+<       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+<   }
+---
+>           RFC 5305: IS-IS Extensions for Traffic Engineering,
+>           section 3.7";
+>       }
+1954,1960c2246,2253
+<   identity path-metric-delay-minimum {
+<     base path-metric-type;
+<     description
+<       "Minimum unidirectional link delay.";
+<     reference
+<       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+<   }
+---
+>       identity link-metric-igp {
+>         base link-metric-type;
+>         description
+>           "Interior Gateway Protocol (IGP) Link Metric.";
+>         reference
+>           "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric
+>           as a second MPLS Traffic Engineering (TE) Metric";
+>       }
+1962,1972c2255,2266
+<   identity path-metric-residual-bandwidth {
+<     base path-metric-type;
+<     description
+<       "Unidirectional Residual Bandwidth, which is defined to be
+<        Maximum Bandwidth (RFC 3630) minus the bandwidth currently
+<        allocated to LSPs.";
+<     reference
+<       "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+<        Version 2
+<        RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+<   }
+---
+>       identity link-metric-delay-average {
+>         base link-metric-type;
+>         description
+>           "Unidirectional Link Delay, measured in units of
+>           microseconds.";
+>         reference
+>           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+>           Extensions, section 4.1
+>           
+>           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+>           Extensions, section 4.1";
+>       }
+1974,1979c2268,2279
+<   identity path-metric-optimize-includes {
+<     base path-metric-type;
+<     description
+<       "A metric that optimizes the number of included resources
+<        specified in a set.";
+<   }
+---
+>       identity link-metric-delay-minimum {
+>         base link-metric-type;
+>         description
+>           "Minimum unidirectional Link Delay, measured in units of
+>           microseconds.";
+>         reference
+>           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+>           Extensions, section 4.2
+>           
+>           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+>           Extensions, section 4.2";
+>       }
+1981,1986c2281,2425
+<   identity path-metric-optimize-excludes {
+<     base path-metric-type;
+<     description
+<       "A metric that optimizes to a maximum the number of excluded
+<        resources specified in a set.";
+<   }
+---
+>       identity link-metric-delay-maximum {
+>         base link-metric-type;
+>         description
+>           "Maximum unidirectional Link Delay, measured in units of
+>           microseconds.";
+>         reference
+>           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+>           Extensions, section 4.2
+>           
+>           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+>           Extensions, section 4.2";
+>       }
 > 
-2110a2321,2724
+>       identity link-metric-residual-bandwidth {
+>         base link-metric-type;
+>         description
+>           "Unidirectional Residual Bandwidth, measured in units of
+>           bytes per second.
+>           
+>           It is defined to be Maximum Bandwidth minus the bandwidth
+>           currently allocated to LSPs.";
+>         reference
+>           "RFC 7471: OSPF Traffic Engineering (TE) Metric
+>           Extensions, section 4.5
+>           
+>           RFC 8570: IS-IS Traffic Engineering (TE) Metric
+>           Extensions, section 4.5";
+>       }
+> 
+>     // CHANGE NOTE: The base and the description of the
+>     // path-metric-type identity
+>     // has been updated in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity path-metric-type {
+>       base link-path-metric-type;
+>       base path-metric-optimization-type;
+>       description
+>         "Base identity for the path metric types.";
+>     }
+> 
+>       // CHANGE NOTE: The description and the reference of the
+>       // path-metric-te identity have been updated
+>       // in this module revision
+>       // RFC Editor: remove the note above and this note
+>       identity path-metric-te {
+>         base path-metric-type;
+>         description
+>           "Traffic Engineering (TE) Path Metric.";
+>         reference
+>           "RFC 5440: Path Computation Element (PCE) Communication
+>           Protocol (PCEP), section 7.8";
+>       }
+> 
+>       // CHANGE NOTE: The description and the reference of the
+>       // path-metric-igp identity have been updated 
+>       // in this module revision
+>       // RFC Editor: remove the note above and this note
+>       identity path-metric-igp {
+>         base path-metric-type;
+>         description
+>           "Interior Gateway Protocol (IGP) Path Metric.";
+>         reference
+>           "RFC 5440: Path Computation Element (PCE) Communication
+>           Protocol (PCEP), section 7.8";
+>       }
+> 
+>       // CHANGE NOTE: The description and the reference of the
+>       // path-metric-hop identity have been updated
+>       // in this module revision
+>       // RFC Editor: remove the note above and this note
+>       identity path-metric-hop {
+>         base path-metric-type;
+>         description
+>           "Hop Count Path Metric.";
+>         reference
+>           "RFC 5440: Path Computation Element (PCE) Communication
+>           Protocol (PCEP), section 7.8";
+>       }
+> 
+>       // CHANGE NOTE: The description and the reference of the
+>       // path-metric-delay-average identity have been updated
+>       // in this module revision
+>       // RFC Editor: remove the note above and this note
+>       identity path-metric-delay-average {
+>         base path-metric-type;
+>         description
+>           "The Path Delay Metric, measured in units of
+>           microseconds.";
+>         reference
+>           "RFC8233: Extensions to the Path Computation Element
+>           Communication Protocol (PCEP) to Compute Service-Aware
+>           Label Switched Paths (LSPs), section 3.1.1";
+>       }
+> 
+>       // CHANGE NOTE: The description and the reference of the
+>       // path-metric-delay-minimum identity have been updated
+>       // in this module revision
+>       // RFC Editor: remove the note above and this note
+>       identity path-metric-delay-minimum {
+>         base path-metric-type;
+>         description
+>           "The Path Min Delay Metric, measured in units of
+>           microseconds.";
+>         reference
+>           "I-D.ietf-pce-sid-algo: Carrying SR-Algorithm information
+>           in PCE-based Networks, section 3.5.1";
+>       }
+> 
+>       // CHANGE NOTE: The description and the reference of the
+>       // path-metric-residual-bandwidth identity have been updated
+>       // in this module revision
+>       // RFC Editor: remove the note above and this note
+>       identity path-metric-residual-bandwidth {
+>         base path-metric-type;
+>         description
+>           "The Path Residual Bandwidth, defined as the minimum Link
+>           Residual Bandwidth all the links along the path.
+> 
+>           The Path Residual Bandwidth can be seen as the path
+>           metric associated with the Maximum residual Bandwidth Path
+>           (MBP) objective function.";
+>         reference
+>           "RFC 5541: Encoding of Objective Functions in the Path
+>           Computation Element Communication Protocol (PCEP)";
+>       }
+> 
+>     // CHANGE NOTE: The base of the path-metric-optimize-includes
+>     // identity has been updated in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity path-metric-optimize-includes {
+>       base path-metric-optimization-type;
+>       description
+>         "A metric that optimizes the number of included resources
+>         specified in a set.";
+>     }
+> 
+>     // CHANGE NOTE: The base of the path-metric-optimize-excludes
+>     // identity has been updated in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity path-metric-optimize-excludes {
+>       base path-metric-optimization-type;
+>       description
+>         "A metric that optimizes to a maximum the number of excluded
+>         resources specified in a set.";
+>     }
+2049a2489,2492
+>   // CHANGE NOTE: The reference of the identity 
+>   // te-optimization-criterion below has been updated
+>   // in this module revision
+>   // RFC Editor: remove the note above and this note
+2054c2497
+<       "RFC 3272: Overview and Principles of Internet Traffic
+---
+>       "RFC 9522: Overview and Principles of Internet Traffic
+2110a2554,2994
 >   // CHANGE NOTE: The base identity path-computation-error-reason 
 >   // and its derived identities below have been
 >   // added in this module revision
@@ -7299,8 +8041,8 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         "Path computation has failed because of an unspecified 
 >         reason.";
 >       reference
->         "Section 7.5 of RFC5440: Path Computation Element (PCE)
->         Communication Protocol (PCEP)";
+>         "RFC 5440: Path Computation Element (PCE) Communication
+>         Protocol (PCEP), section 7.5";
 >     }
 > 
 >     identity path-computation-error-no-topology {
@@ -7320,7 +8062,13 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         a Backward-Recursive Path Computation (BRPC) downstream
 >         PCE or a child PCE.";
 >       reference
->         "RFC5441, RFC8685";
+>         "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+>         Procedure to Compute Shortest Constrained Inter-Domain
+>         Traffic Engineering Label Switched Paths
+>         
+>         RFC 8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture";
 >     }
 > 
 >     identity path-computation-error-pce-unavailable {
@@ -7331,10 +8079,11 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         It corresponds to bit 31 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC5440: Path Computation Element (PCE) Communication
->         Protocol (PCEP);
+>         "RFC 5440: Path Computation Element (PCE) Communication
+>         Protocol (PCEP)
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-no-inclusion-hop {
@@ -7353,9 +8102,12 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         It corresponds to bit 19 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC8685;
+>         "RFC 8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-no-resource {
@@ -7367,9 +8119,12 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         It corresponds to bit 20 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC8685;
+>         "RFC 8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-child-pce-unresponsive {
@@ -7381,9 +8136,12 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         It corresponds to bit 21 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC8685;
+>         "RFC 8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-destination-domain-unknown {
@@ -7395,9 +8153,12 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         It corresponds to bit 22 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC8685;
+>         "RFC 8685: Path Computation Element Communication Protocol 
+>         (PCEP) Extensions for the Hierarchical Path Computation 
+>         Element (H-PCE) Architecture
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-p2mp {
@@ -7409,9 +8170,12 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         It corresponds to bit 24 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC8306;
+>         "RFC 8306: Extensions to the Path Computation Element
+>         Communication Protocol (PCEP) for Point-to-Multipoint
+>         Traffic Engineering Label Switched Paths
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-no-gco-migration {
@@ -7423,9 +8187,12 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         It corresponds to bit 26 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC5557;
+>         "RFC 5557: Path Computation Element Communication Protocol
+>         (PCEP) Requirements and Protocol Extensions in Support of
+>         Global Concurrent Optimization
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-no-gco-solution {
@@ -7437,9 +8204,12 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         It corresponds to bit 25 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC5557;
+>         "RFC 5557: Path Computation Element Communication Protocol
+>         (PCEP) Requirements and Protocol Extensions in Support of
+>         Global Concurrent Optimization
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-pks-expansion {
@@ -7451,9 +8221,12 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         It corresponds to bit 27 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC5520;
+>         "RFC 5520: Preserving Topology Confidentiality in
+>         Inter-Domain Path Computation Using a Path-Key-Based
+>         Mechanism
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-brpc-chain-unavailable {
@@ -7465,9 +8238,12 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         It corresponds to bit 28 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC5441;
+>         "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+>         Procedure to Compute Shortest Constrained Inter-Domain
+>         Traffic Engineering Label Switched Paths
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-source-unknown {
@@ -7479,10 +8255,11 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         It corresponds to bit 29 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC5440: Path Computation Element (PCE) Communication
+>         "RFC 5440: Path Computation Element (PCE) Communication
 >         Protocol (PCEP);
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-destination-unknown {
@@ -7494,10 +8271,11 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         It corresponds to bit 30 of the Flags field of the 
 >         NO-PATH-VECTOR TLV.";
 >       reference
->         "RFC5440: Path Computation Element (PCE) Communication
+>         "RFC 5440: Path Computation Element (PCE) Communication
 >         Protocol (PCEP);
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >     identity path-computation-error-no-server {
@@ -7506,10 +8284,11 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         "Path computation has failed because path computation
 >         server is unavailable.";
 >       reference
->         "RFC5440: Path Computation Element (PCE) Communication
+>         "RFC 5440: Path Computation Element (PCE) Communication
 >         Protocol (PCEP);
 >         
->         https://www.iana.org/assignments/pcep/pcep.xhtml";
+>         https://www.iana.org/assignments/pcep
+>         /pcep.xhtml#no-path-vector-tlv";
 >     }
 > 
 >   // CHANGE NOTE: The base identity protocol-origin-type and 
@@ -7534,7 +8313,7 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         "Protocol origin is Path Computation Engine Protocol 
 >         (PCEP).";
 >       reference
->         "RFC5440: Path Computation Element (PCE) Communication
+>         "RFC 5440: Path Computation Element (PCE) Communication
 >         Protocol (PCEP)";
 >     }
 > 
@@ -7542,7 +8321,7 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >       base protocol-origin-type;
 >       description
 >         "Protocol origin is Border Gateway Protocol (BGP).";
->       reference "RFC9012";
+>       reference "RFC 9012";
 >     }
 > 
 >   // CHANGE NOTE: The base identity svec-objective-function-type 
@@ -7553,8 +8332,8 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >     description
 >       "Base identity for SVEC objective function type.";
 >     reference
->       "RFC5541: Encoding of Objective Functions in the Path
->        Computation Element Communication Protocol (PCEP).";
+>       "RFC 5541: Encoding of Objective Functions in the Path
+>        Computation Element Communication Protocol (PCEP)";
 >   }
 > 
 >     identity svec-of-minimize-agg-bandwidth-consumption {
@@ -7563,8 +8342,8 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         "Objective function for minimizing aggregate bandwidth 
 >         consumption (MBC).";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
 >     identity svec-of-minimize-load-most-loaded-link {
@@ -7573,8 +8352,8 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         "Objective function for minimizing the load on the link that 
 >         is carrying the highest load (MLL).";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
 >     identity svec-of-minimize-cost-path-set {
@@ -7583,8 +8362,8 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         "Objective function for minimizing the cost on a path set 
 >         (MCC).";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
 >     identity svec-of-minimize-common-transit-domain {
@@ -7593,9 +8372,9 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         "Objective function for minimizing the number of common 
 >         transit domains (MCTD).";
 >       reference
->         "RFC8685: Path Computation Element Communication Protocol 
+>         "RFC 8685: Path Computation Element Communication Protocol 
 >         (PCEP) Extensions for the Hierarchical Path Computation 
->         Element (H-PCE) Architecture.";
+>         Element (H-PCE) Architecture";
 >     }
 > 
 >     identity svec-of-minimize-shared-link {
@@ -7604,7 +8383,7 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         "Objective function for minimizing the number of shared 
 >         links (MSL).";
 >       reference
->         "RFC8685: Path Computation Element Communication Protocol 
+>         "RFC 8685: Path Computation Element Communication Protocol 
 >         (PCEP) Extensions for the Hierarchical Path Computation 
 >         Element (H-PCE) Architecture.";
 >     }
@@ -7615,7 +8394,7 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         "Objective function for minimizing the number of shared 
 >         Shared Risk Link Groups (SRLG) (MSS).";
 >       reference
->         "RFC8685: Path Computation Element Communication Protocol 
+>         "RFC 8685: Path Computation Element Communication Protocol 
 >         (PCEP) Extensions for the Hierarchical Path Computation 
 >         Element (H-PCE) Architecture.";
 >     }
@@ -7626,7 +8405,7 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         "Objective function for minimizing the number of shared 
 >         nodes (MSN).";
 >       reference
->         "RFC8685: Path Computation Element Communication Protocol 
+>         "RFC 8685: Path Computation Element Communication Protocol 
 >         (PCEP) Extensions for the Hierarchical Path Computation 
 >         Element (H-PCE) Architecture.";
 >     }
@@ -7639,35 +8418,35 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >     description
 >       "Base identity for SVEC metric type.";
 >     reference
->       "RFC5541: Encoding of Objective Functions in the Path
->        Computation Element Communication Protocol (PCEP).";
+>       "RFC 5541: Encoding of Objective Functions in the Path
+>        Computation Element Communication Protocol (PCEP)";
 >   }
 > 
->     identity svec-metric-cumul-te {
+>     identity svec-metric-cumulative-te {
 >       base svec-metric-type;
 >       description
 >         "Cumulative TE cost.";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
->     identity svec-metric-cumul-igp {
+>     identity svec-metric-cumulative-igp {
 >       base svec-metric-type;
 >       description
 >         "Cumulative IGP cost.";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
->     identity svec-metric-cumul-hop {
+>     identity svec-metric-cumulative-hop {
 >       base svec-metric-type;
 >       description
 >         "Cumulative Hop path metric.";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
 >     identity svec-metric-aggregate-bandwidth-consumption {
@@ -7675,8 +8454,8 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >       description
 >         "Aggregate bandwidth consumption.";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
 >     identity svec-metric-load-of-the-most-loaded-link {
@@ -7684,15 +8463,29 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >       description
 >         "Load of the most loaded link.";
 >       reference
->         "RFC5541: Encoding of Objective Functions in the Path
->         Computation Element Communication Protocol (PCEP).";
+>         "RFC 5541: Encoding of Objective Functions in the Path
+>         Computation Element Communication Protocol (PCEP)";
 >     }
 > 
-2506a3121,3123
+2221,2225c3105,3111
+<       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions
+<        RFC 7823: Performance-Based Path Selection for Explicitly
+<        Routed Label Switched Paths (LSPs) Using TE Metric
+<        Extensions
+<        RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
+---
+>       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensionsù
+>       
+>       RFC 7823: Performance-Based Path Selection for Explicitly
+>       Routed Label Switched Paths (LSPs) Using TE Metric
+>       Extensions
+> 
+>       RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
+2506a3393,3395
 >   // CHANGE NOTE: The explicit-route-hop grouping below has been
 >   // updated in this module revision
 >   // RFC Editor: remove the note above and this note
-2514a3132,3140
+2514a3404,3412
 >           must "node-id-uri or node-id" {
 >             description
 >               "At least one node identifier MUST be present.";
@@ -7702,9 +8495,9 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >             description
 >               "The identifier of a node in the topology.";
 >           }
-2517d3142
+2517d3414
 <             mandatory true;
-2566a3192,3202
+2566a3464,3474
 >           must "(link-tp-id-uri or link-tp-id) and " +
 >                 "(node-id-uri or node-id)" {
 >             description
@@ -7716,30 +8509,34 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >             description
 >               "Link Termination Point (LTP) identifier.";
 >           }
-2569d3204
+2569d3476
 <             mandatory true;
-2574a3210,3214
+2574a3482,3486
 >           leaf node-id-uri {
 >             type nw:node-id;
 >             description
 >               "The identifier of a node in the topology.";
 >           }
-2577d3216
+2577d3488
 <             mandatory true;
-2646a3286,3289
+2631a3543,3545
+>   // CHANGE NOTE: The explicit-route-hop grouping below has been
+>   // updated in this module revision
+>   // RFC Editor: remove the note above and this note
+2646a3561,3564
 >           must "node-id-uri or node-id" {
 >             description
 >               "At least one node identifier MUST be present.";
 >           }
-2648a3292,3296
+2648a3567,3571
 >           leaf node-id-uri {
 >             type nw:node-id;
 >             description
 >               "The identifier of a node in the topology.";
 >           }
-2651d3298
+2651d3573
 <             mandatory true;
-2696a3344,3354
+2696a3619,3629
 >           must "(link-tp-id-uri or link-tp-id) and " +
 >               "(node-id-uri or node-id)" {
 >             description
@@ -7751,44 +8548,103 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >             description
 >               "Link Termination Point (LTP) identifier.";
 >           }
-2699d3356
+2699d3631
 <             mandatory true;
-2704a3362,3366
+2704a3637,3641
 >           leaf node-id-uri {
 >             type nw:node-id;
 >             description
 >               "The identifier of a node in the topology.";
 >           }
-2968a3631,3635
+2881a3819,3821
+>   // CHANGE NOTE: The grouping optimization-metric-entry below has
+>   // been updated in this module revision
+>   // RFC Editor: remove the note above and this note
+2887c3827
+<         base path-metric-type;
+---
+>         base path-metric-optimization-type;
+2964a3905,3907
+>   // CHANGE NOTE: The grouping tunnel-constraints below has
+>   // been updated in this module revision
+>   // RFC Editor: remove the note above and this note
+2968a3912,3916
 >     leaf network-id {
 >       type nw:network-id;
 >       description
 >         "The network topology identifier.";
 >     }
-2977c3644,3647
+2972a3921,3923
+>   // CHANGE NOTE: The grouping path-constraints-route-objects below
+>   // has been updated in this module revision
+>   // RFC Editor: remove the note above and this note
+2977c3928
 <     container explicit-route-objects-always {
 ---
->     // CHANGE NOTE: The explicit-route-objects container below has
->     // been updated in this module revision
->     // RFC Editor: remove the note above and this note
 >     container explicit-route-objects {
-2979c3649
+2979c3930
 <         "Container for the 'exclude route' object list.";
 ---
 >         "Container for the explicit route object lists.";
-3124,3126c3794,3800
+3101a4053,4055
+>   // CHANGE NOTE: The grouping generic-path-metric-bounds below
+>   // has been updated in this module revision
+>   // RFC Editor: remove the note above and this note
+3107c4061
+<         "TE path metric bounds container.";
+---
+>         "Top-level container for the list of path metric bounds.";
+3111c4065,4073
+<           "List of TE path metric bounds.";
+---
+>           "List of path metric bounds, which can apply to link and
+>           path metrics.
+>           
+>           TE paths which have at least one path metric which
+>           exceeds the specified bounds MUST NOT be selected.
+>           
+>           TE paths that traverse TE links which have at least one
+>           link metric which exceeds the specified bounds MUST NOT
+>           be selected.";
+3114c4076
+<             base path-metric-type;
+---
+>             base link-path-metric-type;
+3124,3126c4086,4092
 <             "Upper bound on the end-to-end TE path metric.  A zero
 <              indicates an unbounded upper limit for the specific
 <              'metric-type'.";
 ---
->             "Upper bound on the end-to-end TE path metric.
+>             "Upper bound on the specified 'metric-type'.
 >             
 >             A zero indicates an unbounded upper limit for the
->             specific 'metric-type'.
+>             specificied 'metric-type'.
 >             
 >             The unit of is interpreted in the context of the
->             path-metric-type.";
-3379c4053,4112
+>             'metric-type' identity.";
+3131a4098,4100
+>   // CHANGE NOTE: The grouping generic-path-metric-bounds below
+>   // has been updated in this module revision
+>   // RFC Editor: remove the note above and this note
+3154c4123,4127
+<               "Container for the list of tiebreakers.";
+---
+>               "Container for the list of tiebreakers.
+>               
+>               This container has been obsoleted by the tiebreaker
+>               leaf.";
+>             status deprecated;
+3189a4163,4171
+>     leaf tiebreaker {
+>       type identityref {
+>         base path-tiebreaker-type;
+>       }
+>       default "te-types:path-tiebreaker-random";
+>       description
+>         "The tiebreaker criteria to apply on an equally favored set
+>         of paths, in order to pick the best.";
+>     }
+3379c4361,4420
 < }
 \ No newline at end of file
 ---
@@ -7807,7 +8663,7 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >       description
 >         "LSP encoding type.";
 >       reference
->         "RFC3945";
+>         "RFC 3945";
 >     }
 >     leaf switching-type {
 >       type identityref {
@@ -7816,7 +8672,7 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >       description
 >         "LSP switching type.";
 >       reference
->         "RFC3945";
+>         "RFC 3945";
 >     }
 >   }
 > 
@@ -7911,31 +8767,33 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 <      the license terms contained in, the Simplified BSD License set
 ---
 >      the license terms contained in, the Revised BSD License set
-51,52c61,80
+51,52c61,82
 <      This version of this YANG module is part of RFC 8776; see the
 <      RFC itself for full legal notices.";
 ---
 >      This version of this YANG module is part of RFC XXXX
 >      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
 >      for full legal notices.";
->   revision 2024-01-25 {
+>   revision 2024-02-16 {
 >     description
->       "Added common TE packet identities:
+>       "This revision adds the following new identities:
 >        - bandwidth-profile-type;
->        - path-metric-loss;
->        - path-metric-delay-variation.
+>        - link-metric-delay-variation;
+>        - link-metric-loss;
+>        - path-metric-delay-variation;
+>        - path-metric-loss.
 > 
->        Added common TE packet groupings:
+>       This revision adds the following new groupings:
 >        - te-packet-path-bandwidth;
 >        - te-packet-link-bandwidth.
 >        
->        Updated module description.";
+>       This revision provides also few editorial changes.";
 >     reference
 >       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
 >   }
 >   // RFC Editor: replace XXXX with actual RFC number, update date
 >   // information and remove this note
-61c89,187
+61c91,196
 <   /**
 ---
 >   /*
@@ -7984,65 +8842,72 @@ sed 's/^    >   /    >   /' model-diff-spaces.txt
 >         Marker with Efficient Handling of in-Profile Traffic";
 >     }
 > 
->   // CHANGE NOTE: The identity path-metric-loss below has 
->   // been added in this module revision
->   // RFC Editor: remove the note above and this note
->   identity path-metric-loss {
->     base te-types:path-metric-type;
->     description
->       "The path loss (as a packet percentage) metric type
->       encodes a function of the unidirectional loss metrics of all
->       links traversed by a P2P path.
->        
->       The basic unit is 0.000003%,
->       where (2^24 - 2) or 50.331642% is the maximum value of the
->       path loss percentage that can be expressed.
->       
->       Values that are larger than the maximum value SHOULD be
->       encoded as the maximum value.";
->     reference
->       "RFC8233: Extensions to the Path Computation Element
->       Communication Protocol (PCEP) to Compute Service-Aware Label
->       Switched Paths (LSPs);
+>     // CHANGE NOTE: The identity link-metric-delay-variation
+>     // below has been added in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity link-metric-delay-variation {
+>       base te-types:link-metric-type;
+>       description
+>         "The Unidirectional Delay Variation Metric,
+>         measured in units of microseconds.";
+>       reference
+>         "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+>         section 4.3
 > 
->       RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
+>         RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+>         section 4.3";
+>     }
 > 
->       RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
->   }
+>     // CHANGE NOTE: The identity link-metric-loss below has 
+>     // been added in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity link-metric-loss {
+>       base te-types:link-metric-type;
+>       description
+>         "The Unidirectional Link Loss Metric,
+>         measured in units of 0.000003%.";
+>       reference
+>         "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+>         section 4.4
 > 
->   // CHANGE NOTE: The identity path-metric-delay-variation below has 
->   // been added in this module revision
->   // RFC Editor: remove the note above and this note
->   identity path-metric-delay-variation {
->     base te-types:path-metric-type;
->     description
->       "The path delay variation encodes the sum of the unidirectional
->       delay variation metrics of all links traversed by a P2P path.
->       
->       The path delay variation metric unit is in microseconds, where
->       (2^24 - 1) or 16,777,215 microseconds (16.777215 sec) is the
->       maximum value of the path delay variation that can be
->       expressed.
->       
->       Values that are larger than the maximum value SHOULD be
->       encoded as the maximum value.";
->     reference
->       "RFC8233: Extensions to the Path Computation Element
->       Communication Protocol (PCEP) to Compute Service-Aware Label
->       Switched Paths (LSPs);
+>         RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+>         section 4.4";
+>     }
 > 
->       RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
+>     // CHANGE NOTE: The identity path-metric-delay-variation
+>     // below has been added in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity path-metric-delay-variation {
+>       base te-types:path-metric-type;
+>       description
+>         "The Path Delay Variation Metric,
+>         measured in units of microseconds.";
+>       reference
+>         "RFC8233: Extensions to the Path Computation Element
+>         Communication Protocol (PCEP) to Compute Service-Aware Label
+>         Switched Paths (LSPs), section 3.1.2";
+>     }
 > 
->       RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
->   }
+>     // CHANGE NOTE: The identity path-metric-loss below has 
+>     // been added in this module revision
+>     // RFC Editor: remove the note above and this note
+>     identity path-metric-loss {
+>       base te-types:path-metric-type;
+>       description
+>         "The Path Loss Metric, measured in units of 0.000003%.";
+>       reference
+>         "RFC8233: Extensions to the Path Computation Element
+>         Communication Protocol (PCEP) to Compute Service-Aware Label
+>         Switched Paths (LSPs), section 3.1.3";
+>     }
 > 
 >   /*
-180a307,310
+180a316,319
 >   /*
 >    * Groupings
 >    */
 > 
-472a603,672
+472a612,681
 >     }
 >   }
 > 
@@ -8178,835 +9043,934 @@ about the process to follow to provide tiny updates to a YANG module already pub
   </back>
 
 <!-- ##markdown-source:
-H4sIAAAAAAAAA+y961bcSLIw+r/X6nfQx6x9gB5UruLu8p4LBuzmbGOzAXfP
-PjPzzRJVAjSukmokFZjp8fcs51nOk5245FVKXaooMPSYNdOGKikyMjIyMiIy
-Lr7vf//dIBlG8VXfm+aX/u73333/XR7lo7Dv7SfjcRJ7/7P3/q13EOSBd343
-CTPvMkm98zS4vIwG3mF8FcVhmML7+GJwcZGGN33v/NB6md77/rthMoiDMQAe
-wtu5H4UwXh4GmZ9eDnZ3drb96WQY5KHfffn9d8lFlozCPMz6Hn71/XfZ9GIc
-ZVmUxDlA63tHh+dvvv/uNkk/XaXJdIJj7p15P8PfgIv3Fj+DmQG4qyS963tZ
-Pvz+u2iS9r08nWb5erf7sruOKGd5EA//FoySGIDeIZqTqO/9OU8Ga16WpHka
-Xmbw292YfxnAtMI4z/5K053m10na//47z/PxP57H8zvKAZ73eppF/GmSAnV/
-nAa3ofggHAfRqO9F+FznAp774zV92wHwJWh7EXzpvZ0mBrA303yahvCGdx4O
-ruNklFxFiLsBPMDXrqZJB+n8xyv80An+T9PLECj2Lpoa8PdG4aV3OLwKLZCf
-6dHOKJo2AT0P0vCTdxYEQwPofpQNEu/sLsvDceYdxYOOBT3P4PFOHOY1cI9g
-Nb3X6V0Gq2xAPoqH0U00nAYjm75/u+BH/3gXXCcJQ0R+j/M0upjmrrX7Kcqu
-46l3EtwEsfcaWDsYGwP939M4moSp9z7MkfVsit9c0ON//Ds/hFMpgT8NPoXZ
-tfcWmO46qqLNWpk46RW98ccBPicnEifpOMijm5CmcXT+8W9vO7vd3U6vz++K
-ffw2jGGHDrxJmuThIIct5GW3UT64xp3iw8rHYZDCvoCBPBjFg60W8/yMVxii
-wfGa+Ocf/XPvNOStATsYBxCI8IO4q/vecXDnrXd7m/xZBiiFWRRfJhKCegU2
-KnxsTu348M3fet3Ohj2vw/w6TAFT7yxMb6IBiKa9nBcWfj25DrLQ26hGG2Ca
-2H0Y5MkFrCxguFHGEB72EAFBZ/8cKL3TfWnjcxTnYXoZDISMBOy8ZJJHg2CE
-xI2zCYgTT1C2hpwIJSYqwovn4YgICyw1YMp+jNVqMObAkyGgvd6tJuwOitTv
-v/N93wsuMkBmkOPf59dR5oFUnqJI84bhJXBC5gUg5EYjwSjJJYk8+G2IJ0BO
-JwAyCUldYKDMi4SUpwfGyTAcIV+NgvgK5E/Y8c6vQ1iJIaB1Ew4lNBcgkBkA
-LAcegufyxLuAP8dINPjz4g5BT0fwUn4d5DyO6xjyVs4PV2GU+DK6mqZMMmLq
-HIjlDYJJcBGNohxIhJiZ81dHjnf6Zp9OnY4k2jgaDkch/vUbXJ8UMBGb4vvv
-aO6//PK/4KVtWIQvX8QfOy+38I8ICeomjTfNeKI8GRtnfGVNYM2/n4Zj2Ize
-SZoMwiFIf28/GI1AVuDs4iSPLgWHMPfJHTwOYhiKJoibOYG1zWCHD669ICMW
-FaIMDmxz+BPxrLfy/vB8/8P7N6tyjuubvS9faFV52dVssukEFwvnm40BNeDE
-HPnnYhqN4LQvcRCgAzIb/hjDERbEUQaHAhCDGcVLcHOLpy/TZEy4KlD0eafM
-w5FYnFZsLFmyDF7zMw9Es5WPV7EuTCW6ihXrIkCb2SeTESzRxSikBVLsUMnE
-l2GApzztMHp6JVsVu3ToJdM8A+rhzHKTBA6iBMMh0DC8xV8iIVdK1FjzAFqc
-085YK8wOJwTrQVNaEmqbT28t0ZPW55Ng8CnM5ddESUKeSaY3GbMTbjNgJ0T6
-DRDlcprSug/DHE4jVLxCpiSolVFGJxfuCFLBeOqhGoKEA5DqjNc88/5EI/6P
-J2RxNh2Pg/QOH9mbTEDKRJ+9PRp5/0cAcei9/3B+2FfiCsgcMZzrAPgRznYg
-V3gTjpIJkB+A/PLLH478g45WY+9gJ8BvX76sVXw3CfJrHyg/mea0y0A8IIbu
-h0cbROVkkojHkMf+MY1ABIyJL/o1GNTAdSABk5kEKZxU0xEoAiyGvZ/feu+C
-LCcpwxI0GVfRZZzcMN/nNuNlBBcXCqHtK+0ZlhPYYIpgaAFQ4B4Cb8JZCF8h
-NFoxY13g3MJPmdtgDBB4LI9/A3IRqJIKnnif8Kx4F4Tep/DOA/EGG2Dp+OPZ
-+dIa/4sw8ffTw//+eHR6eIC/n/249+6d+uU78cTZjx8+vjvQv+k39z8cHx++
-P+CX4VPP+ui7peO9/1ninbT04eT86MP7vXdLSNgCjYDa4qzDg3+ShnjcBdl3
-IE4GoMwwr73eP/n//t/eptg0673eS3XO7PZ2NuGP2+sw5tGSeHQn/gQi3n0H
-cgf1O4CCKwknIJoduMfhHLhObmMPNlzY+U5Q8zxMxxEZFHf4CSgUSMZcf0rC
-SyCHoqpw9md44l0m0xjxpvfN47AjRjkBayr6zPuVTMv38K73HlTkjEc9KtBp
-jfRn2vM0VpwMhRDmg0IjACLm7yABSDVH4k54qCGctoguSQK0+YJ0KL4DSmTJ
-IAqQ8KAXk5zDtwdJCnw6SeKhmqfSR4S8MahIEiEPLnwxYCZm+y8xWU/9/MsU
-WebHp+ElLEU8CPEt3KyeZ35NG5m3OB0o4mNxLr98CecyvhihSlx+ET+ufzG1
-vlcvwjGQR8ag8sXd9Zeb/KI8DQovlj+Gt/4EP+Id86Qw3il8rN75pe/9xqQv
-q92/W1K8hNzgWDOxVEtfipLmZBSijZCGkxEo7R6OotafdMB4OkaTANhDHezl
-s/Y33t4gTeK7MSOwRy6QiDWx72lXvT0+eXfWx99+z7ZYMIr+CeCOp6M8kkoZ
-CNsLYN4zaZjh4+/OTsRr5pfw5gnIcH7g1PEAzvwUFi1M6ZlD+xm06o2vDdwa
-8Tk9+0kidAoCfJoC1eAXsL5spZGE76F4ssJVdHDmq0cOokti/Jz3oDLnKl49
-O333Vrx5dg1bfOidRtkntGM/ScfP99+9f328Jx56n8T+6zQJhgM8z2iW/t4A
-BqD12TuR89+b5gkanQOaiNAcLQKcHchxgSFAizoIr9JgSAfR2Rv7qzegv+AH
-P59L8v8cRMDViQ8UA/ajl06OxXcnYDiixQt73zsOwYgdEG7I8nDsATnC2y/M
-bB/En9X2G6jztk6EAlvoe3CQ0r7ql/Q48uodelfCV6CV3ArFDp8Xn2STcIDW
-h1SWP7DqLh1Td/oBOTwJZqnBkkQegFbl1mXxTDoUrsdjFplgquR42stDvjgX
-IVlXQB6HLDAHcDJ8+UJ2ISiWoLsU6MFGJWs+wxCVQzqbUeu6ipMMeQKQC+I7
-T09Wzc8j+qLlMfJBlMQIBI+YQdhpwFChgzS4BHMluVViKw2nGRkLDnuDuAag
-XcCnt9Ewv5YczK/K53hWii9gDLm8MG/1Lls3yhzJ8hSMW7QvA8QHRp5e4WLw
-FsdlDwOwHvX0Ox5q7tNYUAblpOGTXBMnLm5eH862BI37JRP3JZohqg1oD3fE
-1EYofuaYFr330FNakkdl/0rLc0Z5yZrIRO9rf8z72g+Uk6rN9JI49G+DO9Z8
-bxP6fQzn1hTlnkNseCsnx6v0NHCy8ggQ84JwG0UE0gOyfEJrUphGaBOgJiON
-S7ZuUGvb3OkJewZP/K2dLv4ljAv8fnd9Q+g5rqnm1yBI4ZD2BaOHaZspK0cI
-cf81nOfXyWjIciwYgvzLo4w9GuhygK8z6eQRhJGuADyYRpnkqGHmD0ZwlisU
-iO3g9AcIePYI5bDqMFo5OFv19hGAj8KIhJU4n1yU2+ytbwrKSG72h2Cm0Kki
-UYi9EHQMYKBc+BVojsx1dxIh+OgWlVX4BjSLMEXrVAKihRU8L4a6TibEmzOM
-gaLPg/eQdUdJAgPgE7iEuYR6NUougpEfDRuox04E2DIpw53G0T+mIRgk6gsU
-ZR5Ie0AoSdfAUIlg6w3gMzCBwoiOjkD6hlJEJPAGwLZwGggvjDRA1XEhxUce
-fAJblLw5vAbbG8ivBrtudbsb7LxCt5zch5b88dA/AfiCrieQAAR49vApT4fk
-dvg5l4cmGuksGiS50DyZiVjE22TVkKFmQL3jeRvPRpkGRbait+klgzzMyZwa
-wo4DYfSPaUBuQRIApRmDbYr0HqNtKPRaqRR6e8Mh7inv/N1PnmWECseKt97Z
-7PSQ+kzUje0NkgoIAtAWUI4O3C9v6Be3d9d31IsOJ5iGVInKZseAt7XR3UJ4
-QqhZuFRC2Oism5PZJtOaSZ7iqcDu4jt8gr2mCJfWSdAQnonCG3ZRB9qXafhY
-SbQ5ht7urBeJIflHrv0cPKTZ5ihHVsErCHL5wSqTxwZOFI/8j9o4RtZgD2gI
-5I8BNnreJgELDZgYKPVwjDBZ1Dti0y4JV7PyCFrSUPsGxWNK+SFRSYbkxiat
-GyIYjib0CmzFFIDnuHxT0MZSstnpKzlB+PoS5yB9hlGMfqA7nPMYlHJFyslM
-RCSBCkscycsctivYLSLMnAS+9FbenZ+s4lkaeKZ+S6xxiy4VyYR41qLEiNEr
-UdqJhK3chSDKE7wuIlFP3n562UDP3HIW28vpkntvGGV/RyThNG067obyuCOf
-HJl05tuCfcThS2JpCjMZVasMm7s76wKdYAg08+mQ12hM8f5KH0SBJNEyMBSe
-rqhqg0L2WdwDEYwI76zwNpA1hsw5sJRDtjAwdJWN7q5ALEtHVw10cVuW3goa
-n6vuia/j4WKeNhtdY0uzTtQwKtCCn3PPcGfXWGlQAdA2BPMKhPw0qz/v7aXm
-N9idFngSEIgyvi5zTW4TxZMxOThbJTWJ5RRH+5ej4Eov9wW6WNh3xvcL7EAU
-l0UwxLuzE2Ymes897/XuS72ym92Xxjpv7mxsG6u+01s3vnu5bnLEpvnXjtBl
-FdNuGU/2tnrWX8aT292u8d32jonLzvq28deu9eRub/OlzY+7ve2XgoLI/76+
-a7f0t2YKkowwLveFwVi5Nw0ceFkJh5TcEiTh/GxwDUr0jGjgQhpAPAZShwhz
-j542bvoUjiq8ngBDYjgDFxlQ0nBEvC+heRIa63e0G2Avg3EBdkVCW28yTSeg
-9rI7t573jSgLMYHi7ZE47Cfq6jmVbl15Y6XmEMh5h+kAbBqpDdNNIRlqrIju
-nZyxRUcHOih1Jo4CwTU43DO+jeEwKjpQ9NBWjMU9L12kv3x2VkUeMd6uYdXt
-nV17f65bf23ovUQqBGy2quUoYgunI1pRiJzEcs0eX0PURA2GQ60pF0HyxCW0
-e1KX7y8AR/9yGs8jD0iaKiiehFKmM85za2uzkpErMNHjKurAUSkA810W7TRi
-X/YTViGEDjYvDm+97CYc+O3H49WQB9vZXTy4TpM4+idz1U+H+0B3OKvhl1XX
-wKTIpqw+UpjOpY9axjj6Z+gHV1faN4WOi2w6pr28Zj02SoKhP06ynH5D7w9K
-YbqQMp4a4AN0PmIwhHnDXrEQBKEUmNBEmDXjLlbesIPeHg4CWAgSGEbwAVq2
-gBFQcprjH22ol92Tp1EPJ71xRlbW+ma1pGDtwDzU6DDngzWbsNNRXWDNJqvk
-u3XDk4tMjTb3KU560HyHOIlDVmzlbYVvRjq1R0JbPTpC0ITURAFpQ/hozcf0
-yoxk0JbRZTQCZLLS7WygWIICwaZZjhInA+bNyFXLVgVtRxZGwWAQTnLifRf6
-6ztdm57MUM1nuzjNaXuz1s67sngQ32/rFMHPeA4Ic6KGf01bki2MNSmSNjdN
-7db2Ba9v2NYOO4c74tIPTXhYf5NGEpWbYDQlu9cMeBCeAulYc7yGM7ADsbQ4
-9URshnSzsAsBxyevcPA5Gk/HYuAK0HSRcCfII2bxhgzRYDwZheyluqC4BgFh
-2VyZUZJly5ZUX3bdm8EjkbUGY7pzHYUqmglWFTAi3LudLv5s/Aevm+FBMhfE
-vQThZ5T3UU639+QUbuN517wj3/fo/ZaCFwSBYfCSURPQPWsLh7RtoEq3Cb/e
-yL3uvSr8TMW7N5eeDPqE6w7OPLAd13D3PBTFccGBbXQ9lqZJCvZLkOkrgqpt
-noa4UoipODgUGI/AeAwGVJ33iQ54eQeWRPWzIozR8N0VL2OLwWNzokybzwBT
-RKOw0JMBj2NYjBhm4CdpdBVZ52z14OQ5FPc2KsaBAZTHsweQZ2uNitpeKKNW
-NaNybto528oDROjMdS7MgQLLFKlIAT6+1jSMwcm3GXHsLd2vazGTCNC0EJZq
-RbGFStvQkb2l/Sw0SPYqUhyoH0zzxJ7rWll7Lr03zQyrzaYUCodglCWGmUE7
-yDz3YYLiami45mURWtex/YRiuBlHpkElbGHcq0D0Ej1QfpheG/4dL5/isJEo
-xZcfhyCzjFpLjAqpi7EvBp2yKtGLgTVKqnCUyW8oqgrz1pRUOsSvm6JMrBgO
-O3LDUFDuJf9sXUz81TP+2lo3v9va2tF/7W50twu+Ei1DjnJeWzOWQh+BRrh4
-y3kRMBtI/VT7NYdKnKhrMFt3me1QwUhYxCkN2Xmm749UrJ9iMvWVvnHpKHYp
-HAqKa+Rh8oE+Xxi3zHJgaQYx1vllt7e+0HWuwajvOpeDSaSPZXvlDC8RrU/t
-bCMKGdhjD4YMNLxKg/GYsFRpV97K3snRqgoxJrW7feyYHd6mQ8gmn/JiDBm6
-Dx35HXbOhAwo0wFjiQiYMwON2qFxrzixC4A4vYdjouSUEAEjDBcv6y7uJgFq
-6WyW47WwCp1w+S/o/kZaCXTnZ2NEfECDqPuxTIXmYLSpj/nFOhKnIfzmYtAC
-vAn6tfT+IbPgzWOET6y83s8qLv6ssSjqbEYSN49+LFJo3MMbd1fw17Z9zwSf
-GFaZdm2m4T+mcBSHw5mtM3knTBcMBERHEwr3i+Z6YooWwXCC8+vMVGsbyJg/
-A6qw54VfWUu1YpyqeKyd1WhvyLmMx4VajXoBYZNdRqN213Q3QRol08xYJ/F2
-5ukgR2IpmWurWWp9++WO9deu7X7s9YD/hDcuuFOCHSgzisaRyRvTPBpJNzMK
-ehaHlxSTuRJ2rjprHsaj4zYAEyFb1UENtAakKChoLWNDSS3QKKjUYnE5N0im
-o6HCGc/W+M44OzilpICbUhPo21W1QwpDKfHCowkg7OSRz1BgpjnpVeF72huN
-jNDMmP3DJmy+5MxkspsVaqPVDrlLmKtxDe2Q6DUvDtWtjQiL1WkwwHaKsHKS
-cNpc0TGtiWQGxxoOQP1AgTAicMgMYqPgqRJzorzjXUX8/X/gBz4aRJEfpLnM
-moaf3/p+f4WZZNX4mL5Ib73ylsFkoj9gsnTOSQUtXkGC4ityW6XhpeO9QZT+
-wXP+TEGOb286Xglnf2Vwkc08SuMrSF2kMotCDuLnvaLVP8mohQUt+I2q8hL9
-8WSUCdlB3la1+fg+jyIfL6m0hZCv7pQALRHIxzhzFDy5Fh9GJLAwKAxgC4LC
-Bi89+5Q3NuVgmeOQsq2VbCI8a9oNhhBn0hm53fr0FHkrtJq+eF+nvS0ZWSk6
-p60Ydmjntmk4VjKb+yWZ1wZmU6y0CCSkCdO0p+n5NaaqmJ2Kuyiq7JKPOVSX
-YplF6JdW3y3uRTJId7sVA2FHQa13ze821neNv7a2jXubze0t4zC3o6e2u91N
-46+tnvHeTm/DiMHiWDodS2XGS+1s7dh/GXFPRu0Ml9deZORdApEy7y6ZUsR7
-FN5yKEHCO4ElQyZjMXSGeZ+yxcnQ1bsBtVYx1Pw6Fx08CO777yT7WgmOv6DA
-peEosgQQ7XV6r/BDylqdoHG6NE3jPr7Wx7jacdb/PB7146yPr/XtPUJvitxU
-+eErxMMT26aU0fkLS3zxDn7xij9JdUopS/slpALycFV9Jx79S3EwI+/UHgy/
-WPRgdsqpPZ5MvakdE/dkbQErGe+Ou28vDQOFSBEVWUfDRmIpvl0qIiBG3tjc
-6ssjiAYl040GlaU2zlW+QNOwygNWGj9f/PgJFhkS6jnDXsIqW87Y/L10cB2h
-W4CyqmC/cNqjqF2xdybVMKsgF49GVtxAqG9LP7/1fg4v+vDrf17n+STrv3iB
-udxYo+ZTmJIO0QHEXtxevUBV4sXvJeC33rsoy+HF/8QKSXnSx6//KJ//PU8J
-fuSO90pFqYwfBaNcg8oFyVHFyQGsVLPJBaqy3pQDoKPAlAtksaKXA1JlJS8X
-vHLRLQdER62t3/N6G/cAYs3pmsjMgVeGfbFoi0ivw8ybLLycivJehfosVlEK
-0912ftjxdCYgaJYASEDAHDNQ+tQpIrfGsS6Xg5uHLlQsZhfvr7w/PthjW43+
-tmtNLGONieU1/hdPFvxd1prA36nEhPpFwBDPcSyD/k2/r8pL4J+FihPLawLK
-8vHe/yzzebss604st687IaAUq094vU1vBeUL1p5Y5V+x8sSqs/CEAEI6frvy
-E4qQ+8nkLo2urnNvZbCKZa02PSGEMNBH5oAA99NNifLTG6hzUS0VUIFqKrAB
-qtsEl4qPhOmNyNCkV07DIaYYoCNKGgEYOAc4i5QI/OQiirF8DLHNGivSSSoA
-4F9wmiCjqTpMFOoxwbyRnNyo0zSbBjGG3K3JMmt4BQt/a3KBNTAI44wLbmRy
-X9AqsOfgFOvgwN+vzw5gg/OzWShtYcCN7BkjP2og6aCpuJx578KrYIRudI4E
-yBQdwPgQ17X0/IFUVyXbSxlNVRTDUMtngbiPxpS1L4AIUimSxpy59SNdIwZ5
-iks92GPd3t520suBH5JEotFwlBfwGT6++kpVCUIIUZ6Fo0tNENr23ogmjGWy
-QCfvsGBSNYWQy/xuz19/KY/ZkswCqbWHNqqq1ebbMb9ebTDHK/2Wjv2uDEt2
-PV1x9+16tO5a2PW8I/A/DYUG9qpqurWBIMje+qCABXGEbFVDdkR33AtgbWgx
-h9UreMYgLQGbgX8FYG4Yyu6uCafoyMflvx/Z22xwnyMQ0cauYsav3CBKeQpV
-OQrG+wgOjl5P57ui3BC3GmyH9bYpM3UARMGcOnWrmpVm+EGGLfcdLNoqPtvF
-240R200vWQHcVbvNSj7hgLvwM2iw7Z/XApMuKClV3ivE8IlIbD8Y3QZ3eIqh
-bWmcexXPd0qGgmUpoQSdtdSvYbW9eOHZZnWxlg6wzxQk76kqp7MmXXv4HwGi
-6IFT1rlhg9vyuut3t/1et05ev0MvQa7fAqaW5T4aaIJRJnPThKb0ww8E8Ad6
-B/YIr9EPL/hruXGM/Eg5EZIj5BK4Dj/77J6W3yFcr9vrd9f73Y1+d5Pg8Rcj
-0OaB2Eu9TqfXk5P7UneWlbMqvRc6BZRuZeEDzPtNC/5LJSMxyFVjuexZkkvo
-3bAAWDyJlCLQfS7u8lB6NI0JRsJNFmAmb6Y9+0I5H4WXuXyLIGR464j1VTzQ
-ZAKKIvsnbCT6UnpMFRBZTgL2CkcAi0uqRChmuKBUsym/a+ALDDbtV9drPMSc
-1UzejH44O3mjcPhJaEDr6hOEhzmqfe/ozD86M1+uLLBtvIoOuD6/hJ7zwnq+
-5SzZiG+WJDAFwMJceLBXLQZ2cGhmsShn8SrG5ONPP/zK+kIm8/rlJ2p49MCq
-tylKLTjTgTtO3F2j1m2zV9WoHNZlI1fuG0XvwkXgv92+eSRmdeUhNzKtcZ2n
-v/FYl8q4tIwZpEBAFXd/aQ0Kj/0mMDV7gUIT9fsiV5oYx00KR6gFVQunWhYm
-TWS0h0UZ/BCo9SlG+9yYCvNB95X+xIEsIfyRX1aMYdCKgDMyZdi9FrDf07sd
-j8q+D/gu4FoUsOAqRxTpoLNlQXWrRCS4qEJlvQUqe+Ltlsg4EalZdg3z9jrM
-RWmcUrwLT5MmsaKGVGji0IIIq2t6uis2cvwtFb2yF65iR2/u9Pp0xFUfh1yQ
-yjjY7ANsd32jbxaw8l8H6NggTj8LpQ8Qhcyh0GuV887jwi5DV1nEzFuh0BHv
-I5X7hCOD8dDyxI0P5s7Is7j9lJybD6tL2HInivON9ZrzBYtKmLu5iuxYYkKQ
-3dAX0N8jjC7QcY0Kk2qCXPPwpKK0o7dCFSpXLXpg8QqHbrKosZyEw3BAUrpF
-rHxbQTUxN2/VVj2MMUpyWCkIhgVZVwXnIMrqAaHVYWnt1bCOYq6qTIYKOqkr
-gYICMQmoht44oBr5tP9bDMGFjIR6gg5ggb6ZcZfCOnHhQqp6hSOFJhAR03eV
-gml3OR152fU0J3JRHXMDH1lHwZiGg5UVO2/t9oDH3kqwZxKsVAXQFLQKpsKH
-Fl6ujSpbc1RRcsH0o1sIJl6BGhamDsrYaDlO2yqUznhzYMGyqlO2Vq2WbR7c
-JWhETDP5GDNZDslQZZkUbrXDjC+1Nm/RkAVVDYtzeMvdP3/+019Xuisrf+l0
-/7D6hz9PTv668pffrv6h+4d/8Uer/1q2COn91lvuwVcrf/7LMPAv9/w3f/2l
-u7b15c/d9c3t3WBvsB8e/hUgrf6h/J6CvtJb/3PX3/mrC/afu72//mX4r+4f
-/jKE/wGgfxGOxnC9td0v//rL8Lfll1fWVp7zhFZXf1hutstkkpcZhKtXndN0
-Re2xQC68uMgwrVhM0c7oFGG/UFasODYeB3jPQpkbVJ+T3ZyZ3ljyRRFPGMPB
-EYdXbFUMw0EE+s0amkt0xXWFrifDKMPPL0dJwBHH4sMVeM37F333L/529c8/
-rCyvLTu+WP2r8eIbFQLKocZWPptZA1XnvXFQkNZCVArEsnZvRmGIhgwMt7G+
-XIhWknEOGnkOSet+7k163dU1owoZphPL/irC2MMuRlkI62Jcg+lpfBB9a85V
-3xp5Qbry4fz9aiFfb82xqILkanEwlm5NFcVb7q6tr22s9TAfWpQpNVgDs7g+
-HHzsigLvIFrhrw3gqpVl+GWZ01nZJbAsMUUPnQLwEea73Fnl+RzQJdnPwU0o
-vGQHkfAIHovk68+kmBz8fHC86prKJIj4OjEbgR4tmQ5Ro0Wyp6jeL0x1w5oq
-xjmmbIzfMdguuUv12/gZ76h1USal8MIG+1eNBze0E2EftHvsGDQa3VnMVy4d
-iZeywIZhOkAzNdBl+8UeMdlIBJ8sdz8v4++DcCji23BbMF2aPKuzxuUoVCq6
-TGETJkfjJfVaZQOmqvNLVoktKfC7+vQCWFeht9TtdHZa+FrPr6uLyjrryTYZ
-Ab11oKFSsAuOQ0M7V1klwa2p0JleFlNzWjOranZ6VQRSlWBnM3H2Yqs2bFKq
-DHtXXRdWoV5fH1Y9xkUi2tSJBXpmHpaJJc7H8rAmlPmKxCoAjcVi69cZselj
-SzM4+yhkQ3e58440KVf2jo5W9Q5So+9dXaV0GBraI4XjbaChK5lAbIoTEW8v
-HGwnq8YIbiPXqDTc0kzjysIt9Ns98ShVJMYLIV2NAl18lSo0VyxuN4J4tvUQ
-Nfv7sL68cqGgMtdearpoWEexhu0WsElC4WIBP6ZBMCPknOICMn3smHt4o2rl
-iqU5Wq7gBKuCYgsD+qWt9cQlTLPC25WrSBVRBHKzDmG+i8ftYDQlVetCdX/A
-bY6tIRZqMhlVSlT9WETp4a+TKhfYrjfecn1lpfEWVGe3DpbTHwTyMoAj3RkE
-8qYavnKtZT3zewwoQTQMOP/+NWelS7Ar3Lj2eu1Gm3UZgG+TcUsPEnK/XavH
-zGoNYg2M9oj9tqg4Xrk8AO4qWRQiCtgsiNxv2Ypl8gsDW4OW104412fSclT9
-3qatv7O71fc+ZiQvSH2NAP23MBvs76CbLx69PVFeZ1TWtX1AplulLme6q+3I
-hBdeua5KOY4HeDq5Vcmu4kWZ8ipjSVWuC5tT4qmKLAsM43CnV3guBJqu7eju
-1ih1b184YwJEP5rcbPsBF7PHYhL/1PFvdZER89Tq15arLL5u2NTn9tsFE0yq
-tFYRf/Wuq5g/SiERV8VpRBjguOaNscnZGsbUpnBumJYobgz5qU+PeUcnN9ue
-oI3uEmAhPU+/AI13bd8AefiVewbUA9iQL2Ox/Mq+AVrbbd0/QAZjSIRmAaEa
-CBBivd5L2YBAm65I7HbdCDZtUEU2mqMjgXp/js4EktQPr8es2UxiTHv2OBmn
-LlyAiMTti4Vx4A2koNHW7FUuAgHS9HXXMEpTUHeR0i+l/GZ7Zx/er1qMJZMv
-kSQ360rqZ8aoVWcT2smuS7LiDVrNUdWk1LIpzgUUxEiJzngmpmu8DDALXz0U
-noWQnHlRLfVNsPC9QP+pOoH4Sn1o6a2TJGNvQ5voCOp2KQdzqV84AqkrrhHa
-xEhQy4KmEcyLamuENqEPdGe94m6TsFozdJ2nTPrBzDs3a01cXSia3GW7O+vK
-lq6+yj6Mh2ibHhqB5qVejY232uSfxFYKVVxW6NnQ0iAoR6hULcpr2aZZ9XTI
-JkGs0mZuRTYef0i9U0yHFf5oC4u8zhRBviZyrYSkjFArLJZNUA5WLPx9g34p
-VDsojkOUnVs1UbDeRXRkH3MAFF1dYfTzDVsOaShqfNVcuZtkJQxaX+zanS9U
-dRcJB0tkY/AMZjpQdHoLFKaDQRgO74eEAiIS2KyFu9Yh3x7zvayd7F0G0Wia
-hi+G3JgSfY+cv76meIA66+SFIDv8kctqLaW5iqsyA9tirmaKIFL3IwdDaHAj
-RHyazLb+MjWJiM4vtxlm9jWWAzkXuXnEWWlozquRemKdpnFwA49SMbFZF4uC
-EdTrlN2HjWUyEJsoXaWVY1v90tu/jG3nBp8wgU706mC/vuBmzcXW28MwZ+Ey
-H1eS3tB2nhJTomeUZVPabRJZzHqho0BtsKJovBQZqe3xvBXdYkX21swLMkww
-FIWtTfqItE288yhJCQtZRWtJVkv0kMmgBIWIHRqRqWFP+Tos9rv1Vn4+P4Uz
-IBobt4SzeF/5GlNod+W2RU1qwCYq6/J89laMFr+4hKc6CW7V7oEuZoSax+wK
-gW0vbOzstrh5ATUKE2Y1glXKRB7CoYSZgJgI1C7c5sUfVv4c+P/c8/+frv/y
-L/7fOn/97erKi9JHbcJA9uzqcISDdH6TcizR8/jeC9VZ7ScR31Wq46oBHqkB
-s1xSYDW2UixvG6V8T2GuES50HKmRKuToKo3bRlWvH5chV48skqlKI7eKXq4d
-Wbj7ZtPgD1lv07yBKbcyI7oiUcPud9jo+isyt85+6pphhy9eeMBkmKZp1fj6
-0gBLbZXSRunDtrCEnEfxVbNuqTZktC/LC30dFQ736u+ooDj7PDobPS5bjR6X
-jcxDu2h8KHofiMeXjYaPskKJ1exRQZm/6aMCIZs/NoShzF8kxWTaSRt2te4M
-iC0/xhwro4OmTae1dFmbbxyd3Gzimppu27mYSG7yMB7yHS71r6RrEEXCezWo
-VFBKsWoZ+Qk5zmKju/WkU+1aX5mQ14g9RK4bE1XW7mHuS/ToLe/v02gcgOpL
-1ftaKJSOlBZZ+4+COwW8hqgMuqla5LAKYv3Acrbixnbhs5Y3zy1nv2g0NBXq
-EWmITJNBCwK2FaRoJB0VZ7+mEvdJrigU5LdcBFiiuGY/pVE3FNTrTutdh1Fo
-YVx/WfnAW6+AQtMhoG82nReVJZlPX8a3ffulmqV8KwKxeTSy0oyG6xWNxW2C
-/4DfXYYBVjnKVK66+MCbrI8nvlY067PVZA0IFK8nMuyHo23p1IGBVk7Wj9Ej
-u9rsvt0qRUBJ3/ApVfJRNeHZFPP1SeY6PoQneLUGOQWgJr/Mop0k0mWazkUj
-oMcbjE465WoQ3sqb09NGwnRfwglpvVaOE0OXdyFUzIm4K1c6m2serF6486UV
-Xa207a+UNSynTlU0+PpHN62bfepcjIOrNSswnZoRF0RyHre+XXYdGngHdM/B
-6SaoeSRRMkjXtL8PjQ047jFpNLSNxqKiYSGep/2o3L3UgKTqx7ccuFyJZxFI
-uNqaFgQ6wfxBhPIiP/IHL6pP2BlqWnkCRqEn68JP3JbY1FD0tTUpKQ7LbdAK
-9NN1nirKAMw2JkXMCJEsIJYy+isQIJvLrBoEI0apvg5oU6zAWSGHbDmjvwf1
-JiTQjxGgvFNIMjAI7mf53Shc1DzFJbUKTyTg5ILA285bWhrEleshhhn2Co2y
-ayOpmer1XfNdJOsemW4flIwo3nXRJKvjBfR9p1Q8bFGsQJqOAvtUOMEqw79g
-7j/l1iWZB8qW3XpAbgf437uzU4wkx6ZEFHXyGEqZmj1p/w88cbIMntCc6fhM
-wxC92LJ+IbeYueesya2FD0kLV3cyosM1DX09qLfCYSiKVwfTlFrfsCEco6ty
-lS/XRBOdjue9x1NMGOtUajXUDlIMIpCRDdhOAOkgar9xI+4I9JkwGHp/n4rS
-P8HIjPeVRAByCixD0zynlaGLW0Iw/AwqYJN+jbXf8UbM1iouRVZkxcWWQmiF
-A14qPXTvMO1ldOeu1KGgULUPNKhWK06C5DKHHRCGXOJvYQcCgPU0WJw1L4iU
-7a3F39ZOb71fHYZNA52ogSpEuqM20Oz6TEtdIuQ4J/xHVfl0krWmYlG92qpH
-8NQIcK5eBzcY405+aJQxJ4oJyNXPuQHq7KVeH8IXjWGtogWl7Cyk3hUR/+Jy
-Q4yBAQcaCV5Zce9rZsgZBz21G2raLy/XQc7tp0H8CVufGRXPCw5lXbvCKlgh
-xKD+G9lnE2EeypRwQHzPWEYJC2dwaFJGweAiN/X+kLoQaeUNsbDaoVo4DucH
-b1WNo7zvkRV6NBQ6Bj5wgeOVw9MPFfubGmqzd/RBeFHCr+dEgwPLzNHAiZID
-NUeG1GvFv6ByRhbz5deAxNW1F9OJ4Q0UK9VyJV/GqZlgVrT3GtQ0kPwionxl
-7/XpqqeKQVJIcpyMsbbT2R0MNS49f4Yv4LUelkkYUt0XkeOkgOTUwSm/PkxT
-MHgzag4DFn4Ow4/pGJIhPfpTiaNG5PXpCxxLRMQDu1xRqgBoGFSSG29ayVGB
-aeqgmCNGORLK2OAUfIaltGi4kAEoaiCkb9v2sbetxeMPtXftjfRgR8ksGxhH
-/HZqfHX2Q5ai+iIp/EX2weK4jvR3JJ0aQKr5LbTBp3pZ8ZXWCeMDo6spnEM+
-rsdCpYMw3fQQvGit9fbeVk8UDvEPOFTS3oDO9fD1ctUuq1+7mApGVWnER91I
-WS4rzy9+fXBJFPyZFqeCAGcKGHnfKusPVpmv7l0mFvyryTOwRH0sIYf5mUhw
-8lIsbhWke5Oa0VyE2vOtAra0m8OqBogNXRqWarvbhX1ULNKn8mEqqtTYi+W/
-C+5Ik5RRtafhFe4mWcnPWzl+9/7F8en7r7U+WFhscj3xpeax6AVC+Cc/nngr
-9EsYIxHG6OH5MZmA1J9gu4hVpfco9OWtwkyCD7v69b331QN5r6V+hQvyYZr7
-yaX/2mzAcRxMVONI6dtzHT5fabWS5MIfM4qLXqhMKW8iS02aI+hSpLxR3ccg
-0vPHxAZ4AX3MskjbTRQQAGGYlTP/X789WW0KAfj1r2WI4mhyJ+qZDIKJTH5e
-kKeKoHMND09DbyL7Djq80SgXBRwOBRyiiI5JeMMWdal0/+PthGDsj8OJz38u
-4nz/sHcMLKMLqB7yQBSMgSmUrKOCwD6EiVi3zgJiCwm1s74N9OEz2ZG2SRnT
-MjfZuE0y40NkvpuJ6grgvordVaiofVDtjiWqRY9GNdJBx+EQK8Mx+fDAOzrR
-h51qI/886EcRJbqN3yIISBEmRmfAloR4gI1m7eRdUn4qaLwv0MVbAJ0kra01
-lSztreD0VoER1OFRdfWbTNCHsAiK1t6GpXk0mI6CVOSGxIaWofBXVje6ApGF
-FXpcyFo4XNCjJxwu2kljO164VYV8meoOy+PVKgpUuci9Bm5/lwDcI4wXmpIn
-UZ9+78SoFWo5hzz6eRry3aDzKnJGwouwRw+BFu4cBfSm3IXeprhwL86zfJVn
-X8KpaTsdCQ7DqFYRcIRB6pZy+Rj7ZS2CUcG8RrAggM6jcegdh0E2TblB58rp
-OUgknalA7KwvZJvIuI1krIYuT3G7nnhpT2KBL+OK3ozGbx8XREGTxiV8ubFH
-5YDTWPxRJLMDsRoyfzTAEDZtuhF89coKlVSh9mu+TLy9B10OCZDcHHPQ6Kuk
-nbYjUsbH0j2oIw62XxXr9Hygud+7D1k+xCEBwUy8lV6/t/pro9BkNM3uTyKC
-wjT67a+NRmF8jVrzvXbXHpUdwZtO5wHhyTajlNXPZd7ho1GgpYdRKEe/OzBV
-eBlkLKsp2ZVLi7Ms9qyd/aQT6BiAWg6lSudYFC0+VUdN/ajOTpZA15RSKiGS
-wiubSCuCZpjlLuZgvv8UGdUyVbZ3drtCa9w7O/uwf7SHncGlaVPR0KhuMfj2
-g84QI4N6QYsirlYEcL04IfXwMWwQ+0FvOKV/xsGn0OdEYf8iDYOmQrywPBvS
-hjjj299HoeIwmcJ0fFRBh/5FNIzShdLRBO8ReJYAwYh4W5v+Zd7HDgyK/+F3
-ZnlpIhrF5MF6DCeYehLnozuzZSAgIiJEZK5xoyG3VW1My/kB4NfmRLQl1zJT
-q3ox8E78ARfDBL+YxZCdGeAEVS8L0RRlhaXAUxaHfqESv2ViPYXVON4f3sXB
-WBQ1HMAeMgrtJLMsa9stY+2zx+EFVwJMi/bsRr6pgPIo6S81CC2AT6n0noZY
-cRreXmMtewmAKtlTgTZOnODXQ9ZHuGMPcko9g+zudoE/yCu3r9vJe4cjtsKx
-Vcg0FvVD9PWIhLByso+eZsUh7O+p9PgdqAlKAPsqj0xH5jQyiUFMd+918WJV
-0/liiRX5/MMxTxUmM+lvnINWSjur81Y4W6lb/Frfpt5pOpQxoM5rPA6e/yJD
-sNGVtrW12bPjqDTsNzKpTjqHkY2UiJmBVZlFm8lD7ekfhTzsbw3UwSCKxajJ
-telQ8SRIF3xm0qXoxZsGo3LzuQXTkAfECcshdeLQEyVY7SFn8l9wdaXpR3m6
-07GiCh1yZpUFICr2wHmQcvCzoTfDUsvqcQL1e22iQLTXCTUHyLcN5B6KKR6J
-J0gmYTNy+g2jk0QRt6/PD07UvhIvmAJVufPRVJIw6CIsTVVjiuvoCvu100vP
-nEXUqY4XPk+DNSyUviJLIB5cYIuOdbP599M6I+zky4GGhTUTrpPhbGqi8Cjq
-Sg0aNdWDoCo7jRCgFOfRnUCk4EOtQLFVvE+gy0aIehQi0lt0mzM9fbLikULi
-Ql5UY878u8OmtJONdXT5fbjBTn/hLXHuSRrFA+w3mamuL3GY15Uu0Z0Atjqb
-NRTD8h9pTET7xxTevDfN9pvopOiTXOT0mFkBFnEgWUd91Rg1j111ugVo4AEj
-ehg7DSaievVIdKVGtNnZFOv4Ri4nJ7L01ZQ9MWXtQolyUNXuOO6ASiIG2mWg
-igDoBoGZtyK6+BnZT1yrt4A9mcTR0OTpVVksMaBqAFQeV0FJw3yaxpp5iuAQ
-SxFIoSoaEoMpCObuEafLMMTekY/BfpZPZnN7a6fGUEexsmrLHPW6kj2yStUp
-zxlfrEsDl2s1wigsXvxHYmuFukZBhKvg3gpYlKhwJOzEws39gM4vkpR7/ikY
-10ljraOZqyhYS7OQxa7OEOByN3Ne+CDOovKOIOBAe0YrC57oUdNwxKWMijEk
-Bla1cU5hYfhwaOJGBJbLj32tBQrGFr7Ebr/wVWH9ucyuQk8IjKO3crrGFua8
-fTHiMjYgjUboP226lnjUHWfQNEANaJo/OZqDKiUxI+o/VfpFMQjyqBSRMw8B
-W5BNk0uhj9UmNOm0DHvlpQEeMpRsi0cqec+xB6/EWIFQl8rI0S18aY9LbIzK
-I0E4q1TCWTENpTSSdx4kj8ibLe7VK2STHnqyPrEW2Eaqbn0PdQieCJg+WT9Z
-NTF5nGJC5lzG95jM+vHJDMg/1SzJChoxFYK5vObV7BZo37nety24z8IG6/Pk
-08LClfCtX7wCPpQwFgYp1q+5jY2YDTi3ZBEcM+N6JbrEgjar3C4ox8L+Oa0o
-xrbK7GOsQAqKiS6S1TQtEcgaLnpmGjL3k5iMggELqEKgh3gXMF7JVlshzR1A
-Sg78BSDNkAXGajFEwbIpGUpGhIoS++Wauua+1xyELVruxdGAtUCXoc3EzwoT
-6oaj265JIWThWU86gcStbK2TZZfTUeO42Azl/oNaPXbqGSXCUFvOG7v3sBG5
-gyS8huFVM75wDl3eYM1yw71KRd4xdIW4KiBXN3u5A1yIUCOiSXtsSMg9MD44
-RnNx6zosgyk5PUbJrXj70YpuViGzCJIVCUaA6f0OUcTZ2VHCiGJBYGxNxw2G
-qG+Z8OgApGULr+lkGeNlrHRnwdAU7CA8NINRhKfBCDOSRc+0IiRcTtUIhECy
-Mo1KdxWoeoa8/55sswnrtt9sjN56p9XvsTkHLW+nQj2DuYnJ5QpqKEklaLXX
-qRj4aA9fM6kzmkvJPd5KmhdwECWGPy0UkVZHqBMRu0/dQpCpPVo1cNCEqQZR
-gcFnHF31NsOro0r2tkadTu5JftbhW9PcHPj+5ObBW9L43rRtQVE0PqgaSVFq
-zLuScDbE7YTGAoasGYf2ShTfBKNoyJtlPpuSZZUoRKqhWRblrCgM08Re2lpk
-awjxcYJyzERLBMjZPXvXzGQA0EmCyIgApZfXqCoqlkqdBINPYS6bEFFvWeNl
-pDkgP3mMQsXrna1ZlxaYucRV89K2dtXFQF+RCLhZUp3PNr+rRJRilYCaPHMN
-6nQRLdFQ048x9E29XwhZaFSr51Wsa+hlIfaLJJOSQ0XSvpJPOBsILb1PuCrs
-5SXnVIFSqhuqUkUzGk3vmqbllOjhlizKyArcnEHHovhxW8RaozUa3QstiQ45
-2kWhd8IDMMXsdoRvZAQpY9iIm7xIk09hlfQ3cckG1+F4Hh21uDMYUDbTfnAg
-omsrfs39UIuYvR8qiNmwJYxkWxlToKI7eJERW8mK3F4YntXBCZ7+jYoblJeC
-emRh2MGnGKW+2ah7+c2UWcg7hYnxtDrLSwrnksBeUAbxvVKIW/HxBLPgVLaJ
-uQnr16ki3b+4Rjb4SYrljMR1qlirZ5SDXUU+R6TT4ogngP8qSccluR6IdAr4
-MyedaJ0zZ5EKWzMrZCG7FLMnlQbbiiKVVTTKhKthomWjisayi1hPnj6NmrRB
-DNG+gmttiJe/QuRvHVYt17J94O/yCp7iq6LRCZDTvczyefnvuRWvUSZP3/RK
-L9cpQssazNmPHz6+O5CVrOXboo/Ir5HTnhqPLZ67FFtReVssG2nVn/nGbAsW
-+1zrpezzm0Hk9/rvPeNop7LELRbteVOsdw+KFagBBOyZBMRE5OVnS55pjBnp
-FRVyZmSs3/a8j7FVKECT6dfFVBcLJdrrfwua1VQ4m4lkdoGzOSj0dM0cvjFu
-beckl+bU+R5Y1KORFZIm03SSZJXXKzHW7yy7IYso1azGe4bAQRDuQdgmpZs/
-rOZsoHyPcSmDxVh3jKQg5ja0iEAMTfYvZlINI8vBJpJfkI6U35iy1UzhANcB
-hxICObEoFke0IceotwfJeBw0h8Q/JW5LBp8SLqm9mEXY894lGdHPmNbKu+Rk
-VVKH3IuUD/iM6MRrLuIj70efEvs8a8IYO/mee5dvTio2qFGKCbcgFjOVRTLU
-tESWgcHHRvToM6LlMLxKg2GtZTY7OSXQBoqqeXGdlOdOUdhWWFJjEduWQf1a
-tu1tEFF+gbggvB9pfj4/9fJoDCTB+6RpjN3InxEthokfJzmQAlApl8WeiRIH
-CTbQBfQJ1MrBe+xQqHacYhTvIhwEU+q7oGYUk08G3+MHuOfFMyKjuFGQqgQB
-uAcxC1q8iE2Vgl8TkDoHi+EECoY+Jkj/jMhom0eUae0LSTNLQ11932H5/EYi
-f1ykcEvAaiYU+0v5eikVXsyuk8SyGlqkQ8ichDQMC8kvdXOr3VeYkQMrkN4V
-Cr/KDALMgQ9kIAYcbdQaIikp5qzeT3CbYYcKjAIx5LnMgkDSiai74FOobQMA
-sOZxgOP1msfT43wWmVNkmjzPgdcGozBIF7lQsZXzQ+CZQkLuiaGeG50ERxvG
-ksNK/vrMjbVlsfS/7pgm0JQeFiFEg9EoubXrRIgMrDr7+RmtF/P1wyxXE4uL
-UYu5eHHZKfIcKFnm/Ao3wVPk/jpnkJFoLjGIRne8PW5AjcAazRQroV4M1DZi
-k0q9vyLMKLHEQH3LH9nUAO0JLne1t2PuZS6fs1Ura64ov6VXivobmb5eXoo1
-l7CTX7ERqzciRrAJo1jEwtTwyZo3jUeY5RgoAA4LEPZ6+I8pr33Rbcj5MCGF
-Zj4/Tqg2oJ8lJ1jvz8cJWh0EcwPTjrV9F36OMlAr0bfCfhUbBHY/wy6G/x6c
-1FRzGPFQyMuAZPFikQvDz2E6iLKQC2FZVYcL8RICwCJLVhdQWLwOATpBiuUG
-YFEoauI6JO5JUjqN9qZ5gg3VBjpw11hNYw32Ts7Yx67r5eFFBnfJU2HRdGKm
-XDGl43lH8rYDNcLiZQfYR+ol5mjR2CxtcdNxdP7RP/fedna7u52ed7PZ6Xor
-3a0X693e5mpfVUkxL6vUVHyF67soBv0KN1I0ojXKphcx97IyXq1RAh9F5UMc
-/RA7nGjdT+9yPepa2fe/VvYrrpE/jSitE1eA5IoDn98tk1pa3f0UhWF7bwbg
-gk0c08sAG2WoQU1oTUlDmzvFHs+tJqTooSqrqyqWsGoHGvWmmU+ygR0V4CZK
-DR+eUA6Zzyh6+/jSKPR7sLRn+36vSc386gQIbyaj+xHgEGUQVoD7KUrzKcVF
-RDdU1z/CBkyHP528a+w23O1u1rT6luEQyHDHYZ4mnhxTkeFNkk7HtIVQtvV6
-6gnvDEvXAX8qEjZRZLSeDe5HEWo67q97Nk94K+/Wz/afPEPkw/H9Zo/tDv2D
-iI96USppFH7WZDg/OH7yVEjy+H5U+HD+3oeJsjAcNbYa7W3s9p0VqOw8yg9n
-J2/4DMDpqtnuJ9gmekTxQjfJ6AZffNvZ6b70PgBWWFX2XCm99U0n9TyHg/tu
-g4MgD7x9UFlia6kUHxzsN28HkAzrNZLBHEKvfcVQJB4UPiAamImaeisZkuH+
-gmF8MQz8klx4BmLh8r5zfxNdgFAsTv3Nk506XoyFol62z+koM2lG8l0ra/4p
-z1EkwxcvB20aNCpCFOcn33kGsw6lnjD3vJWm8cxmPhmWYy9aT3rv/dnRi8Pz
-syPv5ODH5zbz7D4zP4P5Sit6p7vjvfDOPrw/PPeQIt55r9Prbj03egyjqygH
-q/s2xUIY6fy0OWBA3s8C0DOjw4iO5/mnz8e7tzK5BpzjaLD63AhwiWf0/POn
-I/5ZztkfCLXwfnOXyuUzI0EynJarTLWeuTA0Dj5+Aj1bCACsfTsT929urO8u
-iAyFno5NdlDRiGpDLwZ2f6axcZuDe54V2UZRXA5pbC9cyZsUdq46a97u6xe9
-7uuZGGxWF5Oan1Lv7u1i4r5BkuALqPdMwXii/890MnPBZ9nHaMqVyAq5Pg5s
-67QiBiDCA9n3I0PBGb1mJNLsxlEprDUKMpVKvVAe/IFrnpsETe9DTG4ULUu5
-tCXiIJnMXPnHwVU8GgLTVRgUV7XhKMIjE82uy1RQaNbakgoHAag5m66yz3Yj
-riHn2OFd0b3RDWXQS4vU5Rkx5uoD0yy4mqfAE+eV09tVdaQIfhQPRtNh6HND
-M4sgRQRqKLJ8xGD4nWXRHq124PDzQgY+/Fw9cM1abOK25zdP8c3M843ev6U2
-Aj+5+0z4LheuaiLQZvZZOrqad+5iApl3dvrubZPL6WvMuWXHY3uPGo1NBIxS
-k+OHK89QxGC2PafaPomWK86iCgcsUuWbeAUrSiLwIBeM7jSOuLU6tYoFTYT6
-1EgggnLFwehC/E70N6sT2nKKYVkCtmwsc2gO3nTe7uxu9b2PnClAHaSwBtJb
-WMvb4M7oJ3j09mSV1DGYTmBFe2HdLqHCOdkPW3bwi82Tjq4cake7WWMHm2cw
-bde+01E+klOdxLlOJsVd99CF4QvDz7s2P8Krrddma3Ozrld8TY8hvWzF7peV
-kxqGo+DOD+CkB6E+7/T2xOtTu5ADNYilAZquHMnxQBeKDazUeENWnhu1K52O
-553bsXj9ic2toRn4DBMsVN84lS2/X0vAa0IrLzanVKLgWJwC6g04clHEbG90
-V7Fb7JRjoTSmIhtmpGOJMOFgQOdnThVdGy+pALb7kpoIWr6pViP9FKakUqyr
-Tx5wlWQbHqnJZnPvMHWSYoCZ3d0nno7R1wlyXIyCYZOsLGkTXDfMibBVr+7S
-2wr98PMDoZ8ALlKJsOcihtQ5KGpOM84FtJiLNAw+hel9tCYNxSwX0jQgMP9l
-VCjZ60KqXv74byJRU5VQUd2c2iIRfL43EsHneyKRwuZPHEK4PQ6nDKE1BpJf
-fNzOMSmz85iq0uwYjAIM8lewGgTU+g4Gi5gt/rikvUO4YEdT0qOa56Es4mId
-6KrJ1mnJ19QWgUJRc9icF2iTA6Pk2GXRaCVMtb603scVodeoUjS8ykfDeJrl
-WDUNi4mijoJTDeiM1O9RP+NgMAgneYsopHnoZ0n0BfnR3NQvFAf/CtSP7/7t
-qC/dEk+M+kC9Ib3GOuE0fnZUzkN50nOBxAH2SE0jnb/X/qwE09sE5QlQQaPT
-+8FaO2PhBqlw2D7VymnXMM4Hc3IyWXYyGUWVfmjqi7ygYbExSNymTe3W1iao
-s4cy7AsI+IF8j5iLIK9mMzabQ7I0FT1dFqdla9YYmWbFDLSMFjvtNsbWV593
-qVMU+lDnUDvQa1rqEVVVKg2HiK7iYpWWalzqvEgER7htJaVmQUS0iL8/ItJi
-CmTXeaLJ4DocfJoHrwlxTLF0/31R01Dvh91tGF1dF8ty3xc5BXRW3Fw+uguL
-R0uoARES0PLDIIOtImBQ6aM8kxd1pldZVjcWyXryhcfw5lViPdMGLfVvI1Ae
-gyq1KmnCgD7Gk+oymeqbvyo2MLF+JR91NwM5KaKJnlPRTs2skBOD3qLNag2A
-B1FS192/Q/ZM2ulsIbCWLkwNoIWcnYGWceLnyYRS1R6ZkLmsqRYnnkRBgyBd
-UqQQ30RDcnXxMz5PCUivqznNMt1hOEEdNM59bCquo+Yei39iSvgcJxTlIVDR
-MEo7hZHkOkGgLctaCh05Y/zh2zgBqwoEfDQdDU1PJAi918Hg022QDv3TcDBN
-Mzz5S3y48vr0ZH+VutjB2RIGYw0AeI5SsEFcRgAb/mxgfub23hqy/e727tbM
-CzgBy8UgwyMvHs5X6rHGSkgY+rejnNOCs0mCdabQoIxyb6Mnr/vejIIrgB6F
-o6GZq80/7z/4J3vnP/o/He6ffzj1zt/91Iqqc16DlC5CXrkmdJ3nk6z/4sXt
-7W0nCuKgk6RXL8D2A02KbLEXsDAT+k/n83U+Hs2zM8lhQLlnxuXR40sj/Wac
-DGmzkqmqBNHFnbWJFdYeYJ3NLpKGlKfOn0xj6hHlU0dhbID4+FTwDHyYAEZp
-F08giFpHFA8jvoQw32C0Z9gTvZcPtidQwHw1Zlau0CfAx1pcKqyi2D6JaNmy
-GdZtvfsrXDc6xsQZwxOmI7HVEjpUiwWspzpYxbljKpsSv1lW7eFOoK+3aqYE
-ZUaWgvQri09GxlBq4RWB2Sxrtv4rXLPJ+vixj3isob5+jM0yg8E1J74aBgcc
-7yAgx7Osy+bDrctGd/urnVxXg8QfR1eibtyjrxGYg29HyQWmVSSxiH3QUCyX
-8srb/Q8YMyFxJcuHnAKzLOP2wynlW1s7X3UZs2Q0/XqruP/BkwhoADMvz9av
-cHkmnzI//DwJOF738cUgDvFf4Z13Nr3gMGsNY+Xkv85WPU9jJztbzrBkOw+4
-ZOvdr7NkF+lkgHljpFzM6H94GNUQlUJ0zXiElWmjzeObWN99SN9E7+ssmrjq
-/jraoLC0hA3tmQs0swr4cEbys3ccOfwnj7zQbTwms3gJH86yfvaLDZL0q3jt
-iz51/bpAJ8osufvcV6LFnaZMIkrS6CoS/aPxMlG8/rSuMl3IznaDKWnOEBxh
-rTXDBZOoyK8OhJrYtIABzPMmCrw9jKfRl4FgCo3HpJkcyQKPhm63d3K0Wueh
-LmCF7PEgiJf5ngKTNGeb+ijy+KNuqPYEurh6GPq8TlLYO44Eo9dv3bQgErzs
-9tZn3sfZTTgQmZuwV/1LEffDW0Ruz6cWmlCL9GyhQ3B8egqSJyG16HL5iNFT
-lYKG6XDJWTuYehBcXekcFzgQ42w6njg8AHUEbGDXD2ViISEFCkgKQCINr7CQ
-qE5i0QBMpFaOX++32dtzk3puWrei9igJhv44yXL6LRz6dFH4iJTG+eLQXsJz
-p/Epa0SDgf0zCNL0Tj5PZdCznN9bOX737hkvAAZ3cjhQpgvBPRbhKVYVyz+r
-Mg/msXW8/5w5G2tiI62wekyUuy+jH5zAOr2J0THIKxCT95ZI7vODFvTGC48a
-LaGCfkVtpFhyB5H9MQrTIB1cU9Wd0gAaglJIfvRJJdnDd7CSOPrYZlih7DpI
-v5LE0evCSBizQ3RwNc7aSJVf3WKYJSCewGKc8QenUfYJS3p/8t6myXQCy4MR
-rqu4Smf/jquELprsCS0T4wOr8f5XtxotzQ+zTMdTdSGUEJ3dzDBriTwP00LM
-dzAdT0dGiRFz05RTmqs2yj5CCWgS54d2Xs6z0I8sYkQly39+amAtkmdOjnLA
-5vzkqCr/8Zyookzg9tZ4e1rtOexrA/izJBiZ0nBYw4itLOr21HpH9jHfniBk
-jyGTqvq0SfXihx/o7x9QXuqlvkItDpDhS6YffnjBT8uPPZPp6k6pczzn1Ftc
-rIRrZFyJblLmsPoC6w2cZ1kyDj2+axsGeeBPRkGMWYuDa2p7BMf0mq5LCIdx
-iNUTFYQsT6ekL3Bag0ql6XAqA2awYYF3JDos1LI5oWUFhA5hvHaRLZbNnBwT
-E435ObEAI6OR8AZBTPneU6rlh6wBeyslmNSmSw9pQpWLBTsvBxsUS104CF8p
-7/Rb1LNMYJ7ZNGeUB9dJZFYn8coYI66K3hUrYjA7Q9TfGrk/iDA34lsSbKBf
-q5iMxx1DikPe2ZoO451p7vrFhDAKg0v3N2KlTeK+sr+vQIoQ01V2CnVQ5FiX
-2Nswt7CkDVj69Yvam+4NOqKCvS02Jz94341JUGZnbWpwEQyujWWyd3bVLlrz
-ltOca/32r3QxXp6N3pViQ7p3hzXzmXeGyJjniVs7A6dpLN+/2c6oXpYZ9oli
-4AVtE4G3qpVlYi73Mw3oq0deOQgNw2J6WhtCc8FsBc1A1bFzzf3oSCys2517
-zFqBsvQD5EoJxM34NUNUbQMDpme8pcAa8yNKi/SkFIZw0fqKQmrhSxeVu23o
-uxebeGCP8zj6xzQcKfTuKMObsehYDHZ06SXjKIftuOZhLcwMVFXa0KKxtJqo
-fN07OrAAUMVM73de11vhGHtCfLW8xoIYg1GEoXZflRSMw5yE4JfvSwaD7VyE
-ML52kaINJX6+Dln1RcmKHTBDyaGZl4VY6HAkscAzxJrNsjH+Mmxcatc6jbJr
-8vHktyGDHncsulkgDCp4KyGYP3erQnsUbi04jogSUSaIPayXC9aJPglTEnt4
-v872RtZ4vhvvCBsl85M49G+DO1FhcZRktQ2pToxRj8WoKyfHqyCPWQhH1OIZ
-0xiAttFYNGg3j0A8ADksRHRdZ7c89ZmNY5aPGZD15FjVKBSOMwVCTQgVdBuY
-oYQAgCDzbsPRCP8VfajODxWUk+OHqPeowBOE3fWNvmcQzUfv25A9mGfhKNQu
-2cPPOI3IrKRI1ZOHVrMF8W6G3d1OslXvY4aYwGQZD/VqBT67Wzvdvnd05h81
-VnotFUcU29biF71xadtOozjfWDd3cxrEVyEIrk6nt72zs7Pe23KIgwrXNQ8k
-6s9goisYPvHgDrlhHA3ShMvWWkmtbix9bhGOVr2Nbx4K5cS1MdRLTS52C0/1
-lo1W8WR3DZjfJrPsxOPmPVe91xT+TXuuZq/p7di4577ttbn2msURD7nXznmg
-+faazbcPutdsPO+x16R8aOWLusdW0xrWTFvL3lIKxrettfBjrLr4ctGA1b7y
-KAxD/3KUBLABFcNiIf3MW7q4w4YH2KWOt8ySwdFSi//cnXSXGjhd1W7WeLHH
-YXqRp8EAhuIKhphpHaY3Abt6sfGKoYM6qjnLghHYXhWWCVRSo8AzPGa8Leyd
-DEsKqSsDLEiMUS1oBwUoGDLvv5MzLqlq+SoqXNb3KPdsFHyuO/LLK7o4mSRW
-kL+aYwkrJFZhBipS/6kx5Z7KLCtwZbGeuCcXwVg8/YquIz4Og2yKAQf6S+Ux
-h++Nt4HlkZTC5SJuO+Ik9mV/Ji4mjEIRFRl0Fgbm4NN4OBL3KmtGyQk9bmkK
-9vhgnsl7Gsy0gKUCC5h2kgNYvU7qWN6vxKGu9WzHotM8YlfeE+NQLekYQz6x
-iUfTUBTVZdZjhjJW2HxBrDSt70rUCTtreOYqbhU3atRDJ101vSjEdwVuu3Di
-ZPGbyakc9lHNb05w9RxXXq2vxHDu5Wmpx8nZODCr096kfQYKWH6dJnkO7C5h
-dpw6wULV7bLr7gHN3W/azK9Nm/mmC/yqdYFv5+iTPkdLF3LC1THjESTdFs1H
-0IN4fNoeQfN5gVq5Nq+BZa6T0bCWTG8liEu+DLiMrqYpe0T0+xS+LBhIO0Zk
-5X+NG8iOrE5lMB+rWdZXbaeoUaib4r68f0JHaRlpfS9b47RqupyVmgQXhjQu
-bKqcWC3Oufv5kBbhRbqXH8npSVqEL0kwULuLtfbvFIOJvrRhD8HFjXf34rFF
-ssf2Bnb9PGGf5DtUozBW/YDkyDFvVoowpD7YZusLT3X+bkHR8gXJHHKIpK+v
-KdmwWdNklBly2xTYRhCFFOqK9NTHZTmbTvCspKqxEWa83wBJf/87Kb/UZ8um
-UOfiEGN4DfvwLTmBLKPLGQv9wik3gu/wZI69JYOsxs9vAUhpRCtYpuoCHQiQ
-gX4OL2EqYQUmtprtebVjNdxDvPsmsh5BZDluSJPLSytJtVLlqFc6rKir2cJW
-PjAGHEUiehwNubS6bR6wdkLPVcaWFFmwYmKuwJKNVtgeCcBryJVCLVpDVMXI
-hHKItMcpjItLK6JlssoJBMObMM2jjMTmPNO43yzU8Pedh1MCzsBlvU5nHHxu
-YrDe+v2mK7G0yS7sBmu6BVKUp++UR0IizbBvrUH1Hl7zZIOGbQfFrQOJ9WUf
-BJBJ2OqzVWnYbQh5aW/JSZAGAAjD0oMRnJcwKJj8IfWimKAxeoF1Fa05UWzi
-aAQmHgeXidauwvAR1F3h7mfJbSWIyleTeHS3KjLmQr2uwzLzqpr5IzhdhncK
-eTJ2aVTsEuYtB3EyDkbJNFu2YOA5PI0HIu1QPUTFskCgrXq32GwRrdE0uroC
-znAEebmXzsxpf6yVA9Pk2S6cwN1aN2+Zncvt12wAcgsoc491w6ZxozBF96Jv
-C5RfmhdIxyxGl7J8jhFvCCY5KJaaKoISRR2M3B1cnVavNT8afh6EIdZzwwgE
-hTSyuK3FaXZvzeI2Cg6yzcbFTRGQwmUsQyUqgh9dWb6h0NV88jxRfqAyG2QC
-b2bm704nQ/IWLzyDVw3rQKnOoWRMgt1nHqxNelf2KsmUASMpuNIwrAJayAeg
-bABOGRcJ63aGpbkrah8TZtISfRcN/WkaoddJ/LlkP1qfIbCXo75BJU9kUUsd
-A3388ezcaKpZnScglBYTnwIORMf4ti8eedUeQ6SugRN2ahKIxlZ0dVvsnJgB
-5yweM1cCQRVysMK+zWs2dvL7EnpCk+P+cEszYH/GHeXQW5kkwJgwQh2WlaCW
-3gtW5bkz/5eBObU7eRk0aw/PtcJspHK32dlY8w7/dPLuaP/o/G+nHz7CEsBi
-CMiFl2jkzZ2dvncWXcVwNKM4+RjLnUfFNSgJ9FS01yi+H56F6U+FnE/fraAK
-DFadCvkXt4BAP1MLAeF6TDAVfZVPapieviwwDZwvILQTlF/ptMxwtdlG5Ic4
-D9OxrJx6kqATZOXd+cmqsVee/3aozoMy0aQFcKVCWcjCjrlKVPPWdugSoXmv
-cYETZ45UCe0Wu5jcm4Xj7Nt2nns7T+OWG7rhQXnmr+hNLc99/Qnr/0veb4v8
-Aiuz4tYWVhenLuDYgfkAMWkRRrN0mFnvKJDEqXrkfZesa9xiC5Bl80nhJkF7
-fmLiIBJnk/GFRFbc3WIGKM6jkHOGP9JUhEdoJY8OVOI97FOd8xYbrFkCIuB/
-Uw1nw+xXpRr+6s5C49T4dhou9DQMMl/UTHOegerrCoXW+Tr+cNmQOMz76pGF
-abWwXfemeRInY/TdnN1leTj2VvbOVoUO/vw3cPVO2DtrYv6KhS4UhTAXmQsE
-lBa4Ggm+BcQXSgUWZBxKWCqNYF13uF2G59cSz/Ici0PVVRsAWZOkQ+GAyvIg
-ry0jh6Oe0ht8y1kR0ISxlZ+dgUwKp6qQUQM2zoQgCQ2Boepj3qCHeeCz+yqS
-5YezXLzOBczhNMMHIqt4jRFOdnFH78EQKXV8xquUNBzdcSyy9ym8K17/yDCN
-2Xxu1kz/7TxuMztknFUmFL99U9DmVdB83CDeJXV1ceFHlaxVzJpPD86AKYVM
-GEFy9H6neBpUaCDz6iAlPR+hbHZfdvveG+Td05DZqgwJw4gFsLKxUAd8a7vX
-9w5QhETSgAnsLc412kDfOP2wWoLxHlngaIjNz3x+sHLZWhwNzT7Nh3DatfXO
-tNzSj+z+UziWzdNvO+jfdwfZHFu5g56Gn+ybl+ybl8z++eYlK2L3TQn7doTc
-/wiZxf9WNGln8b49BR9Y9SlZnGnzObl4x0qlzwN/qtwr33bds9x1M3nFKvwr
-jqBlp1uM2RGUE3JGciDzZVLnGmN+xGj2CH2sRg6D7RszYBY8ZCFsp7DY496j
-jwHcYDTNsMR3y+2hKZGIzSWiq6NMA3M7Q8WQ4ecFDqmANfhfld9Y4aifdzvT
-juIhFi+HHXZ7HWJtbOX3EwthzBcRK2NipujO7bnUDkqZ/soEMFabcCJWLPkO
-C2Iwy4PUCBwVRkGc5Cudzgt+JIyHL6Roe6GujMg2MDOCfguGAr7neHS1+BwQ
-p/BR03De7zwH4BZwK1ByYd8Ch2WRFL7cak7zktGBcGFsa9cWErqMhaXsKW9Z
-IbDMC0ztY5BzqjO6smAc1tUTrmZO3AWcuk0oKBHnRSiuC5tVV783MDFh8PMi
-HhsBYDrTSH5uQjDvA0FZub2OBtesCyAckwbqqJQR3iBKjRm6zvKK3QPg6vcO
-keAxd0/VgI+7f2qwuMcOmomYv5I9BAPOu4NcbN6wh+bbBVludkquPrToOTgh
-RbKuTDsgIKqNiDE9e0byK+YC3Hl8O8bZAbwclNaH3WDg/IMhjPfxgo2FEtg4
-eHBKYOFElPAIPwfjySg0xYjNBv9pMUGIWheW31/WRFj2fu91K9//fYv3/9Pr
-Pu96/MWEQQvT3kzhKgaf0zI1a+tfLDZlHRjf9y+ifBxMCsrWHXzVvw4/+1w0
-u0HrkokzWEoT/n8VTHSh7lpxYTJUXtqX0kPGW5BvhCdJRgaOaQYJVY8e5w3T
-0QelKpnCKSQX0RXJDaxEZMJY1pNdLu4tag6EewNbRQS4O+9y5WDS70mxdAkz
-xUa65tw4j3YUXubyPYKRhf+YotkJ+L4LA5Jm/wTb0ONSMvykAUbW5VAJRePg
-Dne1KIFOluMFJsbkd+YcDrGtByYMSeJJHJZNDli2aACgJ5k9AyleZeUY4j7Z
-hg/rRdlr3ZFtnejHlCJccZ0bIAZ5gUN+5/W2u91uIa2qgOnvvO7nbq+LP701
-xCbuW6P59nRXuqskysN8TTljwS4FvpgkfIYA1EnB6cqTpXnp6QIURu+3ANT7
-wRJQq2ZtZ/zhJ3FR5C635BnMtFOD8/rmQyC9vtkCa3ioFmvLbnLb7IB2o61u
-1ZxR5qI6fwyjTR7DFP9xC0yjMBYH5JiL5oypMjGVZqhoNlPyKGRtTmcHQs5+
-G4h/aQTzLMDAlSUyUNscSTh0cJFRImKVPWtg4kWwveyQGo+3GCaNCkpRvePB
-IJzkWN3nFTeyuo0y2JaY/qlAuxhLvC0LbbVMvd7Z2nnZ995yDxpZc8RofKbq
-XMhmatbAyBtvsW6JL0qCYFGqcuESoZS5HUatfE0J0H8sSlHJLnLssaph4Q/G
-S6oVhCqfRJ+6Y7McDUOlliC64AFBTc6hDnfkDHV1uGvQmo/kDQmfUMsGiGXd
-ZIR6Kw50czpjHSZpMsAkfSIy9T8zJu504dyG0dV1Xpgb+nB2DWWirPtU9rwx
-Gj/KopWC7DxStTOnkN5JnqdhKJr6Gtv/FrWYJbCozLX5XdHsWtZVOo3FEORQ
-0LPlpinpblZS+i2Ld9mbviwDkSl2rmB70NDO6bQkAvniHowIAvpcRBDvzkaE
-wnTqjifRwH6gxE5DzTDqL28+rQvSGeXn0Xw0ZhYYb/B3qTB2QcIm4s6U3Pl2
-zbRZGgXugcgF7THLrbKN2HMIBAWSs7idnduU7sxhd+fFyPtGWVR4s1IeiT2u
-OKb43jQWf4TDJnbhEkUaWa7SCFSIUl2sUvTZECxhnmJCcWWSUAGG/LpFMaPN
-9e56n64wcNWNOxuAdzadTJIUlRZjnLe63Zp3DJOPfHX1Z1Yjoks/OtpWXSsD
-bDOdAKGiJC2XCiZBai6Jrgy04/SliFXYaSFp8SJLsxah4Uk02pRlnfW2zDV5
-Kubw1eeOWDz61DO6aMY+p/MoB/bbbfYjv0bMlmY3kxZEEsUfSL6o8WxPibuC
-J73XVvQyiR5D9HJkCquUVnCKCphR37W4fhIPu5r0FSWwlPmOLoDmqVA+sl65
-yEsLaTwkzsbCEe+8NBV2ly48QZoieQylHFWXdvg7aglq2qKkCK9LWYtUk25R
-DUTiqvUWVRJEwcDSIG2KgsxbFqRGayppS221mkJyiKHUZEXz0RxJKXfB6Da4
-s+Ij3IYkJVdgReM7Sp1oYWLaSy8niN4eHlLqpMqlMLFaWRO1ykutdlXhIldt
-qlLxtLobbVnezw5kaJmTgj/3zEshEPfJTcEfwydLm7pcdKYsrMsMIRVduSyP
-yRFSM9eCQJJxNp4ozHxK10plFqk46vCHjjvj7XLqWyFKrHjmuayGpZbc6Ih0
-cNKmWL7OsygquE6iFlkUjvIq1lncpjo1JVGRrSr3VmFGhfDVp7u3bGqJJtDA
-EEC2Ulg23fBk6eiq+IV5Mri/r721IbKfnb57W5lywT+sBVbAr17qlhhIHIpF
-PPXPl+JHpQ9qh8AmuHqEGi2iNHhhnNrw+HKvZXnzVjhr8UtEp4SoiECqS/B2
-Xp451a5ar0qzymVIWZNY5IzR6pVCrFbNqj40xGZXXOU6MarOiyqDnGfhPKFL
-0yndZ1XOoUrQVRVedZ9kloiTsqml0nBvsXZPoaZYr15ZaOLICmfnrBxpKf4L
-4EgbrUfnSDWdbxy5OI40qVJ3wFYer02Ha/2p03iw1h6r9Ydqq0O96kAtnGqz
-HHLzHaRt6zLc9wh1H6CtzkwxkG/eHlDZ2HqPkH0LJF4ol93UnRoqwbe8aBIv
-Vd71lgYoGWTGNUqbG18pvpx4lE0p5y0i/rSyoCpvE2fgIuNm0SWXcC72bSNG
-gxcNACaddJaIudeaQFQhuUxyYyNvbxYMIVdx9toMIl2EWfoNw3jo5wlFttoL
-1LHftf/a45ieSNmNlOhHgGEfc63nUTSOcke7LfgRAYgDm461I+JRgE2pkPoU
-eJ+H6SQNlcOM4gDz8LOzzHqJLe65vc2b4obdLeUPUdZ6r2aTm8+1Cubg4xfz
-EC6nMV8kmaWkA2UOm2xqpBCh0TueYE0c0oZYW6BW0g7WFWGKwegKLxGux3aU
-YkU7BmtG6tVyGKKQDtYGiC79yzDIsQ/CUon+YlntLfDiB0+MiFFpEijWcNbP
-8F4uQyrKlTqZVzNlyQCmzHNkksnOUlWRGtUCDOZ4HoUXaRh8CtOsMDlj9Y1n
-fmmPednhK2WfAbA0F3pGP1BWS4iY+gEnQZvUonMnMh68ATIhCsjTO5nw1Ujg
-0m7Cf0yDEXx/GdwkKd8HIixcqYyaObDOCXAm0eCTAwAFO4ZZMbmcKEBt1+wJ
-VmpnNacZ/zSfafxTcmc0K3gtTrm6la5XAt25dbTBlajylaiaYbOX3y5v/JIs
-rN4cTcg0J2rPJXn5Z175yz/cdaeEfwXDtWG3C/fyuHnO4UAreqSTS59aMmD4
-zCDJcjo7Z93s5dUsJLo5EZrV4WWd7pjHjCmn9a33OAtXP9qks+tHfZHI0HCu
-Fwcwo76DrGzMau29OFRJg6cbhll09zgY46gM9868wC4r8HNffoh0cxP9B1Th
-RacLMaUC51VNsKizl8gr5hoMgfN9Ygk7s1vtkrYqO8XLSrqzPV66ZgnHk/yu
-WaWtYsk7H5f3vvxIMOrYkYf5xosOXrSnNAcvIpxKMgtC48c213GQSOlpQaNC
-mkzDNAsTLa6SS2a3pJ9z3aOq67LWUh7dZs0CnpxVTaKdQFHRh3abiIBO0mSC
-XXfCJl+Mhn7/vaN9b3WxMAvcRzNcaM+4fwK1e3BSNJ0wwrvrAl+Wr7HrJDrT
-uXhAq/niWrQU3A6SzyGiefFbyedqi413DpGphsMWKZ3Vkvw6OKwwqYXxWWFd
-1aQdoretfCyu8jyicRhlf8dyZTGmRzRJSOthd2KIC54ukFUasuE6DJUfeje5
-VOe0NYTpR/yZzSmVY8iXApM0GgewyDj0mmiPZqA4Cm9CswU9ehNE9CBmHXGr
-R3wfW652KgYx3tcv1A3oJTdhmgK/i0oIBSQK8Ol20phGfZiqCLcshVO27TJO
-GQPiIlHHrjYkBdUFeopvqy9NKp/SCkDlIyTPXjWyecug3bej5CIYie01Kw0K
-4twxZM21TfWQJXXBpHXNKtvPV276OlayXjKUmBnc4MZbTQQrDyB3AnaYzMIW
-skL6YDWomiuv+152NTl8n8gVVxOaRTs3GAym4+koIMdQldHrvKJqiYE5gOPa
-uVzOqYVgqBcN+FNgtoqI6OrVrla57IgTVhjgtMqnKccqWNTQGTyBcHBhCT3U
-JIJBzq5qip64oEAJOHRsllIsbOLvMABLgbR1obRtNI6mSRYnVtCYZptmdaBo
-XahDnb16n8gV/FlAmOiMESyltx12RUEGNAVm1+uHL14YiQ26uahIavaDeOhn
-MvGL5Zmz3yl3Xn/Abqc1CDXrNToFJxFrQSNjTpMEbJZuUPC57J+l6arnbS23
-LsVJJxFmE19NhD56VViZygAxE9OCLK/I69p4ubllaYwymMhJvFmmoSEMgklw
-EY1skdxiKjaB55iLZt5Scg5ChDVGdOFckMV5vw7XMg50NhVqCLuYFXNjwcy9
-GBkbka0ZQ70qVNW2zbBSGphNhBaqlF2VmCcKdq63z2lrBY/wkVnvE4iZoqmD
-qWsJVXb5xzQYmh8HZH1/PD1yJvU62LG2qmXraq9HJwoJhb9VBbuKphY3i2Hz
-ciXoWhXITdC6EZzVpmsifk6P7jOtpsplwgwvFnO3RyyZpvC//wM/33/3S9/7
-DajyPpANqzN5IFxG4e+QMAg58/4Hdq/YeEvff8em/gAJAGYv3kr/bgmbMSx5
-xjdoM/1uKQrzS1+KpD+ud9c3/W7PX3/ZwWGWSD7g2JNPOQ3s46v06W+8k2Dw
-Kcw9G4djwgEfwG2gwE/oWR5lSUoIvMhNQR9S6WU2Nuo5eeyDgPnlF0EBRuQL
-rxGqBgmoxVjFHoe2hNkJVsrHOMbBNPPuYP4kmcJbrngigrs4pTCTtZokOcNR
-38tCjODJEmNsbBH/5QsNVSHWDAzc0o0Xlkptff+dpIeDWMy+NOoNrCOyZa/T
-IzYhnxg8C3QDPbKPb/cnQRqMs/7n8agfZ30q5OVcAgIArHcZffYK372SHd+9
-I1ofU2oySrLDO6+fZy2a3G4atnlAl84lPJX+BD99T6gYRHmsxiaYCgW3o2D2
-knRaOM6WyQhpglC5uB3rzPQQF8uWpxasiFoyY2FQ2b8KYhFIwZguHR2ev3FW
-7t5L4QTGmgQYh4Egz1RS9Mr54d6ZLLf8c5J+wg+p7hGjT0bVQJQzWvr5rfdz
-eNGHX//zOs8nWf/FC+DJIE9xbdIOUrkDiL24vXqRA0e/+L0E/NZDMwNe/M9x
-EI3ypI9f/1E+/3tVG0tSCPTtIA0/eWdBUO40oGBk8G0nDvM/XuEnHTBOXJBO
-g09hdu29hYlfR5XAkJzw/R8HUTZIqkD9FGXX8RSkyg0cbq+BusG4EuDNBX3/
-x79P42gCxAE8XSD/NL0E0wnIM62E9Jke6YyiKVG4frZHV8CNr9O7DFayEmL0
-twt+4o93wXXC0+X1Lh0NXNDSkN3Szs4ok300EqUuElFaUFp+l9MRvSVwQDbh
-g36oaoBnOnQUZJoU1Sb/xsS/AgSw6qr0Bot/uPjdECuKTXFcdCYl6VjJSFnL
-6TiIgysu54T7NgNaye1t7Y2V98cHe6u6MBzCR2sbgAwzbxm7kSyv8b8oN/H3
-08P//nh0eniAv5/9uPfunfpFwBDPnf344eO7A/2bfn//w/Hx4fsDBgGfetZH
-Asry8d7/LHOdteUPJ+dHH97vvVtW6qw8Waj8lbyo0TG1qpAgr+4Fn1Ov90+8
-3qa3gkJnvdd7ucq/7vZ2NlcpcomHoyOI/hRAgLB36EUPg5QuVkYjD4yDKIcD
-CCvnedl1cht7WGxRE3I/mdylVG9pZbDq4RHuCWmF5Vhl9TjYJhnVLZHKh4F6
-MAUbOs2kwjMgVdXbg8EJLup7YGrfUClV8cppOIwydpZGFD04pNIzgLO4Z8BP
-sE0KGPvENmssjFW9OWm3A4tRZUUEs4ZG/gR7wZDeO5mm2RRLLuYJkyubsgtC
-uRjYhzAIY7KrkDmlowpXge8PTtEOgb9fnx2AJOBns1AWkQPcACss5qK6pA4k
-HTQVlzPvXXgFh8hJmrBVkyk6oCuOTWJ6/kCwi3xgRQrzHAGFoRbkAnEqUmbt
-CyCCPOulemPKCKRRQGVn6EzDg6441u3tbSe9HPghiS4aDUd5AZ/h46uvSKsh
-6gCEKM/C0aUmCG14MCZwwnAoAprScSJtOk8pilu1lhjZhexsZ+8yiSFhHYOx
-21dS1NdljNCVfRmNireUvuXPHSXG9VfhO5BZwZ1/E6QRa9VGdcgKjKSdaCGk
-9SICrvB75XyGKhupZ/TNmvrlo6haoZRaRS+l9jvVI+/R9aM1oQ7jwRIKEEYv
-hRrFyeSPrt/d9nvdOv54hzp3rt/i3BcsilRoFOEmzO7OzvbchGEdl+CBpqs4
-kj94Ue0XIR+O9O9UMC1RSBIuz1SdVM34yo9yEz6CI6UJ3Zoleq2Ki53wG0xe
-i4zGAOPwEtbcv7g1vApEsYbd7baajw/feMBBJRzqHV38Vmej7x2inx10QxDu
-6Q2KMW9PX+OeXCNeG4bJXZgLCtD17Zc7i5oN6QIAb9b5wHv4Wt/bA9uC6pOf
-4uY8v05Bhu8nI2D0Y7LyG6eyu+Cp7M43lV2cyvltMt88Nnu9rUXOA+HNMQ98
-DedxEF3S93lE0l1wGk7Px+mt8fx8np8GwTNlAXyIQipCFfNHQINMR8zdin21
-5ViOFejikk6KUsWz0nDcineplNJDC5wSGmLRbE94xUWt84Zc5poTtBV0hcpD
-HBTHAXrSrsJV87pWvkp+f4q4VPHxsnZ4HKlmBHAQEmRZzhVbKY1UdAlXFwST
-HPUzcQHnnayfcGBJ6cwX5wUgQgl5QKBuh+pWb/yHKn5+S5XTV9b/N6jtvreO
-FZm9LZBeG73tzfX/kGXFx8HnaDwdizBqO3FPk0NTwCqSFn5GJ2NmdEKQ//4k
-AhypTHCKBYbTK87GiB3DCuPqokBScmGXnq4/u3fXNzaKNfIQBAVK7Rs3vKJS
-sHwXD3ug5aDQVG3lZP/wZBWB8Luh3If+3i3OiyovShhcgBHQxsGAhzA2afWV
-VhIBvZ3NnV7f+3B24vb5oLXsHTOL6TnYIHa3drp97+jMPzqbAUbH1k/a7vCC
-xvsENnsRo4XtewLsacByWyOWGTCfc0/rU8B+2d7lLbe3ubudKAnhI/c8EHwc
-DdKEg9vQEMYtL6HInd+jnd/bXtvZ2VlbhyPJfMdb6W134Av8HD5aFWJBwnBJ
-BzdqhlhQm/ibdHim0kFaL+d8VWvbLsb9rVaNVHVTS++vviOkizTVBKdNoI9W
-pCIdTTG6c3bS+WINE0zzZOYR8CW0SgcBuyi5uG9Fg0G3ZDkUE8fQFSQEGo5W
-wwGu83ZhDKvwcU2Qbmjr0PpSWqDBKMiy8pKYBdNdmKPqiX457Bu5TyCQEzoe
-t4IkVUck7EoWO0+nIOEU+ihgMk6epO6hnIWZeVcYYBtLAagcyQxMva0pYibe
-eAYqKiZIxeFOU8zd1BgkXITagAUUS6Q3UMP18eAYUhwV4LtmNQjBFLIsk/mk
-aTJqcBts9tY3+1o6GGKGap2oos6eom+AYkKNR/6JJteCXN2LQcW6alZ3VDCu
-YVdz0Z0rgPLWuDGVM35SRFEC6dPFJCvRRoVG4gmaeUv/BQ8t1ewDLRE4ymtN
-n2lIgU/RKLlAQFhrgw9U907UaI3boHV8P7TG4VUwI1pXbdB6ez+0rqIGtAxn
-0uATFSm3qsDXO5NM35kUCgynWNq99aAkP0z10o1XLUUkAjeUVDAqVJrHW5rW
-6FDYycJwStC5kHHYyMqEtm4aDklVLGBZheDAp0u8OdfGlDaacXTbFi3Jj+mq
-0IpD+4qSpjz/dDi2V8QkTM1CnE7hbAGF9yAZjTI3DWaa+07faw/yMikmT+GP
-TZh5CTIO5iPIsdDj99RBvQCqbPW9GeE+LGnSRZGGHHyndH1aM6e5dtE20azd
-YGoAJyHbkk1B+b+8Ey4DGWB3KrSqwMLE62W3gSJ7fdkWii5ZqWEJb4CZiSMu
-2OrDk0XUxMmxUSuk1F1FOB1qR9NqmSpj6HohiUP/NrizqhtynRH+Aut5sA+k
-Iv1jY70Ymq/VwN42m/o1werVcYwfGAGPCooALzIS1A0cBO3gruiOqM1mKc3G
-F92Xcte8akmsXnxlz0NUeeCvl14taJJqtHbTCz5/5cUSgmMxiyVn89QWq2qS
-sy1WhWfxsZes6FmrW6mKBnlClG9t7vb6MkTrgMD+pMDuYUbtgLMDilktZzkQ
-EGXUmhG9sj4HDZ8YoxRJ6+aPeqK299EViKr10cIXBHV3faNvnn3+a/JLcLGK
-UMbrlXWTQ+0oomSqodUMquBt9D5mxUaIHgVGFP2BDgxncCxWTrwNB8molyRz
-peUPw0EES7a9WdyEl2nA5s8wukIjc/tV1SZVd2D32qVCdyA0+a5QX5EJP3me
-5MEInf5IqwJNMDKfss25sxDnL2NiCUUAgv0sktfI3ZZj0PPAaEGjfqyLP3Hj
-Z7rE4Xt95TcDky9isU3ZsTnjyj8RuXFiLPI3WeE9BVlR5bwHBT2xtqavvMtB
-dUnqk2Nr/FIqvDF0rdae3yZurV188fBa+6x1iM8ZscVo86VZPpH92zjJb5va
-ewqb2maih7aZ5t4qi7ClSrN8altlNlvq21b5mlvlkSzWeTfMs7RkK2j7xLbp
-N0v26e/OJ2LJzrt7n56F2+pgfXpWpIugjZ7JGjsnt+AtyM6pEBUzCoqqjXcP
-wXBfsdAoFO4jElwCoa7Go3J1OHiu+Taq4HtCVrhOkzw36pHY5UZq7owqtIM6
-zcCoRFGWKe40iLnvjL64ZlE2DB55FrMaAK5ZVOpsjzuXtrqZawrOg636UKs7
-0GoPs3tM7x6H17wHlxm+6TkOLadAUKfWXAKhcLI0C4Qad9TjsN/cbqcvrll8
-LYEwt0fANYuvLBBmNdZcU3jCAmEB2uyjCgSnd1lsal8Vy2whG05MmRBm18lo
-WFEfuFYTLo/tCGSRD71QQ/mgqlnecG6x1aj+vCq80SwfjTfqdGYTMckMZYXZ
-1pKF8tzqVsBBgih+mhSI4kciQDAYgFpPGRB+MLzByr8ZOWOeEl0MJD0LyYUR
-qbEgYkU5iK9WEtGNTa2sQWzVk0gkFj8dz1I/yqnUdscDV+V9Yzxv6T0+DuK6
-lFXtPJ7qixK0qKjZkPrtKs2nK/K1w3EQpY4T36jhLILvMXL+BZ/FmsGA64cB
-rPKdh0X4Gk5CzGHj8jdHRskNypRf2T86XXWjd1E80R8evdfTFI7RM2wcubL/
-+syNWHgfurkxOPw8wBKUZeocVlEnbEuduzzMWg5vzv6wavaTxc/+JAw+OeZ+
-UjX3ySLnToObMz8pzfwZClC7ck+dAH2HKRevmwWoAFyCuSgm2LsJohHptjyE
-zOVprh8q63jKAqLOGp73qSNqVpLU5US3jHKiv/GO9t7vUSA6CHXOOM3wizci
-5+QyGQE/4Bp9PD3KZKlwrsD4p+N33ml4haXHMIzjlz9gVePt3d0vX9YYLHLR
-VFRawteUuxT0/nCE1cn5I04pNsq79WVNTklnGLzvtSmsSXOVbwnksGrZPpd3
-7LPZcXR49lZlWMM0+t77F3trAkeRlYtjUlZrTBNVBT6NClatsTIX4qGRY7Jh
-yVerXh4WTYVtrBfE4C6V071klY1FzSFbgkF5iWGF/xcmXL/c6n75UlohRKHP
-vzrXQqE4xzpy/VKCXvxKsVTfqL9Wg5NrJWZEzQXCxtD1hBNRuVam7BQlcsul
-wWSFOK4LBhZ5Fv3/7T1rc9tIjt+nKv+B56kt23OiLJISJXnucus4TuLdOPHZ
-zu5e1dVW0RRlcyOJKpKK40nlfvsB6Ae7mw9TtmM7mcmHGVki0QAajQbQaOBi
-QTX+K6ru/oxnt6sUz3HKi9tigqbWsStuTJdKLU6KC8zhZTQPSNVimUsCJK4p
-g3KU6JxH5CLQLcZPcWAteHXKeVGdcsmvnGVWtgrZjRhQFu8Ozvbfv3vFJc13
-+w5WFU6tk4NT9YdRrw8iyEMIoJ4whCBenQXXvMkVr9aSIR8ijFEsMrrNRk90
-ZC1GaXFhQ/l4vmRVDPhrjET5KoA8ZeBOL6PZzNo6PX2zXWDrmkhJvDWs3pyd
-HZ+2REAf/OztKQHhbOj3fV75mM+oKAO6r7X32aO5IC2TJjN+02jr3d7+kcB9
-5CGnCYy8eEmoRQEr+ADuKbqJOZ9XEgGsexiHq1mQSubzcyhJNjaFYA2oKMRT
-9ILKVuf8NjyW+gjkFloHSIiLhc1wRDv2xYQumQuRr5DqWlkuig6apVoJzlbU
-veh2xKXfjnR42KRJsyUTmRLZNg5FI8uFQZfU8KkZKI8VlQFi9UqpUDN6zqxM
-J13sT6isAaDDFTJvz8UkxnxB7AXZapbj9sGX5VUMrKQidlSDdsErsbAaIwQJ
-Rr8ClUCcTrD0djDBz1helE0rYIjLUQUwD67xvZArkYhd9c/wCI+63gCcT6sZ
-1sNl4T2wRsDfFCs+WnyK02RBPEKasNk5AVDmkTMby2PaTES2+X6UaaSIIqWs
-I5IQVnEvGOuoEPGobi5YR55oOsUKpZjrwfEphlVFJhOqMtRUJSrF2QyLSKxy
-YfnQHDtdRxZiKOpSq9sjb+XObu5q+zDQAUBpdNu26S6yqOseXmIgN7PP44wb
-Z/vsG1aUXVRZpM2dKVlhlmMZLarrq1ZvZAOnwZQtDxxBq5lOQ/xsmJt0+dDc
-kpZiSyrKTGJZ3MUk/gxoAJFYTOJ8xpnRldZHxudG0yk4NryVX2EVpLy8YMVL
-HjAZqOAKCuhGrnKVWZSELyiuKEjfFaXvY9ISKl8k/jFJ/TQIMRUK3TeqTU9O
-yWUkq9NPzWGryt9zI4pPI1UaCVDZyd3bfL+grOAZsUe4X7zSNC7+AifFJH93
-+A9SZQGWJYLh+ZAltgomZW0YXEGaYu0RfqVGBby+KHkW+q/sK24FPWfUk/x1
-8885eDVA2ma2888d/Hln0/hde8EmGy3T32NQ4VX5YbP6FY6CAMh7DDBghckc
-4VpfwnLfKj1GdZ7AKmO6GK+N7ApL03UC1+14zk8CCbUYv1A9X57Jn2VF/o3F
-lfASn+tWIr9T4vWprmFRT7W4Jiz2+rNkmcySi7iIGDy3ZNjhufWsCSmwOOjl
-6xrs8ofBzuuF/R59+g/L+KeVwDdKzOPvoEMVBOteLNXOxycGg9AfqKOWanf3
-1qzdbSBz51rgfi8canxpU2L7FE1IBqeyyraB5J2rdvuDju+Hw0HHcTwV13VL
-Z6MGkqWwn6mQirLYzQWxS7Tdvno3B3APNbw5pBsQf25V1fMe68uyFH8SQs9q
-e+/qX9pGdWRs1LUUFdOx0VWUpklqgxEI4ver+a58DdzMJOT5vKjQQa8SR2We
-X8U7+WqxAOWJtaAWNhnJNhbhqn8BcUMXI2GWF/8c2YtkEdW/pb5BNnAEL/Kq
-VKW3dGbwZqOyeJ3GjKKgVaFVqitH3zQK91rsBNRAvJDlqO8FePYpCnnXRGxv
-KeqoFjWvFailAdcaRG38aQBugtSmz11Xf0n/ixdpL8m1enTELTMd6xqulDBU
-AbE66mJ/w5K/cgUwCNHnKA3jrAxFqR0n2lyRH8Vq51DgzfGtJMyp36TWPitr
-pP/9eZbMoioOFJRObUoLin+DJXZxoVQXRFdmNSfa6leQ+vosCSb2PMly+hRN
-KBTf7tUQ32KNSuURcs0qV4ousbUaAWPzNFj3Lck4/b2itanRPJK3+7SD2VVw
-jXYc61IsdlrxfvVb3RozyNDCd+sPYFhG99IrQAK6uWMAPuwNnMAbjzv9nqO+
-3NSOsL4VoXxdBJwbjo9qCG51iIRoe2A/eoC2r5gNpK4ocMs699nYua/STmDn
-QAslkUxMaRMM7RmYynw3Xn7ybd6VDxhj/2buXl8FvsOONxiFfafX6Tt93fA1
-GhbGSn8/Vr61T6okJ1dOweqZDga4I5xxnWBjK2gejjfH1Uc1ICg4yFFZ9VwF
-UTR9OtY8/ozRq+wSfSgwMDsGKCz2KX6z6WHr8PiTLzsdGkRJ98EH58sHGXBG
-nb7r6IygBPjUOnxpnb39m6X1BSpuN3nCAhx4vUHHYmdfBkdBcbeA5XVd5lYj
-NN9xxqUJuANeOfUFf7Y2oBJSOokSFDG7HZ39SiqLGRkFfXeofzfsBX2vZ3zn
-wHeu9t2gPwj83rDj94eqZqhVQrTv0CJs0EE3HmDfTQM9t6wKfDRlUlfXV+48
-WHZ3mcbzIL2mvdR8oMH+x38bh4sJBuBEzDdXesjHlLzJYLPy2RuGEvtagQw7
-/v5W6Ejo7RES3IF5w5Lg35RLfIzbcOtboldwrT2C2h/1PqRYU7zxD8LtYDdx
-iuoqtZeDMrc6xq5C96gkguIZ+lYS0NGfKgjTQZXIqwhs3alj8mOoCAOpsp6o
-N0YKk6vBDBFGSNUji6vdKgAtheS10nuUH/0K4wHlgXXUXbDuziK22DR9fs8P
-hr1xZ+j4jdO5RihDFwwZSX+A6W2JX8uYTrkGLHYZV8FaBDZr4u945AZOb+x1
-HMfpNXK4RcDH6GQhYT04fxtQ1JhLUmM+/Gs79u8Vr5H3ZhVj0KEtHmrzRyKc
-mQwUZALDldVXpjSrZEAidqAXBeElO/lt72CORr3ebm3vhbqmCzoc3oJBXsRk
-wlW+IUoXRLetl5Lwkq/Nq5cWbXZvoalvjOZor9cFvOQ6F96m4f5+I7Ecjwah
-YwS++dKVmBYtjrRSsqZHULHgaaO9CY7TcwaB4/T7sMb7zVp0vbCRscbVjROQ
-4qGpb8daoGuIdI0VLmEseZXJ0SUH3B7MwsDVHTaFlFqmVz0D4DwEN9DBrbHc
-2AKrG/PWgAAxnOnBCGbab6nNb4zwPfosuzjLvtdilj2cZd/XpwWghUGaXovT
-8cv44hJTr5DE2mlv9RIMiHLgj5+eHHgoB0MX5GDYX18OtHDto8+/h/M/HN48
-/67jBw7GzhzPH7WjuuYgitH5+HZiHXplI6biyTVsmTN6m3qzLCjnmLYTGopg
-dYlrxs9sFnRImD2S8wAzay7O8hN5l3OAt6lhulpuUkftcqyJPSbz3yhvZkZt
-F9X0TBPeJLlabOqACDzr7QVcrgXYZCQ7nusETn8IO2h/5CrQG2Wr6cxSs5TK
-66qljN1NyqyWqBpeJomb+ULF6VlDHGPjXUK+SkDpd6Jz0TSIZ5iiRiFmGn9i
-mL2lafHGgTPoOR1n4AzaTkvTofATm5ZGVKumpeKFNWfmpIBAUxRnsiEWTFce
-8UsffKomkehnYgIy/6ZMCwU9lpNKk00HoB8XsHJLp22WtfkKcyIQk5PI5qR3
-N81wVo0/JLov9KmPRxTiffNr2CuLpFCcA4XkbesM+9kvKCxhwkKDm8Ib4Mj8
-Buw4Ws3y2JZbsOofUXmb19iYYfsGCR55IMF+DyTYLxTLjWql7pD0sfdqbzRA
-ctS1WLNXe6NhCE/CXj0Y6gcyG5tbOOfbMC98vjdFYKOi41CFm9TyfX169b9I
-WiXHyyzcLe9Xm02LdbMAJhsv0k5k7p5ZHqkGpjd2gZ9D4tL4LuLx6IIx7gMh
-2t5ZJxhjHwRjBFvtYDQyBEPOqEz1PkCpt/mR+bpycitw34PY+O4ocEYu7Isj
-t9n8b0xwwXnVoyQ1GS8sr16LrhiipIG5R7nyPfBxfHTDRi54vSNPzxLd2Ftw
-XFksGmQuzbE4R6adWIBiR9Nw7/iUkqWlf/Ws5Eny6wHwbpik2LB2dt21rEOy
-LrE7YnIF4JZpnNBtAeq9GiyuawRwPeREk0pza1V2M2XzAVq2dWJ09A0g61MD
-XPeR9aDGR56HrNfzFO6+80q+323jLbH98OyDfWa97o56o65jfep3e9ZWb7Dj
-9pz+9q4lDjCUdS8z0izb4NvbeBEFKbo48YwoylbnIp27ACDX5RgcVNdx+h34
-T3MgriLmWdm4GVVStZv6zZNqgJpx6GKugOu4emStpj0dRSuVXu/rRDor32/S
-xS9L+YdCh4p0BYt3nmaZ1lrDYx2U2qJZGZ5uq1zzG2OF8h2DU+I6fQ/Y0h80
-TrJy25lTWDnHl8nyUSIRzrjvASWDHja4VnfuhtOHQb/fdPqAYaptPYalw6gL
-aI37A0RF8JN9C8LXC1zwzTvu8IZ9bp3kXo1z9ems0oziW5/+2gMGiZqpufVh
-Iom7ApYdJloMbOOZouHF1uBHXwNJ9jRZLSaV7mwjZWs4tccmKbiE0IfF0EMU
-BquM7B3Y3laL4p6zCYYNW0qlqPc9RSrUsDvgqVBtlocJplXEt9K7bDcPi6Tm
-ks8jTEJOzXZI1GV2gAlIXpbjlwYn8km7yFNsDhy1ZswkwkuA8JiN/RaLMm2P
-J6ULulA7Tyj4wpEzIZVWLkOeHTOvFvIydU2KtMUtEA69Dhx8tZohZubbgYXt
-cK+CdGKf4L3ZDIPFJZnfenFyvL9tYcA2y4FXcxMMyDfLAALTC8aBP9dYemyt
-OR1cdCN/NLgHcViGka0w79FFAfnDY9rlGRX/zL/BtidTP1sm/EboOdg/niNs
-nFez4CLjxVdKHiD79+69fbx39sb+28H+2fsTTABde17uZCKUjIRfbyJavaMV
-B4uAbmex6hh073wHpnZJ/+l+vszns/vRHfEinK1wu0cD7tGlRdGs5vuUk6W0
-qGZKFWsOKMpGUmMBNeZ9h1uxaEJ+LvtmtaD4r00nOPMgLqW2PQa/LAVDnrhW
-Ck9zxNHS45mQAEN9j5Fzy3XpjB9wXaKafKJLCfhCFayeglTUraJiY5DYxgt9
-vyZRMG90tZUFt/eHLNhkCvCdmDGIjIs1xKLCqLtnGZHmCt+dy26EwPu2kvCQ
-u/VTlQR192ALS2wiT0FJVGwBJTcGS98xjG8rB+4fcmAv3fnjG1fA82P36Bgj
-BOGl1jNLccrSBDaH+W3nuv+Qc+31/Kc416C7L8LEnscX1TekHmPeF4n1epac
-BzPMdgZnN63wx9/DCPP4N+73vt5/v20VNJB3TSGw24qG/5DO22AwfMKikSWz
-1VOSjP33lkDJBHOnKR/8MeX28mNmR5+XAbuh8AQmHB+z/xpdW6erc5aTb0La
-Ov7r6TbVEOBY8zyq24rB8EHFwO09RTE4T5ch+AXMALxVdO7buwToDGC40yI8
-yzGEu8bv3NHDxu+cpygIzOl+Ml4AjwHwuFGJQXc0/R8yMPS7CNhWRCMfXYTa
-xx9vG/d/yJjS70KMYC95IieF5qmdCYSjGWfa/vN7m9EWuSI1JdqMzMgnniJS
-RcTtM0NkrW2CpudyPb956RjIBMu4erVUIL3OIjGwxEqPcSAam4tkCnDD53Oy
-GA+x8dw0KIv61t7x4fZ6J14G5iiQD0RieTVSGbG6m97irvcjL/y7MPf84qF4
-+yJJYY1br4M8wu6HBQ0vXjdxkFg27jnuPWijxpqOunp5+olrjcTcWjudgoFy
-4534501CztzdvrMLi4cVpkSb6L0E+YqDlN1ucCUYArT23d01FCjjW5sb+pUL
-o4ntayyQ92UWI/s5Usg0QCvFSvtKz7eS+lGR3Tp6sb+uJrrjNN1xntaeqcob
-9o87S1TfGZCxEsYlwoguJJjAmi7Fw+S9ffuDT552Lf7xJw3RwUnj9bYQp9Lm
-frT/o68o1qjF5rfMm9KHHnRyeA8mYB/vJGPC4QiLrBCcqrOXa84VHsretdZP
-udpPJq8jvImjNEjDSwAxKw9jwpHm3xubDMA9fBOvwGCE+05znF1im4wnoiuL
-mWVolfiAaOJ8nq6rD39n05mls+pb7E9rOk/Z1ydx9tGilpKvsWw5TPDpydvX
-2zjPp3/Mc9M8s+ZMT3+iGZ4wn+9+x/PZ0gU1K/5/T8GwEgF3czWrLjR+/+4l
-50+4mq9mdl59nmoyco0lu49wWRmhswOyZH88K1VjYVwTpbofHh6+Pv49MLHu
-IsX9MPENQFfu+P6wvJRhmXVjRrfj8F5FFKiqquKPxmYK9YA5BJisEfG5HY/f
-UvyGndviWBYbi1yR75vB7qDnB57jOh34T1EDsspMMVqzoLKQHYYes/uIO3D6
-QIKHDQD7PYNdljXHXm8bvOS2vUpjVvGD/twwBeVGUeAzuZdjb3uKD4kclKKH
-x9GH0zOsJMPbeJQERJuG4h8AnFoqnpW4NdUQb49/UdKIMMbL2bJ2OHK8snS4
-gTvwfTgBlhtVXxnTRUtlK09XYqW5Ax9lbQwT5fbcmonawjVl50tlsopvtmn+
-N6x/ryYLCNuqnujtbzPTiE2gPkAObDUkVn+FL9EEizZvvT0Dh+SeBMdgW4Ps
-5Lv02C0lhyi8mZZmwfHHExCBfnvBGcIKd50eCI7T/wEWzhAWjuv4ren3+7Bw
-3JEP9I/GNQvniWo4wH0EuNOiH/vf/9z5AwfmbjxqP3djmDuv3+943qAsu3dX
-en+ovO9B5fljUHneoP2SH/ZA5VFjLc//AZbN2Act4HsO9glTy1cyQngzZLMV
-i0KBfGINqx0RF9XCZAmWm2qYuOPhMPR8XK+iARabrrBlZ0NOgV5zq4U9zcEo
-40ij+pkOab36Y3etlnsT3YJgYNwYGWdUa7c2ipaQIuC6GX0OZyuQIAK0ybNJ
-YD0rEZZyX+kKQAIjBkiFU5RQAL+mj86NH3rDMXwa9ao6XW98WC6R5VQriZ/U
-R4uJnSc2/E/2gOKhC8vas36LUn5J3eiZHcsWUlTwiEBi/3gaYBbPAV2BPy+G
-FFbC2VR81c0GvqyPftVCr/qOEbkGQVVABI0GPW1xOBNF5LAjLHrGeZTCZiFF
-PyIBjT7n3D+vgmFW9CtkA0Qi7PcGXqfvOMKP+Ur//1/rXQLa42qG2X2w4SEb
-YYRpPIuMedA82GJ5t+m++8jtsFqh2DJ6zzuuSpB5wiv3ES5Y6VUMUm7AXBSA
-pLp/ul6mHUK+W7U/iPBQGk3L+yCr3s/qdGe7WL1XEktfGfuJYWs0BoVUmiqO
-J26IBHnjfl3ZJEl201SsT3wBLQyW7Bp1uW30mgzQp+4eOfA9t5krFgFhhfVO
-q3vNNXS/ghFXGSVOS2hTKtcFupzDNG3zbsXCqTGpdHataVPpxiBjySTqWvuw
-PZxHZrvcw+OSShbtZIEe1rzWoua1ytcB7TUfTg7ropeSwNqF0dDqk3eMjEun
-HTdQTxw4PJaISkrZKAozmt2CkkND6ORl+WiHkdbRXMWi7ciVstlubJii+2LD
-GprnjLfJNJ1THZN62ZEf4cOzn37+2ToOwo9RjmuLNQpnjcPj6TTDB1RFsETP
-N9L6dwdLvN0afwbhn2IhouXqXFyB6OLrVLY848UqeQGwjJUxgRHgrfwqYi1a
-2LhcJ2Gvl6J/MJL75cu/YTrEcOh//cp1T/FKNJNaDF/98mX5MbexdbYNW1T0
-9StHJSITalHMlEpATFfXpkGIewMeKU2TcJWJDA8EH12J+VXGrRoOAZF1dgnf
-RazLBaWFyPqSJoCCtoJrxCBZkJf0Hnk9BVLTZAaqHv/68O7wH5QNGPAreHzI
-EmMFm7I2LK6ibRfx+z/49+wnQjCO8qmdY8NZlCK22/7Z7bk9u+fbTq+Lr1Y+
-xH5hwgjSSMywEWQ3/5w/+wlb6WxmO//cwZ93No3ftRfsDOACQO09Ie478sNm
-9Styk2W/Mt+SA2N0MtEBL2u5yq2t0mPbvHE59g6fWFjFi3iEQB0ndIwOFLie
-kMW7Frca2XIL8oAvP9zpeJcAfsEG9ruiuWGpnjUA/Af8uy08xw0cr+NoJY71
-zX85A1ZZOAaT3yDMV8GMHmJ5T7qJQZX+CwWhnFW5oVsV9sYv5kE8y5PdPAuC
-yZ//BT4PuFfdRZQ/b3L8zBfxhT9f4DddEH/+qjfseOCbjzu6c449pNheSZY6
-7yEl/TVYQVjoHZRil7lhbK1iJ3m9gjw4YMDgeSaW/DseczkKFsEFO6F8KdtV
-qelSGpStd0cv97a7lcTejKlQ4OokL2iStc1j6+xgW3c9tT8MKteiTAOkUqlT
-9rw84sfo2gKwoLQ2MRy62WH/RysXP58c/PeHw5ODl/j59M3e27fygwaJP82K
-sBefCij774+ODt69ZIDgW0v7SoO1ebT3P5usBdjm++Ozw/fv9t5uSpt5ApsC
-0V60VVXdcqPJkNa9/sX+seX0rS1cOFjbfpt9HDnD/jZ1EmODJgtgPv2pgaJ6
-8LhZBSk1OZ7NLPBkYKeaZR00GbNLvFaO2oczu++EA0337CfL6zS+uAQdFm5b
-qKKtw4OzVyA3GIcXWyosvIy2B2FZFEQZglmC118TXt8P9aAwuyISRgvy3FD2
-RAAOGdih30/j+XLG4Lw4fWm95Y/LZoIGkm1AnuCeWAdv4HQGbug7nZEWOqMd
-mlrTKraEZsFkFmzAOS/OTSr/V4AaFXEaDgl/jfMsmk1JVePiA+v+AjQsqM4Y
-N6ka1b8uCqjBdYWgXnlOp6Edkc6ni88xLP4d+A5f2paIK8hqkG5AHJ+S9hkK
-it1zbHfQ2h8kr5XfdaBwHum7Iv1z1zCS7SIdCPsVYdyqKusFnlOjY7Ok1LTc
-eAKUY3BtfwrSWBi47GHjpRp8hS9bgW5hGtFwEvsyOsWTdAIknzRjisafH3jE
-nEuGwuv2eaXWXcwMzfO4jZHR4VF/3A/1tiQx7VPM/6q3PnwnHI07zqg41tj5
-5Zfyutr5RSH8F+tQypj69U67+Iye21wtkt9dhnMNGa3znEWa3jF7m0lP+wTi
-eTQFr8I+v6rO1my17pu866ODV5bTs0p4tg/uMQhdb9c6wJK+YJNap1H6CRWi
-tZeDHjlf4XHC8SXi662TAYgq2vXHw29HPZkmMMJd6AcYCGLX2oO9enEBU3yC
-y/bsMoU9ZD+ZgZ44CtKPUXoL0kffnPTR3UkfIelnV8l90d13nMG3pRtHuCPd
-CALpxrgRPpXHtN9wyUd22MiODuOHzfhhAmL8YRvAAe4k1EL3DSA24wmj8cKW
-ioNtNre6dVLZCwn3fyV4rkF48O7MJcS0ydfPNswjPo0jDY2ZRd8pgr+FYWdh
-qoDRHmIk8SLaVu+g6ADo/AcPRourUTw8Bv77JE5ZcAk2cYLPwFDvN/BddEjs
-VmOeBmjNipa9x+4xodds2fB9FhCkg1JgaK/bw3/en3T/CV0q9Efdf4KfYlvu
-NobaB6CnPcfvu3+i8B96wGqrrspj1YJlBZfYnfaQnQFEnzEQC3Q09hD7Gw6Q
-sRfRl5wF6QV1wA0WFYjIFo1VU0BHDaV32ht2I9fD3aq4HMY9/rpbZzqExgRs
-BMUgREIX2HtXSC911tMhsTZ7QA4ODBL59vQ4K+o26c8C2sP+0Nm13p8ev6oy
-PCncYR0x4S1oqwc3Ggx7u9bhqX14uga8m+4+tdY+hm/xJBWRieM31Ek0lFUM
-JZQNZY6AiFdqGnPX00HoGmgtpVPWOZVIclUpNBFM0DwO0ySLQqyM12EqSIcl
-9JFD+sjxO8PhEHviaW9aW47fhR/we/hqmysrHVKV5qpGU1FWhjr5Q3P9obnE
-V8ITdka9wOsNO57TK/3GveTXIrLR4CT3h27g97yOP1RvP9wi6aEmVPKE0h6q
-8WvpIZPoFm9hWIXF97tWRYpD2fxfBPPqnIAsR2Go9wysjXf4KiiOkidwYyJC
-m6BA65ydVi5N/YF5cUK+Ph1hXCquSUiv4kXu9w0UUM1n1sY5/HeHKWrTY6rM
-bm7jlKFmiik55FAJbpE/ubV/eFJ7r60g5LxUFeGRCXmxSrPcOo1/QxJelMpa
-lEmI7ncumrA8+BxiSkuZ1wdteB3dhtfXuZnr1wpFlYsHbbi4fDguHkfBxwoe
-Hrfh4fIheEgIqhw8buTgD7ch6ScGbTckugHyou2GxIeqGeXbCd+erM7PhoaR
-C1vy2U9fdq2fE3ozY2lP1DgFZHQf22VNIkzOQcrojAG5xhNh7iUDitK0wyil
-Qp+XIBPs3JiwhY/8XAOnVeTJ5EUiFhcOgppdRhMzX4iiZckqZ1Y+yz5OrPkq
-lI1sL1hiIb/BHdCx/N9fy5PsjGOJYcplkmUxosV5VZw3qOe3gLPIAiQOcOoI
-zvuFeJknVH2MoiWOnOn5C3Ep5yvjERo66KZx6eEAcxEIA5ZSPdm1Eoyr66+i
-N5PlMbh18RwTcRDKvMuazabB1TlIpZrxlSYB8CfmTgxWSgMfg008YiVdqFA5
-6xJDzeKP5kRlMZZi5Q+rVF4hRud41yGNMMkzpTsK89Usj0GSiiQOdQBi457F
-loDOyyKpfE45AJijX4GjtRV1L7odHUk7+pxvr8ERQh3oSkng9SJHGj9YUh+x
-Ll5cc2mWnlitRHMyYfy0ROUn0JxLIE+eGXPhrV8euAiQIwuxcO3zOGtLLV8n
-tMGiEuAIULq+dR5fqDCtf2FyA8tGVuhlqCdUtrJrHYEeAP2QssSM1cVFlFHv
-zhW5Y5Qk4TgeZtQA+rQW4yxcZUhqh89qHelqBp3KAQwuxIymYJYJUSlri/MV
-k/ckYu19wUeccH2UsjSIDn2X8S8LvUOEY2YhJTXSMWVRhhi+V5m0hfkCX778
-FxYn9pz+16/bfLqnySoF1czmu0O1Orj25QrB7vWQITytoUOt7PKEEupsmU4j
-ppvSSEVCDuXNUEyopQTinIPCY6EfLbnnVzYc9aWdMOG/ukxmkbx4pqRvKqhQ
-dcjzZHLN3wclaWXJnO3WWUeyGfeOScV20RHAKobB1FTMR9WSUYni5J6IphnC
-OlTyEtUU5ABXDqyKNJkLue1r0pqrSSgyWRX2BnAUKAOMS1eIfNCXJyN3TQ49
-EB9esqXK8974Ks0iIhpvRAleYMoWLLgctj9W6EfoEckKMHVSGDGEjQsBi5Qb
-zOrLU1zMaReRpKSbeRThHrQDgHdgo45S2P3AGJphzrQNX9oLwsUO8HLbMg7t
-Oebi0RWZy8iOPvF2YFgZhgintF2up2FhdZeTKeLwakU2gGCV0ItyJbHm68Es
-vlgUGcuSX0J9drldxbaFaPKfG1PANtrg9tVeiN1DZtGE5QpmwhQKVmCupLA1
-0iC0mdJcBXST+iQBWLn1d0zqhNl+m6ysFxGGFzvWUQBGxKX1lwifRX90EZPt
-+5doOrXeBJhUxm/igcuDOzjZV/ECk3a5NBSC++wnMJ5Xuuon0cKEavzEU9VL
-e1qgCVEww339WtGS7PIGSHmX5wCfaaxFdQa2AMsGZ4ncH9NgPmF9Vv4fT7+V
-XlpfAwA=
+H4sIAAAAAAAAA+y96VbkSNIo+L/OqXfQ0OdeoBpFRrAn2UuRQGYxHyRcIKv6
+m+4+fUSEAtSpkKIlBSRdXfdZ5jXm78yLjS2+ao8FEqqSU90JEZK5ubm5uZm5
+La7rfvtNPx4E0c2eM8mG7u6333z7TRZkob/nHMSjURw5/73/4b1z6GWec/Uw
+9lNnGCfOVeINh0HfOYpugsj3E3gfX/SurxP/bs+5OrJepve+/WYQ9yNvBIAH
+8HbmBj6Ml/le6ibD/u7OzrY7GQ+8zHd73W+/ia/TOPQzP91z8Ktvv0kn16Mg
+TYM4ygDannN8dPXu22/u4+TTTRJPxjjm/qXzE/wNuDjv8TOYGYC7iZOHPSfN
+Bt9+E4yTPSdLJmm23u2+7q4jymnmRYN/eGEcAdAHRHMc7Dl/zeL+mpPGSZb4
+wxR+exjxL32Ylh9l6d9pupPsNk72vv3GcVz8P8fh+R1nAM95O0kD/jROgLo/
+TLx7X3zgj7wg3HMCfK5zDc99f0vfdgB8Adp+AF867yexAezdJJskPrzhXPn9
+2ygO45sAcTeAe/jazSTuIJ2/v8EPS8H/ZTL0gWInwcSAvx/6Q+docONbID/T
+o50wmDQBvfIS/5Nz6XkDA+hBkPZj5/IhzfxR6hxH/Y4FPUvh8U7kZzVwj2E1
+nbfJQwqrbEA+jgbBXTCYeKFN339c86PfP3i3ccwQkd+jLAmuJ1nZ2v0YpLfR
+xDn37rzIeQus7Y2Mgf7PSRSM/cT54GfIejbF767p8e//yQ/hVArgL7xPfnrr
+vAemuw2qaLNWJE5yQ29838fn5ESiOBl5WXDn0zSOrz7+431nt7vb6e3xu2If
+v/cj2KF9Z5zEmd/PYAs56X2Q9W9xp7iw8pHvJbAvYCAHRnFgq0U8P+MVhmhw
+vCb+1Uf3yrnweWvADsYBBCL8IO7qPefUe3DWu71N/iwFlPw0iIaxhKBegY0K
+H5tTOz16949et7Nhz+sou/UTwNS59JO7oA+iaT/jhYVfz2+91Hc2qtEGmCZ2
+Z/0svoaVBQw3ihjCww4iIOjsXgGld7qvbXyOo8xPhl5fyEjAzonHWdD3QiRu
+lI5BnDiCsjXkRCgRURFevPJDIiywVJ8p+zFSq8GYA0/6gPZ6t5qwgCqS1XVd
+x7tOAZl+hn9f3QapA1J5giLNGfhD4ITU8UDIhaFglHhIIg9+G+AJgLIX2DMY
+wAtBFuDvyDEkgoGbUicQIp+eHsUDP0QmC73oBoSR33Gubn1YlgHgeOcPJGiC
+mgMEAgSAZcBQ8FwWO9fw5wgpCH9ePyDoSQgvZbdexuOUnUnOytXRKowSDYOb
+ScL0Iw7PgHJO3xt710FI80DMTGKo88e5eHdAR1BHUnAUDAahj3/9DhcrAUzE
+Dvn2G5r7zz//H/DSNqzIL7+IP3Zeb+EfAVK3nDTOJOWJ8mRsnPGVNYE1/37h
+j2BnOudJ3PcHcBQ4B14YitWI4iwYCnZhVpTbeeRFMBRNEHd2DAudwnbv3zpe
+Svwq5Bqc3ubw5+JZZ+XD0dXB2Yd3q3KO65u9X36hVeVlV7NJJ2NcLJxvOgLU
+gC0zZKbrSRDC0W+yE+EM6IAAhz9GcJ55UZDCCQHEYEZxYtzp4ulhEo8IVwWK
+Pu8UGToQi9OGpxVLFsFrfuaBaLby8Xa7ApkZJhfcRIqZcQiJBW68gFfLG49D
+WLrr0KeFU2xSydxD30NVgHYePb2SroqtPHDiSZYCVjjjzCRNCbG8wSAFPrmf
+brvjXGBxaDZLQqFz6a0letL6fOz1P/mZ/JrIShgzB+gdx7yFew556x2QYThJ
+iAMGfgaHFOpjPlMQtM0gpQMN9wZpZjxZX8EnMQHE+flnQOEB+NMFfdeHzYiD
+/vzz+FNmfrrmCMmdTkYjL3ngN5Elb/zUvQ5SQIm2/u9gC/5rEiRi0A9x5kkh
+gPzxyX9wYCcBTZdOP15eLa3xv86HM/r94uh/fTy+ODrE3y9/2D85Ub98I564
+/OHs48mh/k2/eXB2enr04ZBfhk8d66Nvlk73/3uJ12np7Pzq+OzD/skSTiOz
+1xtYUohVPHDGiY+S1Uu/AT7twyEKf8A7bw/O/9//u7cplmS913utRNpub2cT
+/ri/9SMeLY7CB/EnEPDhG2Bl1CsACu5/ELao7iIHgci5je8jB1bU73wjqHnl
+J6OAFNkH/AQOMiRjpj+l/SCQQ+7PHTMpCtdhPIkQb3rflLxyzc5Biw8+M0OQ
+SfMB3nU+gGqW8qjHOTqtkd5GTEVjRfFASCyWSRoBYOB/goAhlRCJO+ahBiDY
+EV3iKbQ1vGQgvgNKpHE/8JDwoI/RLsK3+3ECG3ocRwM1T3X0CYY2qMis7V27
+YkDJof8Rk3XUz3/MPWF+fOEPYSmivo9v4WZwHPNr2r+0R1hUio/FEfD6NRwB
++GKAqljxRfy4/sXE+l69CEImC4xB5Yu76683+UUpa3IvFj+Gt/4CP+IdUw4Z
+7+Q+Vu/8vOf8zqQvq3t/XFK8hNxQsmZiqZZ+wdVALeJoEKDJ4ZyHPuqmiT8O
+QVl0cBS1/qRuRJMRqqLAHurEKIrv3zn7/SSOHkaMwD6Z3gEf+t/Srnp/en5y
+uYe//YltAC8M/g3gTidhFsjz3znxroF5L6VBgI+fXJ6L18wv4c1zL7vlBy5K
+HsCZX8Ci+Qk9c2Q/g9ak8bWBWyM+F5c/SoQu/DSeJEA1+AW0fls/IeF7JJ6s
+cFEcXrrqkcNgSIyf8R5UZkTFq5cXJ+/Fm5e3sMUHzkWQfkL76ZN0OHz7zYe3
+p/vioQ9x5L5NYm/Q99KMZ+nu92EAWp/9czn/fbBE0djp00SEkmIR4PJQjgsM
+AVbBoX+TeAPSQS/f2V+9gwMSP/jpSpL/Jy8Aro5doBiwH710fiq+OweDBS0t
+2PvOqQ/GU59wQ5aP75Ac/v0vzGxn4s9quwE0R/vQRYEttImrI9Yl9gpaAnmT
+jpwbYaNqjbBCbcDnxSfp2O+joiv1sjPWEqVD5EE/IIcnwSyVIpLI/XhcoR7h
+mXQkXF6nLDJBK87wtJeHfH4uQrKu5FUNMkFAcwH9LkcPtl/Y1hn4Y7R28GyG
+6Xs3UZwiTwByXvTg6Mmq+TlEX1RyQxdESYRA8Ijp+50GDBU6SIMhaMbxvRJb
+iT9JSf8sscqIawDaNXx6HwyyW8nB/Kp8jmel+ALGkMsL81bvsiKtNFwwS8GO
+QlPGQ3xg5MkNLgZvcVx23wNDRU+fVcNJJCiDctLwha2JExc3rwtnW4x25JKJ
++xLNENUGNL06Ymohip8ZpkXvPfaUluRRuXej5TmjvGRNZKz3tTvife16yjnS
+Znpx5Lv33gNr8fcx/T6Cc2uCcq9EbDgr56er9DRwsjI+iXlBuIUBgXSALJ/Q
+QBFK9hjOE9RkpL1CusyfUWvb3OmhMs5/7W7tdPEv1tjp+931DaHnlE01uwVB
+Coe0KxjdT9pMWdncxP23cJ7fxuGA5Zg3APmXBSkbz2jdwtep9CcIwkirEw+m
+MJUcNUjdfghnuUKB2A5Of4CAZ49QDqsOo5XDy1XnAAG4KIxIWInzqYxym731
+TUEZyc3uAMwUOlUkCpHjg44BDIQjETo4R+a6B4kQfHSPyip8A5qFn6DfRgKi
+hRU8L4a6jcfEm1OMgaLPgfeQdcM4hgHwCVzCTEK9CeNrL3SDQQP12ESFLZMw
+3EkU/Gvig0GivkBR5oC0B4TiZA0MlQC2Xh8+AxPID+jo8KQbIkFEPKcPbAun
+gTD4pZGujgspPjLvkx+x44DXYHsD+dVg161ud4P9JOgBkvvQkj8OWr+AL+h6
+AglAgGcPn/J0SG77nzN5aGbxWIgGSS40T6YiFvE2WTVkqBlQH3jexrOAqQJF
+tqKz6cT9zM/InBrAjgNh9K+JRx4oEgCFGYNtivQeoW0o9FqpFDr7gwHuKefq
+5EfHMkIvBc+tdzY7PaQ+E3Vje4OkAoIAtAWU48Pylzf0i9u76zvqxRK/ioZU
+icpmx4C3tdHdMjwHFi6VEDY66+Zktsm0ZpIneCqwZ/IBn2AHHcKldRI0hGcC
+/469oZ52mxnuPBJtJUNvd9bzxJD8I9d+Bh7SbHOcIaug65tc2LDKtx468SLa
+36NYG8fIGuxs84H8EcBG187YY6EBEwOlHo4RJot6R2zaJeHVVP4mSxpqz5N4
+TCk/JCrJkNzYpHVDBP1wTK/AVkwAeIbLNwFtLCGbnb6SE4SvhzgH6ZQKIvQD
+PeCcR6CUK1KOpyIiCVRY4kBeIrBdwW4RYebE8KWzcnJ1vopnqeeY+i2xxj26
+VCQT4lmLEiNCr0RhJxK2cheCKI/xmoJEPTmW6WUDPXPLWWwvp4tHORw06T8R
+SThNm467gTzu4Cth0plvC/YRhy+JpQnMJKxWGTZ3d9YFOt4AaObSIa/RmOC9
+iT6IPEmiZWAoPF1R1QaF7LO4ciAYAd6V4C0Uawxp6cBSDtnCwNBVNrq7ArE0
+CW8a6FJuWToraHyulk98HQ8X87TZ6BpbmnWihlGBFvxc+Qx3do2VBhUAbUMw
+r0DIT9L6895ean6D3WmeIwGBKOObmbLJbaJ4MiYHZ6ukJrGc4mh3GHo3ermv
+0cXCvjP2XrMDUdxLwBAnl+fMTPRe+bzXu6/1ym52XxvrvLmzsW2s+k5v3fju
+9brJEZvmXztCl1VMu2U82dvqWX8ZT253u8Z32zsmLjvr28Zfu9aTu73N1zY/
+7va2XwsKIv+7+o7X0t+aKUgywrhUFgZj5d40cOBlJRwSckuQhHPT/i0o0VOi
+gQtpAHEYSB0izD162rjpEziqXLTOAckpuMiAkvgh8b6E5khorN/RboC9DMYF
+2BUxbb3xJBmD2svu3HreN273xQQOfgC8jvBe4GhPqKh42I/VLWci3brySkTN
+wZPz9pM+2DRSG6bLJzLUWBHdP79ki44OdFDqTBwFgmtwuKdwJIIGzOE7dKDo
+oa27/U7eFYqnzR2fWMZ0HO8aP+WDl0cmt5X0l0/Pqsgjxts1rLq9s2vvz3Xr
+rw29l0iFgM1WtRx5bOF0RCsKkZNYrtnja4iaqN5goDXlPEieuIQ2J3X5/gJw
+dIeTaBZ5QNJUQXEklCKdcZ5bW5uVjFyBiR5XUQeOSgGY77JopxH7sp+wCiF0
+sNFtZ3rn99324/FqyIPt8iHq3yZxFPybuerHowOgO5zV8Mtq2cCkyCasPlJ4
+yNBFLWMU/Nt3vZsb7ZtCx0U6GdFeXrMeC2Nv4I7iNKPf0PuDUpgupIyn+vgA
+nY94727e31YsBEEo3IE3EWaNNXsijby/Bb3d73uwECQwjPtstGwBI6DkJMM/
+2lAvnZOnUQ8nvXFKVtb6ZrWkYO3APNToMOeDNR2z01FdYE0nq+S7dcOTi0yN
+NvMpTnrQbIc4iUNWbOVthWsG1bRHQls9OjLNhNREAWlDuGjNR/TKlGTQltEw
+CAGZtHA76ymWoJijSZqhxEmBeVNy1bJVQduRhZHX7/vjjHi/DP31na5NT2ao
+5rNdnOa0vVlr512ZP4jn2zp58FOeA8KcqOFf05ZkC2NNiqTNTVO7tX3B6xu2
+tcPO4Y649EMTHtbfpJFE5c4LJ2T3mgEPwlMgHWslr+EM7JgfLU4dEZsh3Szs
+QsDxySvsfQ5Gk5EYuAI0XSQ8CPKIWbwjQ9QbjUOfvVTXFNcgICybKxPGabps
+SfXlsnszeCSw1mBEd66hr8JlYFUBI8K92+niz8b/4HUzPEjmgpQvgf8Z5X2Q
+0e09OYXbeN4178j3HXq/peAFQWAYvGTUeHTP2sIhbRuo0m3Crzdyb/leFX6m
+/N1bmZ4M+kTZHZx5YJdcw815KIrjgiOn6HosSeIE7Bcv1VcEVds88XGlEFNx
+cCgwDoFxGAyoOh9iHfByApZE9bMiPs7w3eUvY4nlwZ4aT9ixPCPKtPkMMHk0
+cgs97vM4hsWIYQZunAQ3gXXOVg9OnkNxb6NiHBhAcTx7AHm21qio7YUyalVT
+KuemnbOtPECEzkznwgwosEyRihTg42pNwxicfJsBh3nS/boWM7EATQthqVYU
+CKy0DR1EWtjPQoNkryIFGrreJIvtua4VtefCe5PUsNpsSqFw8MI0NswM2kHm
+uQ8TFFdDgzUnDdC6juwnFMNNOTINKmEL417FPBfogfLD9Nrw73j5FPmNRMm/
+/DQEmWbUWmJUSF2MfTHolFaJXgysUVKFo0x+R1FVmC+lpNIRft0UZWLFcNiR
+G4aCMpf8s3Ux8VfP+Gtr3fxua2tH/7W70d3O+Uq0DDnOeG3NWAp9BMJiB+Lu
+qOW8CJgNpH6qezWHShSrazBbd5nuUMFIWMQp8dl5pu+PVKyfYjL1lb5x6Sh2
+yR0KimvkYXJGny+MW6Y5sDSDGOv8uttbX+g612C0V3Yue+NAH8v2yhleIlqf
+2tkGFDKwzx4MGWh4k3ijEWGp0n2clf3z41UVYkxqd/vYMTu8TYeQ5QLTMYYM
+3Ydm4kBZ3owKKNMBY7EImDMDjdqhMVec2DVAnMzhmCg4JUTACMPFy7rrh7GH
+Wjqb5XgtrEInyvwXdH8jrQS687MxIj6gQdT9WKpCczDa1MW8Vh2J0xB+c91v
+Ad4E/VZ6/5BZ8OYxwCdW3h6kFRd/1lgUdTYliZtHPxUJGuXDG3dX8Ne2fc8E
+nxhWmXZtJv6/JnAU+4OprTN5J0wXDARERxMK94vmemKKFsFwgvPrzFRrG8iY
+PwOqsOeFX1lLtXycqnisndVob8iZjMeFWo16AWGTDYOw3TXdnZcE8SQ11km8
+nTo6yJFYSuZ4apZa3369Y/21a7sfez3gP+GN8x6UYAfKhMEoMHljkgWhdDOj
+oGdxOKSYzBW/c9NZczAeHbcBmAjpqg5qoDUgRUFBaxkbSmqBRkGltIrLuX48
+CQcKZzxbowfj7OCUkhxuSk2gb1fVDskNpcQLjyaAsJNHPkOBmeakV4XvaT8M
+jdDMiP3DJmy+5Ex9YbtZoTZa7ZC7hLl6rZB9teZEvrq1EWGxOg0G2E4RVk4S
+TpsbOqY1kczgWMMBqB/IEUYEDplBbBQ8VWBOlHe8q4i//zf8wEf9IHC9JJPZ
+uvDze9fdW2EmWTU+pi+Se6e4ZTCZ6M+YpJtxUkGLV5Cg+IrcVok/LHmvHyR/
+dkp/JiDHtzdLXvGnf6V/nU49SuMrSF2kMotCDuLnvaLVP8mouQXN+Y1ALhy7
+hx1dWIKTlkDqj8NUyA7ytqrNx/d5FPk4pJIKQr6WpwRoiUA+xqmj4Mm1+Dgi
+gYVBbgBbEOQ2eOHZ57yxKQfLHIeUba1kE+FZ024whDiTzkgj1qenyFuh1XTF
++zrtbcnIStE5bfmwQzu3TcOxktnKX5J5bWA2RUqLQEKaME17mp5fY6qK2am4
+i7zKLvmYQ3UpllmEfmn13eJeJIN0t1sxEHYU1HrX/G5jfdf4a2vbuLfZ3N4y
+DnM7emq72900/trqGe/t9DaMGCyOpdOxVGa81M7Wjv2XEfdk1Gwo89qLjLwh
+ECl1HuIJRbwH/j2HEsS8E1gypDIWQ+cv71E6Mhm6ejeg1iqGml3nooMHwX37
+jWRfK8HxZxS4NBxFlgCivU7vDX5IWatjNE6XJkm0h6/tYVztKN37PAr3onQP
+X9uz9wi9KXJT5YdvEA9HbJtCRufPLPHFO/jFG/4k0SmlLO2XkArIw1V1hXj0
+X/KDGXmn9mD4xaIHs1NO7fFk6k3tmLgnawsnyXh33H37ie8pRPKoyJINNhJL
+0f1SHgEx8sbm1p48gmhQMt1oUFnV4UrlCzQNqzxghfGzxY8fY3EboZ4z7CWs
+7lQam7+f9G8DdAtQVhXsF057FOUQ9i+lGmYVguLRyIrrC/Vt6af3zk/+9R78
++ofbLBune69eYS431kb55CekQ3QAsVf3N69QlXj1Jwn4vXMSpBm8+AeszJPF
+e/j19/L5P/GU4EfueKdQDMn4UTCKtY/KIJVUDyoBVqgVVAaqss5RCcCSwkZl
+IPOVpEogVVaQKoNXLPZUArGkxtOfeL2NewCx5nRNZObAK8M+Xx9EpNdh5k3q
+DyeirFSuFIhVuMN0t10ddRydCQiaJQASEDDHDJQ+dYrIrXGqK7Pg5qELFYvZ
+xfsrH04P99lWo7/tWhPLWGNieY3/xZMFf5e1JvB3KjGhfhEwxHMcy6B/0++r
+8hL4Z67ixPKagLJ8uv/fy3zeLsu6E8vt604IKPnqE05v01lB+YK1J1b5V6w8
+sVpaeEIAIR2/XfkJRciDePyQBDe3mbPSX8VySpuOEEIY6CNzQID76aZE+ekN
+1LmYkwqoQDUV2ADVbYKLyVPoaxMZmvTKhT/AFAN0REkjAAPnAGeREoGfXAcR
+FiIhtlljRTpOBAD8C04TZDRV8odCPcaYN5KRG3WSpBMvwpC7NVneC69g4W9N
+LrAG+n6UcsGNVO4LWgX2HFxgoRX4++3lIWxwfjb1pS0MuJE9Y+RH9SUdNBWX
+U+fEv/FCdKNzJECq6ADGh7iupecPpboq2V7KaKre5/taPgvEXTSmrH0BRJBK
+kTTmzK2PNAJjHr9DnuJSD/ZY9/f3nWTYd32SSDQajvIKPsPHV9+oMjQIIchS
+PxxqgtC2d0KaMFZkAp28w4JJFa1BLnO7625vWx6zBZklpZZ6h+r02Lo9xrFq
+p5+qJuY6tYEeb/Rz1ZHKxkMVt+Bv7OGq7oWNx0oC/hNfaF7GY2aUEzp+R0JD
+IAzNUSmHIReslv/eDJPjiHZd8UmTLj96VcBJSxAl4SLt3qwNSm4Pod2k9Z5x
+WnGaLgy1lyNXjvCYvetHMiV12mFMO1RCrAkEKYyLTorGsZVJZw1fupcqlsPc
+RXZSRQUr516yvqr6IrgZV3xzG1d9A4qH9+B6sI9Br6h9hoLGJ6OKZ2C3UmFN
+7e2q36MoifvhZFDcTfnn/M+F52DprK0OshAOJOm7ar+CpTyq06OnhFbKimVx
+jo6jeKHI1KEPi5EaT+FzAiF3kgRv7G9IbFEOae5LtwLLOviVsC2x3AcdUsyH
+5PtLn5HFSoL7YGcnD3szjl2+hcXB2Ne3pm9mIpywvK0piGNIQRbLI5IjWsxD
+FcDID5djYAHR9cJ778HcklKUmluYwpHbjD4FFa1xzJWbhZYgu6/hqAZD3lqK
+AfrDsSZ0WyJpONXHpK5b2OYUaZPw86b8+dLMn4pnrfyfnIpmpSzy6vufgb8a
+H6skgSreST7QIZzerDIHmATJpRM7BbeR5TdDfXraguOGD+/VK8d2suYrq8HZ
+DGeYUVxtTV704P8JEPn7GOWrNTyytvbedbvbbq9bp70fo4MAhv5R2yKy+FMD
+TTDmcGaa0JS++44AfkfvDPwhW1PfveKvM/7QMbLl5URIZSQH8a3/2eXLSvkd
+wnW6vb3u+l53Y6+7SfD4i9CPboDYS71Op9eTk/ulmjb7JTn2zitdEIBidOAD
+rAKR5G6z1EbFlAeN5TLna2hOFX4YsOGxmB4ZyWALXz9kvrzhMqYYiE3sYWWH
+VN/0CmdN6A8z+RZBSDEKBettOWDZehRV/G/YK/SlvEFTQGR5IdC+OSNEBC3E
+wlDHJaUaftlDA2dg8sFedUnYI6xhkMpImbPL83cKB8mF6waBECJWLdhzji/d
+40vz9cpS/+JVCwbezezx23ipmlvc91xAIeCgAwlVAbAmIS43Vy1uLmHX1OJX
+LvCguJTNHv3wG+sLWefBLT5Rw7CHwnrK9B48Kq8U0SnFvWzUuj33phqVo7pC
+FZWbSNE7FyPyG9xET8SuZUUqGtnWiPXQ3zgcY5Vy3TEzgo2AKv7+pTUoPOab
+wNTsBopb1++LQhrEOuWkKInDoxYGVOjIpIkMBbQogx8CtT5F6Lw1psJ80DU0
+vRJkCeGP/LJiDINWBJyRKcLutYD9gd7tONSLoi90YVHdiEvgURicLqUAilkl
+It51FSrrLVDZF2+3RKYUkZpl1zDvb/1M1E0rBEPyNGkSK2pIhSYOLYiwuqan
+u2Ijx99SRUR74Sp29OZOb4/Ou+qzkasVGmdc7iDEwoJ7Zn1D962Hfm/i9Utf
+XhGhmDkSFpS623G47tegrGpu6qxQZKHzkapBw7HBmGiJUoURJlfKo7n9tEo3
+IJYfsmUP2JQb6zWnDFYdMnd0FemxBpEgvaE+4IUAxxqj2muUIFYT5KK45xW1
+f50VKmG8atEDqxuVqCqLGquUcBgvTnq4SKZqK6zG5gau2q5HEYbRDyqFwSAn
+76rgHAZpPSDYspmlyFfDOsYbqJFPr9AtZiVQUCPGHhVZHXnUr4NkQIshUKVQ
+SgreEAr0zZTsBNaJK9tSWUQcyTeBiKDvmwSsveEkdNLbSUbkot4JBj6y0I4x
+jRJWVuy8tdsDHnsvwV5KsFIdQOvQqqgNH1p4lW1U2TOoipILph/5QJl4OWpY
+mJZQxkar5MStQumSNwdWtKw6aWuVa9l/prxGmUh6IddkKuvlGQotk6Jc9TAT
+EKzNm7dtQV3D6k3Ocvevn//y95XuysrfOt0/r/75r+Pzv6/87ferf+7++T/8
+0ep/li1COr93lnvw1cpf/zbw3OG+++7vP3fXtn75a3d9c3vX2+8f+Ed/B0ir
+fy6+p6Cv9Nb/2nV3/l4G+6/d3t//NvhP989/G8B/AOg/hKMxXG9t95f//G3w
+++LLK2srL3lCq6vfLTdbZzIL2MzS0KvOdRxEcUpPLrxw/ZlGLdbwSOkUYVdR
+mi9JORp5eBFPqX1UwJlvulO9seSLIuA8goMj8m/Yshj4/QB0nDU0mSgG4ga9
+UYZphp8Pw9jjlBTx4Qq85vyHvvsPf7v61+9WlteWS75Y/bvx4juVI8C5KFbC
+s1kkWydGsw9TK2sqR25ZuysD30djBobbWF/OhbPKQDiNPMcsdz/3xr3u6ppR
+phLrTcheT8Lgw/ZqqQ/rYl7TqGmciYZaV6qhloygWTm7+rCaS+heK1lUQXK1
+OBhsvaaqpi5319bXNtZ6WDBD1LE2WAPTfM8OP3ZFBxAQrfDXBnDVyjL8ssz1
+DtgxsCwxRaedAvAR5rvcWeX5HFIUxU/enS8cZ4eBcC2eiuocn0kxOfzp8HS1
+bCpjL+B4kzQEXVoyHaJGi2RPUb2fm+qGNVUMhE/YIH9gsF3yoOq38TPeUeui
+jlbuhQ12uRoPbnTU6weg4WMrszB8sJivWFsYo3aADf2kj6aqp/u6iD1ispGI
+Tlzufl7G3/v+QLjjcVswXZqcrdMGbipUKtrfYXe4ko5w6rXKznBV55csI15Q
+4Hf16ZWgr91Z6nY6Oy3cr1e31VXHSwuONxkBvXWgoVKwc35EQztXaYfevanQ
+mZ4WU3NaM8sud3pVBFKlwqczcfYjq3h4XCgd/lBdOFyhXl9APOdIa1dKHCia
+OlhJnHgfK4jbcGarJK4ANFYUr19rxGcP+y3C+UdxfboFp3Osybmyf3y8qneR
+Gn3/5iahA5E7ZolPKWp7A81dyQpia5yLtCzhajtfNcYoN3WNgvQtjTUuQN9C
+y90Xj1Lherwp0kWL0NlXqUhzYft2I4hnWw9Rs8uP6qvw5+ruc4m+pvuHdRRu
+2JUHe+nk7hvwYxoEEwev6G481YePuZM3qlYuX8Gp5QqOsXg0drqhX9raUFzp
+Os29XbmKVDhLIDftEOa7eOhi/AuuwbVqEoRbHTsILdRwMopZqTLjiNLj3zJV
+LrDdlqLl+sqGFC2ozs4d7LrS9+S1AF/PMwjkTTV85VrLthdzDChBNAw4+/41
+Z6U7dSjcuEVH7UabdhmAb+NRSz8Scr9d0s0sfuBFGhjtEftt0ZiicnkA3E28
+KEQUsGkQmW/Z8t1UcgNbgxbXTrjZp9J1VJn3pq2/s7u153xMSV6QEhsA+u9h
+NtgGSLeDPX5/rnzPqLJrK4EMuEqNznRa2yELr5xi+S09ZxH8BZoXWAaqJoJ4
+UVZGkCkHKiWSjSrxVEUyHsZ3lGfhOWUINF3g0T2u0RHFvnzGPLm9YHy37Xrc
+8wRrDv1bR0nXhUzM0tJF26+yR0dOI61u8iIVW6vXi3q3rOcLSqHettEYBuPg
+15wR9sJcw9SLBM4N0x7FjSE/dekx5/j8btsRtNHNZKrV35ZtZTTete1l5OFX
+bC1TD2BDvow9VSrby2htt3WbGRmhIRGaBoTqM0OI9XqvZZ8abcAisds1rdm0
+QeXZaIbGNer9GRrYSFI/vh6zZjPJXMEzpbpw3ggC4u6JhSnBG0hBo63Zq5wH
+AqTZ080lKZtN3UlK75Tynu1fnn1YtRhL5ugjSe7WldRPjVGrzia0lsuuyvL3
+aDVHVZNSywZ5QHV2xEixLoxBTNd4JWDWR3wsPHPhObOiWmivY+F7jV5UdQLx
+5frA0lvHccoehzZxEtQUWQ5Wpn7hCKSulI3QJlqCOts0jWBeV1sjtAmCoJvr
+lfJuOqs1Q9f5y6Q3zLx5s9akrFlRk9Nsd2dd2dLVF9pH0QBtU/hHzbLQ0rfx
+bpu8lNhxp4rLcq19WhoExViVqkV5K3vFq9Y/6diLVHblvUja5g+pxZbpssIf
+bWGR75kyctZEvoeQlAFqhfnqOsrNiv0h7tAzhWoHxXOI6qSrJgrWu4gOp05i
+FcckuLmB9+EEi8TVBZeCrLl4N8lKGLS+3rUbJKkiYBIOdlLAMBpMVKPeCy1Q
+mPT7vj+YDwkFROQ5Wwt366UW+SR58KbAC8JJ4r8acP9i9D5ymZM1xQPUgC3L
+hdvhj1xWaynNVVyVhTos5mqmCCI1HzkYQoMbIeDTZLr1lxmsRHR+uc0w06+x
+HKh0kZtHnJaG5rwaqSfWaRJ5d/Ao1ZycdrEoJEG9Tkng2H8sBbGJ0lVaObbV
+L33+y9idtP8J86xFSyf27gtu1lxsvT3wMxYus3El6Q1t5ykxJXoGaTqh3SaR
+BbWWr0XVBsuLxqEoXNAez3vRVFzk+E69IIMYA1LY2qSPSNvEe4+ClLCQVbSW
+ZLVED5kMSlCICKKQTA17yrd+vi26s/LT1QWcAcHIuCucxvvKl5lCuyt2t2tS
+AzZRWZfns7NidILHJbzQOdOroickGfJqVqh5TK8Q2PbCxs5ui5sXUKOwroJG
+sEqZyHw4lDBNHGsRtQu6efXnlb967r/33f+r677+m/uPzt9/v7ryqvBRm2CQ
+fbuIKOEgnd+kHEv0HL75QnVW+0nEd5XquOqTSmrANJcUWLSzENXbRinfV5hr
+hHONqWqkCjm6CuO2UdXrx2XI1SOLLKvCyK3imGtHFu6+6TT4I9bbNG9gZQZZ
+OKMiacNui9vo+sszt06L6prBh69eOcBk2UOuFOQvDbDUVilslD3YFpaQcyjK
+atot1YaM9pV5rv2v4YWYqxGwglLaELi0I/Cy1RF42TEU0Vxn4GWz2NWy0RlY
+lrKyugIrKLN3B1YgZJfghnCU2atpmWw7bsOw1q0BMebHiGNmdPC06baWTmvz
+jePzu01cU9NxOxMbyW3uRwO+xaVGx3QRUu3+na6XsYJSiFpLyVfI8RYb3a2n
+yMITn0zvRmx9baJKc5TfmqgKqI9zZ6JHb3mHnwQjD9RfKvTaQqksSXCRZWIp
+zFPAa4jMoNuqRQ6rINYPLGcrbm0XPmt5+9xy9otGQ1OhHpGGGDUZuCBgW+GK
+RgpSfvZrKj2VJItCQX7L9eIlimv2Uxp1Q0m97bTedXbxmy+y9XIoNB0D+naz
+9LKyIPXpy+h+z36pZinfi5BsHo0sNSmT09yFpdYmbIJ/h98NfQ8L4qUqkV18
+4IzXR2NXK5v1uWuiCQKJ13MZ+sNxt3TuwEAr5+un6JVdbXbhbhWioKR/+IKK
+vqn2IWyOufokKzs+hDd4tQY5BaAm18yinSTSMElmohHQ4x1GKF1wLQhn5d3F
+RSNhuq/hhLReK8aKods7Fy5WinhZ7nQ60zxYwSjPn1Z0tdK4v1AOsZw6Gq8D
+vgLS/U2nnzqBEYX9FZhOzYgLIjmPW0Hw0nx5Gw28B5pzcLoNah4pX25nLhob
+cMrHLJS6ycX0tB+VG10bkFSrkZYDF6ubLQKJsg7YOYFOML8T4bzIj/zBq+oT
+1mp5Xl/i0BEwcu27F37itsSmhqJvrUlJcVjsmJmjn3qjqijAdGNS1IwQyQJi
+Ib+/AgGyucyaQTBikOgrgTalC8qQPCFbzmgFRW1sCfRTBCnv5NINDIK7afYQ
++ouap7ioViGKBJycEHjjeU9Lg7hy6Vw/xbbSQXprpDdTaddbvo9k3SPVnebi
+kGJeF02yOl7genK4CRbFCqTpKLDPhROsji0L5v4L7nKVOqBs2V1q5HaA/04u
+LzCaHPvXUeTJUyhlavak/T/yxMkyeEZzpuMz8X30ZMtKt9yNbM5Zk1sLH5IW
+rm56R4dr4rt6UGeFQ1EUr/YnCXVJY0M4QmflKl+wiX5rHcf5EGe+NNapKrev
+XaQYSCCjG7DzDNJBVH5LKdIgAH3G9wbOPyeiEJAXmjG/kghAToGlb5rntDJ0
+eUsI+p9BBWzSr7FNCN6K2VrFUORHVlxuKYRWOOil0kN3gqkv4UN51Q4FhSp/
+oEG1WnESxMMMdoDvc/G+hR0IANbRYHHWvCBStrcWf1s7vfW96lBsGuhcDVQh
+0ksqBU2vz7TUJXyOdcJ/VGHoUrLW1C+qV1v1CI4aAc7VW+8O49zJE40y5lwx
+ATn7OT9Anb3UFkr4ojG0VXQrlk3o1Lsi6l9cb4gxMOhAI8ErK+5+zTw546Cn
+znRN++X1Osi5g8SLPmGXTKM5Rs6hrKtYWKUrhBjUfyP7bCLMI5kcDojvG8so
+YeEMjkzKKBhc8KbeH1IXJq28IRZWO1QVp8T5wVtV4yhvfGS1Hg2FjoEzroW/
+cnRxVrG/qdgpe0cfhRcl/HpONDiwyBwNnCg5UHOkT2253GsqbWQxX3YLSNzc
+OhGdGE5fsVItV/J1nJoJ5kc7b0FNA8kvospX9t9erDqqUiSFJUfxCCs9XT7A
+UKPC85f4Al7sYcGEAVWAEXlOCgiuK675UZKAwZtSHzGw8DMYfkTHkAzr0Z9K
+HDUiby9e4VgiKh7Y5YbSBUDDoO4NeNtKjgpMWAfFHDHKkFDGBqcANCysRcP5
+DEBRAyF93bZPvW0tHn+svWtvpEc7SqbZwDji11Pji7MfshRVGkngL7IPFsd1
+pL8j6dQAUs1voQ0+18uKL7ROGCMY3EzgHHJxPRYqHYTppofgRWutt/e2eqKE
+iHvI4ZL2BixdD1cvV+2yurWLqWCYZQm/2EZKM9nqY/Hrg0ui4E+1OBUEuFTA
+yPtWWYmwynwt32Viwb+YPANL1MVicpijiQQnL8XiVkG6N6lv2bWvPd8qZEu7
+Oay6gNj7q2Gptrtd2Ef5cn0qJ6aiXo29WO6J90CapIysvfBvcDfJmn7OyunJ
+h1enFx++1PpgibHx7diVmseiFwjhn/9w7qzQL36ERBihh+eHeAxSf4z9UVaV
+3qPQl7cKUwk+bAC753yoHsh5K/UrXJCzSebGQ/etZ+RGnXpj1WNY+vbKDp8v
+tFpxfO2OGMVFL1SqlDeRqSbNEXQpUu6obnIQ6PljcgO8gD5mWa7tLvAIgDDM
+itn/b9+frzaFAPz61xI7ysTjB1HTpO+NZQL0gjxVBJ3reDgaehPZd9DhjUa5
+KOJwJOAQRXRMwju2qK209KfdCd7IHfljl/9cxPl+tn8KLKNLqR7xQBSMgWmU
+rKOCwD6CiVi3zgJiCwm1s74N9OEzuSR1k7KmZX6ycZtkxofInDcT1RXAfdU5
+ECXuvWp3LFEteDKqkQ468gdYI47Jhwfe8bk+7CQdXwj9KKJEd3xdBAEpwsRo
+ItuSEI+w0aydvEvKTwWNDwS6eAugE6W1taYSpp0VnN4qMII6PKqufuMx+hAW
+QdHa27AkC/qT0EtEfkhkaBkKf2V1oysQWVihxyWthcMFPXrC4aKdNLbjhRtX
+yJepArE8Xq3CQJWL3Gvg9pMY4B5jvNCEPIn69DsRo1ao5Rzy6GaJz3eDpVeR
+UxJehD06CDR35yigN2Uv9DbFhXt+nsWrPPsSTk271JFQYhjVKgIlYZCKckk2
+wt5Yi2DUC2yRSJ3Qr4KR75z6XjpJuJfzysUVSCSdqUDsrC9km8i4jWSshi5P
+cbuyeGFPUoNUfUVvRuO3jwuioEnjEr7Y5qNywEkk/siTuQSxGjJ/NMAQNm36
+Enzx6gqVVKGea65Mvp2DLkcESG6OGWj0RVJP2xEp5WNpDuqIg+1XxTo9F2ju
+9uYhy1nkExDMxVvp7fVWf20UGoeTdH4SERSm0e9/bTTyo1vUmufaXftUegRv
+OksPCEe2m6bMfi74Dh+FnpYeRrEc/W7fVOFlkLGsqGRXL83PMt/LfPqTTqBj
+AGo5lCqfY1E0/1QdNfWjOkNZAl1TSqmESApv6uTCwFLMdBdzMN9/joxqmSrb
+O7tdoTXuX16eHRzvXx2ffZCmTUVro7rF4NsPOkOMLOoFLYq4WhHA9eL41M3H
+sEHsB53BhP4ZeZ98l1OFXWox27w8G9KGuOTb3yeh4iCewHRcVEEH7nUwCJKF
+0tEE7xB4lgBeSLytTf8i72MvBsX/8DuzvDQRjbLyYD36Y0w9ibLwwWwgCIiI
+CBGZbdxoyG1VG9NyfgD4rTkRbcm1zNSqXgy8E3/ExTDBL2YxZI8GOEHVy0I0
+oeFtLQWesjj0K5X6LVPrKaym5P3BQ+SNRGHDPuwho9hOPM2ytt0y1j57Gl4o
+S4Cp2awB1VXCoDWVbyqgPEn6Sw1CC+BTKr+nIVachve3WM9eAqBq9lSkjRMn
++HWf9RHu3YOc0mSI73aBQcgtdwDqzkQUuj0K2QzHriGTSBQR0fcjEsTK+QG6
+mhWLsMOn0uV3qGYoARyoRDIdmtPIJQY1pavKzpwSLxYzv1htytdZkc8/HvdU
+YTKVAsdJaIW8M6vhdsGbXtY43eLYCtTqjIciCtSFjcdBDUDkCDY607a2Nnt2
+JJWG/U6m1Un3MPKREjJT8CrzaDN5qAf9k5CHPa6eOhpEwRg1uTZ9Kp4F6bzP
+TLoE/XgTLyw2olswDXlAnLAcUqcOPVOC1R5zJv95NzeafpSpOxkpqtAxZ9ZZ
+AKJiL5xHKQo/HXpTLLWsISdQn2sTeaLNjq85QL5tIKe6c8l/uZGenGCRmnum
+wbmc3vl9txUVljXQyx/OPp6oeuoy1FVkGD0Wlz4Rk5KQxG7p9BsGTInacl+e
+QUtR+0LMaUp4dcOA1puEQXdzSaL6ZdwGN9hQnl5aNM+WEuY3wq9K58ELsefB
+pxZKX5A/EQ8uQUZKD7ZKXzDjWTP90gy3KL1H1NFQsLCwxW08mE6VF25fXU5D
+o6aaReTrSZSwvCKRNINsLClZPXwQ2PINdJH/H623TD0yFudXELVVGJmnq5GI
+MicigUC0MzQdyLKQlkLiWsY/YCmGk6OmbKbXW+vre87ZHbaS9O9pyudJEPWx
+oWmqGgpFfpaviFPR8nFzjiUWbxDpsABNEhF9/zWBUfx8WS65yo9u6VahM99q
+HzStsFrZ+Dqjx8yyyIgDnbTUbJBRc9h3rbvjeg5segeTCfxECUJYT5aViDZ7
+XyMd8Mv1FUXZCjVlR0xZ+xSDDCyXBw7EoSqhnvahqaoYunNm6qyI5pZGOiAX
+sM5hTz6iYGDKj1VZP9Sj8hhUM1pBSfxskkSa7fPgEEsRWaSKfNLWUBBMSSV0
+m4GPbVUfa+PYGVDqU7o32N7aqXFdoRBftSW8el1Jelm47YJnjS+mC9uTvLIh
+BjEyq3zZPVlA54n2pKK6RkEEn6Fg8FiCq+BC7K3E7TphQq/ihLt4Khi3cWPl
+sqlrouT4aiG8Wp3xw+WrZrzARaxFJS1Bwr6+6agsYKRHTfyQS5PlY8IMrGrj
+Fv3c8P7AxI1ILBnA0B0NCTTEPt7wVY4DuHS2Qk/Iu+P3crqGBOI6HGLEZWws
+HIR4H9J0zfgU4qKM5h6qy5Ps2dEcVH+JGVH/udIviOAcCgoRdrMQsAXZNLkU
++lg9RpNOS7E3TuLhGUnJ86gR0G0YdteWGCsQKkgEObqFZ/xpiY1RtiQKp5VK
+OCumoZRG8g6T5BHdTok4mQrZpIcer4+tBbaRqlvfIx1SKxIgztfPV01MnqY4
+mDmX0RyTWT89nwL555r1XEEjpoI30yVYNbt5xlWYQq4F91nYYL2tbJJbuAK+
+9YuXw4cSQH0vwXpU95ERgwXnlixqZVZQWAmGWKBqlVuAZdisI6MVxVh1WU0A
+KwqDYqKL3jVNSwSm+4uemYbMPWLGoddnAZUL3BLvAsYr6WorpLmrT+E6bgFI
+M2SBsVoMUYBwQnaeEXGmxH6xRra57zUHYduluTgasBboMrSp+FlhQh2udCtF
+KYQsPOtJJ5C4l+2y0nQ4CRvHxQZH8w9q9c2qZ5QAQ+c5D3TuYQPyHEp4DcOr
+Bpv+DLq8wZrFJpqVinzJ0BXiKodc3ezlDihDhJqLjdtjQ0LukfHBMZpdo3VY
+ehPy2YAtLt5+siK6VcgsgmR5ghFger9DFCnt1iphBJEgMLab5KZh1ItQOKQA
+0rKF12S8jPFvVvkCwdDkzBcOpn4Y4GkQYoUB0QcxDwmXUzX3IZCsTKPSXQWq
+niHn35NtNmHd9puO0VvvtPo9NuOgxe2Uq08yMzG5/EgNJamktPY75QOZ7eFr
+JnVJcyncpLSS5jkcRMnwTwtFpNURWoqI3XtyIcjUHq0aOGjCVFMsx+BTjq76
+FeJVZyV7W6NOxnOSn3X41jQ3B56f3Dx4SxrPTdsWFEXjg6oL5aXGrCsJZ0PU
+TmgsYMiacWivBNGdFwYD3iyz2ZQsq0RhYQ3NsiinRWGQxPbS1iJbQ4iPY5Rj
+JlrixsHuw71mJveATuIFRkQ3vbxGVY6x9PHY63/yM9lUjPpFGy8jzQH58VMU
+Hl/vbE27tMDMBa6alba1qy4G+oJEwM2S6PzU2V0lorSyBNTkmWtQp/NoiSa5
+boSBrOr93EVXo1o9q2JdQy8LsZ8lmZQcypP2jXyitCHY0oeYqzwPh5wjCUqp
+bpJMFQppNL1rmpZToodbMi8jK3ArTSIQxczbItYarTCcCy2JDjnaReMGwgMw
+xWoVCN/I8FPGsBEFfZ3En/wq6W/ikvZv/dEsOmp+ZzCgdKr9UIKIrpX6JfdD
+LWL2fqggZsOWMJLnZUiECqvhRUZsJStyy/DAiMjVYWYi0Ky4FNTzDqMmPkUo
+9Y2ep87yuwmzkHMBE+NpdZaXFM4Fgb2gigBzlQRoxcdjzGpV2WPmJqxfp4ry
+Hfk1ssGPEyxPJq5TxVq9oJoKVeQrCTFbHPEE8F8l6bjE3iORTgF/4aQTrbBm
+LDpja2a5qgJlitmzSmtvRZHKqjhFwtUw0bJRFWe5jFjPnj6NmrRBDNGOhmvn
+iJe/QKR6HVYt17J9oPryCp7iq6JxEZCzfJnl8/Lf6cLS6xShQlC6jEaXb7cL
+Sn+RnPbceGzx3KXYispVYxlYq57UV2ZbsNjn2k1Fn98UIr+398ExjnYqM95i
+0V42xXpzUCxHDSBgzyQgFhZYfrHkmURYYaKi4tWUjPX7nvMxsgp/aDL9upjq
+eqFEe/uboFlNxcKpSGYXLJyBQs/XzOEb49Z2Tjw0p873wKK+lKx4Np4k4zit
+vF6JsB5v0Q2ZR6lmNT4wBA6CKB+EbVK6+cPcRQPlOcalBBxj3TGSgpjb0CI8
+MTTZv5jCNggsB5vI3UE6UnJwwlYzhQPcehxKCOTEIncc0YYco97ux6OR1xwS
+/5y4Le5/irlE/mIWYd85iVOinzGtlZP4fFVSh9yLlDr6gujEay7iI+ejT4F9
+XjRhjJ08597lm5OKDWqUVsMtiMWJZckbNS2RZWDwsRE9+oJoOfBvEm9Qa5lN
+T04JtIGial5c9uilUxS2FRbIWcS2ZVC/lm177wWUXyAuCOcjzU9XF04WjIAk
+eJ80iSK8FXo5tBjEbhRnQApApVjmfipKHMbYEBvQJ1Arhx+w46jacYpRnGu/
+702oj4qaUUQ+GXyPH+AeNi+IjOJGQaoSBGAOYua0eBGbKgW/JiB1AhfDCRQM
+fUyQ/gWR0TaPKFHcFZJmmgbZ+r7D8vmFIv1dZKBLwGomFPtL+XoJFVJNb+PY
+shpapEPInITE93PJL3Vzq91XmJEDK5A85Ao5ywwCTOH3ZCAGHG3U6iUuKOas
+3o9xm2HHGYwCMeS5zIJA0omoO++Tr20DALDmcIDj7ZrD0+N8FplTZJo8L4HX
++qHvJYtcqMjK+SHwTCEh98RQL41OgqMNY6nESv7yzI21orGVh6M6IAo0pYdF
+CFEvDON7u8yFyMCqs59f0HoxXz/OcjWxuBg1n4sXFZ0iL4GSRc6vcBM8R+6v
+cwYZieYSgyB84O1xB2oE1lynWAn1oqe2EZtU6v0VYUaJJQbqW/7IpoaGz3C5
+q70dMy9z8ZytWllzRfktvVLUr8z09fJSrJUJO/kVG7F6I2IEmzCKRSxMDZ+s
+OZMoxCxHTwEosQBhr/v/mvDa592GnA/jU2jmy+OEagP6RXKC9f5snKDVQTA3
+MO1Y23f+5yAFtRJ9K+xXsUFgN0PsSvrb4KSmEuKIR6Gkk3gxz4X+Zz/pB6nP
+dbzq6ucJAIssQZ9DYfE6BOgECZYbgEWhqIlbn7gnTug02p9kMTZI7OvAXWM1
+jTXYP79kH7surYgXGdz1UoVF04mZcMWUjuMcy9sO1Ajzlx1gH6mXmKNFo8Kk
+xU3H8dVH98p539nt7nZ6zt1mp+usdLderXd7m6t7qkqKeVmlpuIqXE+CCPQr
+3EhBSGuUTq4j7k1nvFqjBD6Jyoc4uj52LNK6n97letS1ou9/rehXXCN/GlFa
+J64AyRUHvrxbJrW0upsxCsP23gzABZuyJkMPG9+oQU1oTUlDmzv5nu2tJqTo
+oRolqIKnsGqHGvWmmY/Tvh0VUE6UGj48pxwyl1F0DvCl0Hd7sLSXB26vSc38
+4gTw78bhfAQ4QhmEFeB+DJJsQnERwR316QiwodrRj+cnjd3Du93NHBWwAZKM
+XpDhEMhwp36WxI4cU5HhXZxMRrSFULb1euoJ5xJL1wF/KhI2USRcT/vzUeQE
+8/LddcfmCWflZP3y4NkzRDYYzTd7bF/qHgZ81ItSSaH/WZPh6vD02VMhzqL5
+qHB29cGFibIwDBtbB/c2dvdKK1DZeZRnl+fv+AzA6arZHsTY9j2keKG7OLzD
+F993drqvnTPACsv5Ximlt76JrJ7noD/vNjj0Ms85AJUlspZK8cHhQfN2AMmw
+XiMZzCH02lcMReJB4QOigZmoqVeaIRnmFwyj64HnFuTCCxALw3nn/i64BqGY
+n/q7Zzt1vBjzRWl1l9NRptKM5LtW1vxznqNIhs9fDto0aFSEKM5PvvMCZu1L
+PWHmeStN44XNfDwoxl60nvT+h8vjV0dXl8fO+eEPL23m6Twzv4T5Sit6p7vj
+vHIuzz4cXTlIEeeq1+l1t14aPQbBTZCB1X2fYCGMZHbaHDIg5ycB6IXRIaTj
+efbp8/HurIxvAeco6K++NAIM8Yyeff50xL/IObt9oRbON3epXL4wEsSDSbHK
+VOuZC0Pj8OMn0LOFAMDat1Nx/+bG+u6CyJDr0dpkB+WNqDb0YmDzM42N2wzc
+86LIFgZRMaSxvXAlb5LfuemsObtvX/W6b6disGldTGp+Sr2b28XE3Z8kwRdQ
+75mC8US/qsl46oLPshvVhCuR5XJ9SrCt04oYgAgPZN+PDAVn9JqRSNK7kkph
+rVGQqVTqheLgj1zz3CRoMg8xufG7LOXSloj9eDx15Z8SruLREJiuwqC4qg1H
+ER6paF5fpIJCs9aWVDgIQM3ZdBt77BVzBPkakt4MZHzOscO7ornR9WXQS4vU
+5Skx5uoDk9S7maXAE+eV09tVdaQIfhD1w8nAd7kBn0WQPAI1FFk+ZjD8zrJo
+51c7sP95IQMffa4euGYtNnHb85sX+GbquEYr70IbgR/L+0y4ZS5c1USgzezT
+JLyZde5iAqlzeXHyvsnl9CXmXBZ9QLtMNC8RFfSNIn/XJh8LEE9Woboetda7
+T3aw51ZTuhuU6MNiQpYQSiptltEOm5e6JpZfnmblKM1DK+oXywNahLNpJf+S
+/yJ5JlEgIz4tinN/JQrcyfxknOgSH2qL9EGr9T+Xvk0TkviI81BOINAKmChr
+wVO+5qlUIcTnLHyqLvp5/m2q7xHBa5ef3qOUqCytRJh4RIbxPEmNyjzeP8u5
+s21QxkdvNHnKqvAVDz3FPyah83Upq9EykDLRKsOoAie8Dy0Tj9hS5gQROyVY
+CqVSea1k9sb2Rrf8mpAAFu8KTQg/+gnJ9fU10Kk45GS9s9XZMjq+Odz0bWuj
+u7XnHF+6x5d5s7Bk7DXzdQl5o7Ojp9RE5+BmvAhCUys6LKb23sv8e+/B6GF7
+/P58Jnrv7AIhPnJGUxP4U7s3G/xwZjuWGBTWZuXK8bvtKTbwQ+/Bhf2agFqw
+CNrlyoEQqQ5xkDXYOl5K9RFBHqAAS838OPgZBf0k5lmmLem6Q04vusxuIIn5
+qmZFzcGbnZ75SJ6Td7d2upKT5x9p2vWh5s+T0SLW51SAmrzYdVp/snVan3qd
+vM8LWycB6us6LXSdsF7mAEPer0GluA8GuhPWPIuVE3oXYhDnrRykebGuH9Bs
+wrsuXrFOFfU4pNfukyyZRY2HbeknHMSqJmoCERmN4QMli/Up1DqjatxfglO2
+noxTtko4pUwXJkbQqrkOazfTvmRPYlP3LKjL03SEX4AyXGUwtVKGtbOqylad
+SW8uGChlenObfIKspE208b41LwOPQlaB8U7tasy+HlUrUlSxKhdjBjuAvIdT
+6aVbm5vdGTuiOkZTVHzufFVvtJ3ObqlIXvAio7pfvcrOF1vmMjNkhnVushN+
+a8t9G9ct9xdb7dt4Iav9A4A5iCewDL+1dbVt0Ge4wvVG8iwSHDCh1SJNXqz1
+Yyj0u+sbG/lryEwOXsIq5vsWv+SZBAHx+768tXb3780LPqe2j/Ga4eDpVRjE
+j8Jm0pR+tmxWZevPw2Zg9D8uqx27h53Az4buGPgAjB/XC2/iPefAS5IHVE8u
+L9x9+CQJslsgfTTEBN48uoAJsJaLkx2o6BCTT7aehk9KTMRnyCwtDNl5OKbM
+hJU2p8eGpWRUdElYRlvhVWpMJD3o2Hwmxmh2YRl0bLdxDQZO34vQ2k3pZiFV
+ECy+ZTPDS9O4zznnVO0aH5VGclIEfJ6DsnL6FkQc3/hSXRsRENf2ON7aBNv4
+SMbtA7edKVAyti4V90SFscsO8FpRPI1Ja1wZ5Ww8dV+vr3GK9dmf3oYtYJcz
+aOexVveVUYp5v3bT9WgywhBUoJcYGLPZ+Q7b6JekG5kDRdBDnxVN25nWQlzi
+P9O1kNg9xVrEQFfpVrUXRmAxMHekWKEWC2PPMAv868T3PvnJDAExysehoZhV
+qZsGBDk6DHKd4cqQqonXgPPdfReI1l2Eyjj0+r4R7tSIhPd5biS8z3MikQAn
+xqN5cLhgCK0xkBzjokclolvsWSKiZHRLP/SwloyC1RA5s76DOYkX/r8mQUJY
+Vl6NOmdYRQSv/prnoQKv8u0GqyZbQ08UVthlGCseZLA/r1HfB0bJ/CQtHLK6
+JgI3Hlyjcx9e5bjA0STN8PjGnlV4qOFUPVIJ9Hvkzfb6fX+ctUh2nYV+aqwF
+hmuWUz/Xg/ILUD96+M1RX0a/PTPqA/UG9BoHkUyil0LlMu2lUNZHLYV4I/Pt
+8x9IS57MKN8XyTCi6g2oOWPJqhGa+qC/OrLi7BwBymtYxtdb67CMuEJ3gX9P
+qJ7DovWxokGqgkIwB0CsrFpDY4XL+R+LG0uFyY47rpx2DdefmZOTBSXH4zCo
+jNXux2m2qGGxeXZEEBvoObuJNaN9VagqTe6UhU6bQD73eZNC1tewKM54Bp0J
+I4tZRzOAVbUTwSGCmyhfybwalxqSHxMcEdosKTUNIinaKSX5CFMjIi1asE8Y
+JNGkf+v3P82C15g4Jt/edl7UNNT5sLv3g5vbfOvKeZFTQKfFrdIor+ZzIEIM
+JorvpbBVBIzqWFh10gl/oXzhKQLNK7GeaoPmCegQKIdBFdp5N2FAH+NJNYwn
+Ojumig1MrBscB+d5NFG5wELxWG7SqCKPbm7tFTB9BjiI4dir6nE9zx1bzQ2b
+ikhpTcoodrN4TNXcnpiOmWw7EsWOREGDUI5WytsbUEQRP+PylIDySdE/1mK6
+A3+M+nOUuSnoTzqx/KnYJ6KaiKOYEiEFKhpGYaMwklxKHzR9WW7YcnTzHYWA
+VQUCPpqEiId+z3Peev1P914ycC/8/iRJ8eAvMOXK24vzg1VnEN9HcLT43shg
+xYMjqlIK0jIA2PBnO94HrWO/dOyDI/ctXdkUEbA2QN8fUPVm497wNk6wKiZm
+/qZYAxIvF0gPdg/jEfxpkKvE3Cm7XdRv6N8oiGwb468rN2+FHqRhiEvPXAw7
+MvsPwNReAsTsi2x1awANQcmJH1ySFPv4DlZsBKJMvSfwls3grCfeD8hC0jIw
+mLtI+eOMi5GmY7xGJP9CkDkbPWk3vgu9G4Ae+OHArBDLPx/O3PP9qx/cH48O
+rs4unKuTH59WSJdN6DbLxuneq1f39/edwIu8TpzcvPJSzMcl0/wVLMxYP05/
+dj7fZqPwdyDGaF3uYMlhMbLwbhZJSM4lKodnRZ08tfTXb0bxgIQjuTWU4L9+
+sISmwtoBrEui/5omPqDSufzJJPoUgVgDSrgDEhJPTwXHwIcJYFSbdwSCqOQF
+0SDg2FrzDUZ7ig3Te/14G+Z5C8ZnuQeVt/8ZbD99BCisgshWWIjb0inYbb37
+ld2eC7uRkiaOe14nUrpacV6J4rwANlRqo1ABTEtK4jcNsz2iMvCV2WY/Zlls
+yNP2C5+xg5w1cA+vCMymYbX1r6z2XFhtvD56avUVWxavn56jw6d/y3VmDecF
+qK5wio6mYafNR2Snje72bGG79UG7yFTncRBRb1AuqI1/LcbO/uKK2U0/dkfB
+jWgw9eTcFcXO+zC+xvprcSQS7DQU615t5f3B2aqjcSX/D3lGp2HA7Ue0o7e2
+dqaWZwVxZt1a85Wn4EeDtUFflTXTzBDkAiktCj5b/kvjcPLl2O/gzJEIaABT
+89XWV756Pnw1/pS6/uexx6WUnv7IxCH+y38AWl5zPLS5Gv91ueo4GjvRn3ca
+Xtt5TF5bR18gxjsl1MjgSt6aHGAnQqK7F1LnLYMwpv+5yKgfUwTkKbKw61u/
+fepjKc8gHT0/RrpOxn0sNEpa/ZSu48cxJdGIxHsCh7AyPWizuJXXdx/Vrfxy
+7z++LNuJsLsvY0gKl5jw0Tomi01tPT6iE3aBtxZvnh8HlHjvn5gN2vjrp7nA
+ekQH6a+bFQDEF7nBz9+v69cFOkFqnTq/7nVqEfwkK3LGSQAHjqsqFYrXn1fM
+Uxmy04U6yQVhCCXJOzXDeeMgz80lCDUxcQ4DmOdd4Dn7GHirraGbxBuNSGs7
+lt0SDW18//x4te5uNYcVcsyjIF7cFKS0VLs9n3a7tafQ9c3jEOhtnMDmKanq
+8fZ9OTFECHm3tz71Tk5BCrgqkdWViay8SeQGfW5RjLVITxdlDIdvSR6vucOf
+W6R1gQ5DLgmAiZfezY3O94YDM0ono3GJu6mOgA38elYkFhJSoEDW781N4t9g
+X06deq4BmEitnL49aLW7Z8+XnjlbugW1w9gbuKM4zeg3f+BSkMsTUppS5mFo
+J450AVpKkNVgYP/0ZZUFfIa6ioNNSe+tnJ6cvOAFwDwQ1mVS3VftqQhPaS1Y
+PUJ1TTAPrtODl8zZoAqPkFbYjCXIygOpHp3AOpOb0THIKxCTwStI7qvDNvR+
+3vewU6xQeuslX0ji6HVhJIzJcf2OldPLVlLleS9GjapctRpmS4VnsBqX/MFF
+kH7iurDvk3gyhvXBbJhVXKbL3+QyoYsnX5viS64T4wPL8eHXtxwtLRCzIulz
+9SMUEJ3e0jCKnL4Q60LMtz8ZTUKPtkaWvxPK06VhuxwoUJgrbaXyvgg9qUiR
+oOAHmJ0kx+/PfxU0KaYfzE4TrHxJOvYoX/Py5ZBGGcXt7fP2tNovsbgN4C+S
+YGRcw+ENA7aysdtT64QsZr6NQcgOQybl9XmT6tV339Hf36Hk1Et9g2od4MKX
+Vt9994qflh87JtPVHVpXeOypt7iaH1c7u8FulnBwmcPqC7F3cLyl8ch3+O5u
+4GWeOw497Krk928jjKmAU3tNN/6Ds9nH9oQKQpolE1IfOClS5eF2OBES09+x
+gzrSHBZq2ZzQsgLC9dVT7uyER66Z0GtiojG/IhZgZDQSso6gN6FmecgasLcS
+ghljmoUe0oQqFws7OuFdfVJK+Ep5p99CB47EPLVpzij3b+PAqjNXxBhxVfSu
+WBGD2Rmi/tbIHKYWUd4kzJwlwQb6tepCkYclQz7Yig/jnWru+tmEEPresPwb
+sdImcd/Y31cgRYjpoo65GnByLK49amFJG7Dw6y9qb5Zv0JDiL1psTn5w3o1J
+UKZnbWQUjHg2lsne2VW7aM1ZTjJuprt3o7vd8mz0rhQbsnx3WDOfemeIcjs8
+cWtn4DSN5fuN7YzqZZlinygGXtA2EXirNigm5nI/04CueuRNCaFhWAywakNo
+jn9S0AxUS3auuR9LyhLU7c59Zi1PWf4ecqUEUs74NUNUbQMDpmO8pcAa8yNK
+i2TbBIYoo/UNxbnCl2VU7rah735k4pHFWCf6XxM/VOg9UHkYxqJjMdjx0IlH
+QQbbcQ1sfCyWNhnRhob9jbtaTVS+7hwfWgC4seIfna6zwslAhPhqcY0FMfph
+gKGJX5QUjMOMhOCX5yWDwXZlhDC+LiNFG0r8dOuz5ouSNc0ww1RwaOqkPlbI
+DyUWeIZYs1k2xl+GjYtBWTeTIL0ll0927zPoUceimwXCoIKz4oP587AqtEfh
+5YLjiCgRpILYg3q5YJ3oYz8hsYdX7mxvpI3nu/GOsFFSN4589957EAXdwzhN
+6+TLuTHqqRh15fx01ayTjrI58ZG2wchn9jGPQDwAOVQEg0OAP9lRH5P4iFg+
+pkDW81NVxFv40RQINSFU0G1ghhICALzUuffDEP8de/1PWLHuSEE5P23we7Vv
+G2V4MP+//0fCkP8SqN31jT3HoJ6IwyXP5qUf+tpXe/QZ5xNkocr4ojbFg7oO
+BSLWGyZtN5fSaOl6LlP2qTJgSGoR01p8ozcwbd9JEGUb6+auTrzoxgcB1un0
+tnd2dtZ7WyViocKlzQOJInZYvgEMoKiPkfDllf9/qcLSjZD4FEVv45v5Qkkp
+2yDqpSbXu4WnestGK3/Clw2Y3cfT7MjT5r1XvecU/k17r2bP6W3ZuPceac8p
+DObeanPstSp8FrDXLI54zL12xQPNttdsvn3UvWbjOcdek/KhlU9qjq2mNa2p
+tpa9pRSMr1tr4cdYXYsS25DVPvPA9313GMYebEDFsNygZinfInPJ4GipzX/u
+jrtLDZyuOotovNjzMLnOEq8PQ3ENZ4dTxzz2+A6T2MjqKmm5uSLLIPU94KAA
+VdMV2Wt7Fe8djbeF3YPZizqeDltMYLwL2kMeCobU+V/xJReVt3wWVa7rebp6
+q6bedUd+cUUXJ5PECvJXMyxhhcTKzUDF+D83ptxXGXk5riw0e5WLYCyefkX3
+fVUdnvSXynNuND+CH2B5JKVwvYhLjyiOXFE0XLRTQKGIigw6DT1z8Ek0CMX9
+yppRkchon5Sfgj0+mGnyvgZzNGCpwBKmnVQCrF4nLVneL8ShZevZjkUnWcAu
+vWfGoVrSMYZ8YhOPJr5oK8CsxwxlrLD5glhpWt+VoON31vDMNfuRUa8uPNiS
+VdObQnyX47brUpwsfjM5laNBqvmtFFw9xxVX6wsxXPnytNTj5GxKMKvT3qR9
+BgpYdpvEWQbsLmF2SnWCharbRRfeI5q7X7WZX5s281UX+FXrAl/P0Wd9jhYu
+5oSrY8ojSLotmo+gR/H4tD2CZvMCtXJt3gLL3MbhoJZM7yWIIV8KDIObScIe
+Ef0+hTULBtKOEdn7SOMGsiOtUxnMx2qW9U3bKWoU6qZ4IO+h0FFaRFrfz9Y4
+rZouaaUmweWOjYubKidWi3NuPh/SIrxIc/mRSj1Ji/AlCQZqd8HW/p18UNEv
+bdhDcHHjHb54bJHssb2xs4n5AOSTPEE1CkPYZTdn2qwUaIhrazX/clQT5RYU
+LV6QzCCHSPq6mpINmzWJw9SQ26bANoIppFBXpKdOdsvpZIxnJdVCDzAb/g5I
++qc/SvmlPls2hTqXlRjBa9jIfakUyDK6nLG2PZxyIXyHJ3PkLBlkNX5+D0AK
+I1pBM1UX6armDyUZVmBiq9mOUztWwz3EyVeR9QQiq+SGNB4OrfTVSpWjXumw
+oq+mC185Yww4mkR0eRxwgxbbPGDthJ6rjDHJs2DFxMoCTDZaYXssAK8hVwq1
+aA1RFSMTyj7SHqcwyi+tiJpJKyfgDe78JAtSEpuzTGO+Wajh551HqQScgst6
+nc7I+9zEYL31+aYrsbTJLuwGa7o5UhSnX9dyfYp9aw2q9/AaCB0WOdslFLcO
+JNaXXRBAJmGrz1alYbch5NDekmMv8QAQhqd7IZyXMCiY/D41tBqjMXqN5T2t
+OVGMYhiCicdBZpSpOBkJw0dQd4X7v8b3lSAqX42j8GFVJNL5el0HReZVbWJC
+OF0GDwp5MnZpVOyT6ix7UTzywniSLlsw8ByeRH2RjageoiJcINBWnXtsN43W
+aBLc3ABnlAR7lS+dme3+VCsHpsmLXTiBu7VuzjI7l9uvWR/kFlBmjnXDtrmh
+n6B70bUFys/NC6RjF4OhrKxjxB2CSQ6KpaaKoEReByN3hygdq9aaH/U/930f
+68RhBIJCGlnc1uI0u7dmcRuFErJNx8VNkZDCZSxDJSqCIMuSf32hq7nkeaI8
+QWU22N1/BQTRA3jxib1q2BKU6hxKxiTYfebA2iQPRa+STB0wcoUrDcMqoLm8
+AMoK4FRykchuZ1qau6L2MWEmLdF3wcCdJAF6ncSfS/aj9ZkC+xnqG1QMRZbS
+1LHQpx8vr4y24tX5AkJpMfHJ4UB0jO73xCNv2mN4dWvhhO0eBaKRFWXdFrtS
+zIBzFo9ZWSJBFXKwwq7NazZ28vsCekKT4yazS1Ngf8ltadFbGcfAmDBCHZaV
+oJY+CFbluTP/F4GVanfyMmjaLuZrudlI5W6zs7HmHP3l/OT44PjqHxdnH2EJ
+YDEE5NxLNPLmzs6ecxncRHA0ozj5GMmdR1U3KBf0QnRfyr/vX/rJj7nUT7dc
+QRUYrJYq5L+UCwj0M7UQEGWPCaair7JxDdPTlzmmgfMFhHaM8iuZFBmuNuuI
+/BBXfjKSFVmpIQWY7Ffnq8ZeefnboTofykSTFqAsJcpCFnbMTaw6wLdDlwjN
+e40Ln5TmShXQbrGLyb2ZO86+bueZt/MkarmhGx6UZ/6K3tTy3NefsP6/5Pw+
+zy+wMivl2sLq4tQFHNszHyAmzcNolg5T6x05kpSqHtlemaxr3GILkGWzSeEm
+QXt1buIgEmjj0bVEVtzdYiYoziOXe4Y/0lSER2gljw9VAj7sU537FhmsWQAi
+4H9VDafD7FelGv7qzkLj1Ph6Gi70NPRSV9RSKz0D1dcVCm3p6/jD5UMiP9tT
+jyxMq4Xtuj/J4igeoe/m8iHN/JGzsn+5KnTwl7+Bq3fC/mUT81csdK44hLnI
+XCigsMDVSPAtIL5QKLQg41D8QokE67qj3GV4dSvxLM4xP1SZT+1lOMhAEsbJ
+QCCUZl5WW/sOJ3FBb/AdbEW4FUZ+fi4Ns1IUqwpoNWAjeQiS0F8YqlZCjNUy
+1RF2rgWybHKaide58jqctfhAYJXYMYLdrh/oPRgice6D7BYvehI/fOBIaeeT
+/5C/nJJBJNN5BK2Z/ub8gVO7i0prYSh++6o+zqo+urhBnCH1sinDjypwq4g6
+lx6cAlMK6DBC+Oj9Tv6sqtCPZtWQClYIQtnsvu7uOe+Qdy98ZqsiJAxyFsCK
+pkwd8K3t3p5ziCIkkOaVZ29xLiQH2tDF2WoBxgdkgeMBNtpz+cHKZWtxcDV7
+XB/DpdjWd9RySz+xc1LhWDSev+6g3+4Osjm2cgc9Dy/eVx/eVx+e/fPVh5fH
+7qsS9vUImf8ImcY7mDdpp/ENPgcPXfUpmZ9p8zm5eLdPpUcGf6qcP1933Yvc
+dVP57Cr8KyUh1aVZLsyOoJyQq5TDrIdxnWuM+RFj7QP0ABsZFrZvzICZ85D5
+sJ0wvjF3S4IfA7h+OKGm0y23h6ZELDaXiP0OUg2s3FUrhvQ/L3BIBazBO6y8
+2gpH/Xy5M+04GmCFddhh97c+VvBWfj+xEMZ8EbEiJmYC8cyeS+2glMm5TABj
+tQknYsWC7zAnBtPMS4ywVmEURHG20um84kf8aPBKirZX6kKLbAMzX+n3YCjg
+eyWPruafA+LkPmoazvmjUwK4BdwKlMqwb4HDskhZX241p1nJWIJwbmxr1+bS
+zYyFpdwuZ1khsMwLTD1vkHOq881Sb+TXVT2uZk7cBZxYTigoEecEKK5zm1XX
+6DcwMWHw8yJaHAFgslUoPzchmLeVoKzc3wb9W9YFEI5JA3VUyvhzEKXGDMvO
+8ordA+Dq9w6R4Cl3T9WAT7t/arCYYwdNRcxfyR6CAWfdQWVs3rCHZtsFaWb2
+eK4+tOg5OCFFKrFMiiAgqteJMT17RvIr5gLceXw7xrkLvByUdIg9a+D8gyGM
+9/GCjYUS2Dh4cEpg/lgUGPE/e6Nx6JtixGaDP1hM4KPWhU0CljURlp0/Od3K
+9//U4v0/ON2X3TUgn85oYdqbKpjG4HNapmZt/ReLTVkHxvfd6yAbeeOcsvUA
+X+3d+p9dLu3doHXJtB4s9An/u/HGupx4rbgwGSor7EvpIeMtyDfC4zglA8c0
+g4SqR4/zhunog1IVdOH7++vghuQG1kkyYSzryS7n9xa1MMK9gQ0tPNydD5ly
+MOn3pFgawkyxAbA5N87yDf1hJt8jGKn/rwmanYDvie+RNPs32IYOF7rhJw0w
+smqISncaeQ+4q0WhdrIcrzEqIXsw53CEzUcwnUkST+KwbHLAskUDAD1O7RlI
+8Srr2hD3yd6BWM3KXuuOLs7t2FKE68Jz20Yvy3HIH53edrfbzSV95TD9o9P9
+3O118ae3hthEe9Zorj3dle4qiXI/W1POWLBLgS/GMZ8hAHWcc7ryZGleeroA
+hdH7PQB1vrME1KpZeRp/+ElcFLnLLXkGM+3U4Ly++RhIr2+2wBoeqsXaspvK
+bXZAu9FWtyriKHNRnT+G0SaPYYr/uAemURiLA3LEJX1GVDeZCkdUtMQpeBTS
+NqdzCUKlXUEQ/8II5lmAgStLZKC2OZJwaO86pTTJKnvWwMQJYHvZITUObzFM
+aRWUomrM/b4/zrD20Btut3UfpLAtMTlVgS5jLPG2LAPWMjF8Z2vn9Z7znjvl
+yIooRnc2VYVDdnyzBkbeeI9VVVxRsARLZhXLqgilrNxhNG2AmC7KCGsyEsWz
+ZP879mKpODEBA6PFniBOrBqhmn12ZrykumqoClT0aXkAWUkrVqnKiIaCsOom
+e1OzQPLYilctfK3wyQY9/1je6fCZumygsqybt1DPyr7u+WdwzjiJ+1j0gNiC
++soZqJQ6ne794OY2y00UvU67hvpT1NYqewkZDTVlEVCxBjxStfspF6BIvrKB
+L5onGwLrHvWuJbABzYX6Y95QXNZVT4sro6Cny01T0l3CpLxeFu+y/39ZBnZT
+tF/OWqKhS6fTkgjkPXw0IgjoMxFBvDsdEXLTqTtQgb9HsHv6SlA21GDDpx3z
+aV3gzyjnjwavMTPPeIO/S4R5DmdCLG556QLCrkE3TQPGfRB3oO+mmVUGE3s5
+gdRAcua3c+k2pVt+2N1ZPpOhUTDl3qyUR2KPK47JvzeJxB/+oIlduOSTRpar
+XgIVgkQX/xR9SwRLmOeuULWZJFTQIrttURxqc727vkeXLrjqxi0TwLucjMdx
+gmqWMc573cbOOYXJB666rDSrO9E1JR3Gq2UrA2wzGQOhgjgpll4mQWouia60
+tFPq/RGrsNNC0uLVm2YtQsORaLQpczvt/V7Z5Kk4xhefO2Lx5FNP6Woc+8fO
+oinYb7fZj/waMVuS3o1bEEkU0yD5osazfTutdUKGZYnjL6QMlmBSczDwAj7F
+wcCRPqyiW8E+KgBJfdfiOk88XNaaMX8+yBOppPejeWYVD9Q3bRefWM94UZzm
+UikhRhBAZA7JEzBCA1Z11+XC4tYFUUjjJl+xPI/UdS3+jtqWWiBR6oY5qKiN
+l5jfOaWuoMy1VbpyuUCGzpXm7XFzJKV7euG992AFnJRb5pStggWsHygXpYXN
+blNUThDdZzykVJmVj2ZsNTAnahUpqLZV7mZc7apCrby6EAFZzdGODGmZ5IM/
+cyb6EIh5kn2MPa92dTGrq3iWFBlC6uFyWZ6SI6ThoPeXJON0PJGb+YTu6Yos
+UnES4w+dxsbbxUzHXNhd/kguM2qWWnJjSehIKW3y1Qodi6KC6yRqgUXhIKti
+ncVtqgtTEuXZqnJv5WaUiwd+vnvLppbo/Q0MAWQrxLnTlVmahDf5L8yTofz7
+2mswIvvlxcn7yhwW/mEltQJ+9VK3xEDikK/Zqn9+yX9U+KB2COx9rEeoOZwL
+g+fGqc03KLbYlleZubMWv0R0CoiKkK66fP7S28hCaetKL0l7TcaQsiaxyFek
+tRaFWK32Un1oiM2uuKrsxKg6L6r8BTyL0hO6MJ3CBWHlHKoEXVWd3fKTzBJx
+Uja1VBrmFmtzCjXFevXKQhNHVvhip+VIS59eAEfaaD05R6rpfOXIxXGkSZW6
+A7byeG06XOtPncaDtfZYrT9UWx3qVQdq7lSb5pCb7SBtW4Zj3iO0/ACtOzNr
+fRVicNe88KDKwV/MT1GDUZ3jyr5KEy8Ua8Hq9iGV4Cv9TPHYDf07do/lXA0y
+KKGIQ97TUBi3YE0aV1Rt7v9PKodeUzG8EfVWfpA9mfPFko1XjXbN8GP+Liic
+CqAUL2jll5oI0DPm27rmsq+jJeUyUYYpMCd7FkO6NGnGgy94E8AjSVVqZSV6
+JgiigYlpO/RMECamBVu79Eocf1qZ2HyTZLBJk51daTPr6/Gy0wuZxr4yxySM
+vJnIPCr5XBC/1lCmsulF3jbE/fZmzlwu69hQm7inK7NL97JeNWtOHftN+699
+DqQLlG+BsmsJLMDh8u9hMAqykg588COG7E83KIpfbFWH5KeEl8xPxomvhCrF
+32b+59LmC/kFE6z0mzgLzNiMhqNAHqkkkqz3ak4E87lWAV+sUWKu0nAS8dWt
+WQzfUx4ec08ZaYboxxmNsaoXKfisAOO0vZJ9JkKZvfAGr+1uR3Ykc0VDGWtG
+6tViqLKQhdZuDYbu0Pcy7OSyVKC/YA97v776zhEjYuSqBIpV6PUzLHiKkPKS
+sO4krJmyZADzLCrJNpW98aoCpaqlLczxKvCvE9/7BMdObnLG6hvP/Nwe8+Id
+hhTUBsBO/rX83xTVrHFR+zW+TuOQBI2wRDTQMrW9QDMsOTZBcwbEFcrLfAo+
+4aphFjV+WlT9QOnCNlkcV6VEceANkKOBR5copOvAbvTKDAf/XxMvhO+H3l2c
+cCSAVJ9SaovD5hzAGQf9TyUAKDDbT/OFMCTZnNwEKw2fGj2AfwqBciWlBfGn
+4Clstp1aqAYmx01nX5XnAZOgUSLTVSJzCqFTfLsogAoyuXqTNiHTXFRiphOA
+f2Y9B/iH+5cV8K9guDbsdl2+POU8V+Kbzl/2xEOXmttg4Fw/TjM6w6fd7MXV
+zCXlliLUMrOlTFK1i0bJ7fDW4SjGewkoPfGoMSrFEtJVQq5MpGkg1bKtKMlK
+HZuWEoYlKbB6QH2PVy6ooB9tssP1o67ISWtQv/IDmAk8cNwV3Gja9M4PVTC/
+6W5zGsM78kY4KsN9MGNnipbhzNeuonKIif4jmoWipZKYUm5jVk0wbwcWyCvm
+6g1AMLjEEnaRDrVr2pqBlPog6c6ewMIFrz8at7GPqljywcXlnZcfCUYdO/Iw
+X3mxhBftKc3AiwinksyC0PixzXUcn1Z4WtAol/HYMM3cRPOrVHaktaRf6boH
+VRf1dReqlpRHh32zgCc3eZNoJ1BUv6fdJiKg4yQeY3s3vyaFKgd9/r2jvf51
+wW0L3EdThNJMuX88tXtwUjQdP8ComRxfFgNo6iQ60zl/QKv54lq0FNwlJJ9B
+RPPit5LP1YY17xwiUw2HLVI6qyX5dXBYblIL47PcuqpJl4jetvIxv8qziMZB
+kP4TK09GmDfWJCGth8vT58rg6VqHhSHbGAz4bjxU57Q1hOk8+omtTZUuzteR
+4yQYebDIOPSa6MNpoEg3YAYQtENEODAmkHJPYXwfe3t3KgYx3tcv1A3oxHd+
+kgC/i6I2OSRy8CkuwphGvX0jIr0L8dGGhV6zziKVSoQw6LD5htTJuhhz8W21
+O77yKa0AVD5C8uxNI5u3zBd4H8bXXii217Q0yInzkiFrsjWqhyyoCyata1bZ
+fr5y07c2lQ0lZorbCuOtJoIVB5A7AVsZp34LWSFd5RpUzX31vDfVTX75Bdyd
+LuLatAnNvJ3r9fuT0ST0yG9WZfSWXnu2xMAcoCTgpViZr4VgqBcN+JNjtopc
+jOrVrla57Fg3VhjgtMomCUdJWdTQqY2e8P9hNVTUJLx+xm4vitu6phAtOHRs
+llIsbOJfYgAWQvjrgvjbaBxNk8xPLKcxTTfN6hD1uiCrOnt1npg5/FlAgPqU
+sXOFt0vsipwMaEoJabxLL7lE90V9CteLBm4qM2JZnpX2DfIGg0e9Q69DqFmv
+0dl/sVgLGhmTPSVgM5pIwecKrpamq55v723X2dXp2FUToY/KnO6loakmpjlZ
+Xpnw+npzy1IZZRxjKfWmmYeG0PfG3nUQ2jK5xVxsCs8ymZpQEAQJq4z4wskg
+K61/Gb5lHOh0yhWEL2NXLBsAhu51aGxFtmcMBSvXIsE2xAo5qDYRWihTdol5
+nihYus4B58zmfMLHZvFmIGaCxg7mzcZUputfE29gfuyR/f3x4ri03kEJP9aW
+KG5duvv4XCGh8LdaGlTR1GJnMWxWLOtfqwSVE7RuhNLWATVxZBfH80yrqQyl
+MMTznTnsEQvGKfz3v+Hn229+3nN+B8q8C2TDUnsOSJfQ/yMSBiGnzn/D7hUb
+b+nbb9jY7yMBwPDFa/s/LmFnnSXH+Aatpj8uBX42dKVM+n69u77pdnvu+usO
+DrNE8gHHHn/KaGAXX6VPf+ece/1PfubYOJwSDvgAbgMFfkzP8ihLUkLgTXcC
+GpFKbbWxUc/Jgx8EzM8/CwowIr/wGqFyEINijC1JcGhLmJ1j3CfGUPcnqfMA
+8yfJ5N9z+SoRMsjxa6ksvCfJ6Yd7TupjqFUaG2MPguHwl19oqAqxZmBQLt14
+Yalu4rffSHqUEIvZl0bF4FZky16nR2xCXjF4FugGmuQevr039hJvlO59HoV7
+UbpHVRlLl4AAAOsNg89O7rs34kz4zjmm9TGlJqOEQRT4CK+fYy2a3G4atnlE
+Fw4mPJb+Aj97jlAyiPJYWlMwFQruku4HS9JtUXK2jEOkCULlSqWsNdND3PlA
+nlqwImrJjIVBdf/Gi0SkCWO6dHx09a60DcN+AkcwlmvBQBUEeanqRaxcHe1f
+ytr5P8XJJ/yQitgx+mRW9cX9/NJP752f/Os9+PUPt1k2TvdevQKe9LIE1ybp
+IJU7gNir+5tXGXD0qz9JwO8dNDTgxT+MvCDM4j38+nv5/J9UoUNJIdC4vcT/
+5Fx6XrFtjIKRwredyM++v8FPOmCelEG68D756a3zHiZ+G1QCQ3LC99/3g7Qf
+V4H6MUhvowlIlTs43N4Cdb1RJcC7a/r++39OomAMxAE8y0D+ZTIE4wnIM6mE
+9Jke6YTBhChcP9vjG+DGt8lDCitZCTH4xzU/8f2DdxvzdHm9C0cDVyc2ZLe0
+tFMqoxGGogpQLOrESttvOAnpLYEDsgkf9APV0EEVIu6jTJOi2uTfiPhXgABW
+XZX+YPEPVzIdYHnICY6L7qQ4GSkZKQvznXqRd8O1+XDfpkArub2tvbHy4fRw
+f1VX+UT4aG8DkEHqLGNk/fIa/4tyE3+/OPpfH48vjg7x98sf9k9O1C8Chnju
+8oezjyeH+jf9/sHZ6enRh0MGgWkF1kcCyvLp/n8vc9HM5bPzq+OzD/sny0qd
+lScL1TKUVzU6UFtVheXVveZz6u3BudPbdFZQ6Kz3eq9X+dfd3s7mKoV28XB0
+BNGfAggQ9gH96L6X0NVKGDpgHQQZHEBYBtVJb+P7yMHKuZqQB/H4IaFSdCv9
+VQePcEdIK6ytLUuBwjZJqaSTVD4M1L0JWNFJKhWePqmqzj4MTnBR3wNj+44y
+McQrF/4gSNldGlDk0YCqcgHO4qYBP8GeV2DuE9ussTBWxUOl5Q4sRmVyEcwa
+mvljbOxFeu94kqQTrJ+bxUyudMJOCOVkYC9C34/IsELmlK4qXAW+QbhAOwT+
+fnt5CJKAn9VRUYAbYIV1rlRD7r6kg6bicuqc+DdwiJwnMVs1qaIDOuPYKKbn
+DwW7yAdWpDDPEJDva0EuEKeKk9a+ACLIs16qN6aMQBp5VJGLzjQ86PJj3d/f
+d5Jh3/VJdNFoOMor+AwfX31DWg1RByAEWeqHQ00Q2vBgTOCE4VAENKXrRNp0
+DiuK625vu9ahfUsFlcU7YDyIgscg2eJ7JFoEapgwlsH23VMy1dX13tC1PQzC
+/K2ly7kxwr8LUsp7cO+8JCA+qnosjI1bM/jOdBHXgDAfQxBGpeJWM5RWqDVB
+rXUReDXfN6XP0CzUM/rmrhyPMXIpXpCR3joEFJgRAljQ/i3WEtO+sFKVzHly
+nWxNqOB4mPkChNGMp0ZZM3my63a33V63jidPUM/P9Fuwi0DBxRp1uU5D5YTZ
+3dnZnpkwrFcTPNCuFd/zB6+qfTHkOJJOpYqtQRSShMtSVWhbby/lu7nzn8B5
+04RuzRK9VbUez/kNJq9FRmOAkT+ENXev7w1PBlGsQYaUW+qnR+8c4KACDvXe
+NX6rs7HnHKF3H/RROFCSOxSdzr6+PD6/Rbw2DDM/NxcU2uvbr3cWNRvSPwDe
+tPOB9/C1PWcf7BlqcHGBm/PqNoFz4yAOgdFPybPQOJXdBU9ld7ap7OJUru7j
+2eax2ettLXIeCG+GeeBrOI/DYEjfZwEl3QlOw+m5OL01np/L89MgeKYsgI+G
+lK0IytUPgAaZq5iEGLlqy7EcK9ClTD4pWtWcyept24PcLH5mFUBOK7RyK2rX
+cC27Pa72+X6MAtWgBs62QxzI+VENdErAjA4WIzDTKU4liCgLlPTvUdBPYg6E
+SZs9+jubO7095+zyvNw3gVadGNco1WmgkCqld8PshwCQd7d2unvO8aV7fDk3
+6Nl5CLUtg2EMHvoCnEPIPBq7UOXfExyiHaN0O9TOYuN/PCWXbD4el2xOxyU1
+qvuXlDQ1aFWxTmWcSjXrUEDhU8iX3fWNjXyV30wicGCEYojuDPpt1JBh0H6u
+le3K+cHR+SqC4bd9eXi5+/foX6Hq0RoKl5GGKZxTmYcVDCRcXVNcs9HpddZn
+55svLl0KyCyYRUxxMrcUeQG8kD9plK11xZfZtqVl3HBrRU6VxraslOpbVLpq
+1AUnWgRDabUv0BEn4UNp47hfrGG8SRZPPQK+hDZ032MnLleGr+inW26PHYmJ
+Y3gPEgLNXKu/DlfhvDaGVfiUTZDusOvQ+qWwQP3QS9PikpjdNsowR0UZPZfY
+JvmAQCAndBzufEwJOCLnW55eV8kk+qTRR2GZcv4tVYrhRN7UucEgZBGM5GlX
+OwNTb2uKmMlJjoGKiptSscqTBNN/NQYxdzAwYAHFYukv1XBdFBkDijUDfNes
+uj6YZpemMiU5icMGJ8dmb31zT29UY89TJSrVEcBR9PVwx6rxyJvS5AiRq3vd
+r1hXzeol5e9r2NVc9NIVQEe6cacsZ/ysiKIE0qfrcVqgjQofZUG+9F/w0FLN
+PtASgSPh1nBfYiQHU+BTEMbXCAir3LByUL4TNVqjNmidzofWyL/xpkTrpg1a
+7+dD6yZoQMtwffU/UYcLq4VIvevL9PRJocBw8n1BWg9K8kMMKvwWZXjVUkQi
+wH7lMNemBO+xWqNDgTkLwylGV0jKgTUrY9q6oOSsUjNzG8sqBPsuXXPOuDam
+tNGMo7uUaUl+SpepVqjeF5Q0xfkng5G9IiZhahbiYgJnixc5h3EYpuU0mGru
+O3tOe5DDuFCwBn5swsxKkJE3G0FOvc/BCPS1fXVQL4AqW3vOlHAflzTJokhD
+7sgLumCumdNMu2ibaNZuMDVAKSHbkk1B+Z/OORfp9bAZIxo4YKjjBXz5ZZBs
+bWlbKLqgsIYl7EAzW0lcEtaHcIu4kvNTo9xMoTWXMDdrR9NqmSoyW/ZCHPnu
+vfdg1Z7lUjX8BZaEYRdJRYrMxno+fUGrgb3tnZ2d9Z4KZuaflkk9Z4yAQzVp
+gBcZCTwvwMSJ+pSeUOEmKWb8FGbjitZ9Wdm8akmsXnxjz0NUwuCvl94saJJq
+tHbT8z5/4cUSgmMxiyVn89wWq2qS0y1WpePxaZeMZ6HRqFupin6wQpRvbe72
+9mQQW97vuY9Zx31OoMhn/vz/7X1rc9tIkuD3jvB/wLpjQ9IcQRMgCZLqvd6R
+ZbVbu5ats+TZ2YiLjYBISMKaIjgAaFnT4ftf9/n+2GVmFQr1Agg+9PJYH2yJ
+BLKy8lVZWVmZZzkQEG1US8rv8deg4RMTFJ20dvmoJ2rzUwGNqKU/qn1BUId+
+d19e+9zXFJdgBT2iIqPR9E2OykARXTibKJ0EtbCf8ynT+/5SNWDjqMGC4Qpn
+FpUTbyJBReaOEtfFH56pOY6BZUFPV8LLNGTbn0l8hZvM4JcqJe132t2uF/T8
+jbSU+w6EJl4sQV9jjBcSrkQP6TzJwymWV0ZaaTTBuwt0I581fmN3vPHqDeVI
+wv6ZX/CjcFuOaeFjKYIufuKsDEVjreooZYH0wiLC92K6/7yCkG+D2bLt6K3I
++SdiN04lJv+wFc5TsBVVwXtw0BNFNV0RXQ6rGwacnijjG+UCpKFrvfb8NrF7
+7fyL+/faV63/fc4Q2443b8zyiejv0kn+UGrnKSi1KkT3vWdaW1W2sZcyZvnU
+VGW1vdQPVXlMVXmgHeu6CvMsd7IVtH1iavpjJ/v0tfOJ7GTX1d6nt8NttLA+
+vV2kjaBLI5M1+5xcgbelfU6FqVjRUFQp3gaGYVOzsNQobGISbAahrg6mCHVY
+ZG75aZQWe0JRuE6TPJcqtqgFWWrOjCq8gzrPwKzNL9kUe0rl2mdG32yzMDcG
+DzyLVTcAtllU+mwPO5emvpltCtaFrXpRq1vQahezDaa3weK17sIlp286lkXL
+ahDEqrWWQdBWluUGoSYc9TDit3bY6ZttFo9lENaOCNhm8cgGYdXNmm0KT9gg
+bMGbfVCDYI0uc6V2RUHRBrbhVLYJUXadTCcVNZRrPWFzbEsiS/HQKzGUC66a
+Eg1n3eKWuj+/aG8st4/SG3U+s4xYIQymw6x6ydx5bnQqYCFBPHuaFIhnD0SA
+cDwGt55uQLjh5AtWR84oGPOU6CIh6ShIbo1IS0tGVpS0eLSikXZsam0NYiue
+RCIx89N2FPfDvPitdoWwdSeQxnNevsfHwVwbd8Cty1N9CYUGRUeXXFS3FS8s
+axY2w3Ec673TtDrXPPkeM+dfsbW4FDCQ+kkIXL5zsEzhkpUQr5OxAkHHUoEQ
+ute/e3j8cc+O3oW+ot8/eq8XKSyjZ9gDdffw9ZkdsWgTutkxOPo6xiKdJnWO
+qqgTNaXOXR5lDYeXZ39UNfv59md/GoWfLXM/rZr7fJtzp8HlmZ8aM3+GBlSt
+PlRnQOkW++vlBpQDNmBuSwgOvoTxlHxbNkRxl2d5hdWi0mlRYtVa5XSTSqty
+rc2y4GpfKrj6s3N88P6AEtHBqLMbpxl+8Ru/c1KWl/r08TgryqmzGpV/PXnn
+fIyusDgbpnH88a8gAt1gOPz2rcXAohQV7brxNREuBb8/mmIFd/YRu98rFcDb
+L6qWFnSGwfedJqVHaa7FWxw5rOt2yApg7rNtx/HR2VtR2Qqmse+8f3XQ4jjy
+W7k4Jt1qndFERQlUqSRXY6xkRtw3coxsWBRXqSiI5bmoaFjBEEm6xAXrl0ph
+XfQcspcwKGMxcPifsMTDqN/59s3gEKKwz3618kKguAYfWYVXgq5/JURqX6pQ
+V4OTjRMromYDoWJoe8KKaMEr2XbyIsJmIbOihh6rYgY78iy+mlEfBEtd4p/x
+7HaR4jmOqdwOEzS50l95Y9ooRjkpLzCPr6ObkEwtFgIlQMU1ZTCOAp2LiLYI
+dIvxSxw6M16/86as3znnV84yJ1uM2Y0YMBbvj84PP7z/jUta4Pc8rLucOh+P
+zuQvhp0eiCAPIYB5whBC8eo0vOONwGJWIC9DOkQYo5hldJuNnmiJapXC43Lz
+xI1v5qykAH+NTVG8CiDPGLiz62g6dXbPzn7fK7H1daQE3gpWv5+fn541REAd
+/PzdGQHhZOj1Al4bmnO0KJR6qLRAOiBekJVJkym/abT7/uDwpMB92EVKExhx
+8ZJQi0JWfQG2p7hNzDlfSQSwMmQ8XkzDVBCfn0OJaWPjDNaki0I8Zb+sbHHB
+b8Nj3dFQLKFVgApxcbBhEBNkoh9GWAqRt0h1pSyzvky41OrFbAnObtS+areK
+S78tseFhTBNuS1ZkSmR7OBSNLBSDLqnhU1MwHguMmfGKrlTKGnfOrJApXexP
+qKwBoMMNMm9hxiRGf6FYC7LFNMflg6vlbQykpJJ7VKUXr6lmTD3HvCU9jH4L
+JoEonWBx8nCCv2MBVsZWwBDVUQZwE97he2NuRCJ21T/DIzzqDARwviymWDGY
+hffAG4H9ZqHx0exLnCYzohHOCVtJEwCJj5zYWDfSZSKyx9ejTJlKUcaVdY0q
+hLW4FwxzZJNHc3PFuhZFl5dYwxVzPTg+5bCyyGSFqRwrphKN4nSKRSQWeeH5
+EI+9ticKMZR1gOTlkTfKZjd3lXUY5gFAaXTXdekuclH5ntfLdC/ijDtnh+wT
+Vra+qAkpFveicist61j9k0u1KNKctaSajKrsGvXnmdQdc0+hKFJPzOSx3ugr
+uAEo0M3gywQr3Ax8AtZJnBGge7Fgj3EbBFPj1uy8pnJrWVSS70r4PHYUz2GH
+D0luiutgI5d5UU8X+6BEaZqkLihARvVX8RlYT5MxT1xCGO4kJgJTQgM+kC9m
+s2jqskbSpPoulhb5pRwCrWTChIf/Dh55Mov4I/LXpLMRPMWraPBH5PI7Cew0
+bnhp+CKIQiPhFslSp0d8JzczQ4rba3TKI0odoRTSNHidG2Y3SeOreNZw0OxL
+NOZdsbB92eViJtUsaPZ2s0lWiFMpwWuJE9FMorras6VizFIz1hmypp+SgoTc
+uWZzXZIdWQ2hyjifLoZmtWP9CV4rWZd/+4vWCsmbULtmjjWFk9WvjZrJOkqK
+mZziwnun9hopLWBLwrjYq3FbWishVeq0Kwoy7xWWjn0bfY3ScQxr7C4YYjTL
+exYSI4h9vlQiXeX6wBYJskGoHyC+mtd+f53Uf8+kBLBI0cVa/mRxil73JBjq
+eLIIp1LQqO5xbqixvDp1Gc6aPc17EptPY8dA2faP0WtKcaWXeGkRMmHVGslY
+trqI5ZHUl0p4T2VPCAGUeTJiL4hRtWRmwVho6b1phdlnT8JcNRmw7/5SYxNN
+SDsC/0JD3KIVlAv+5C/iQzIP+Vz7XMWAjb4RHSwYGojZkFKKzEfaEYS0yRGF
+aIp+V7julmAkzHjwgrY2N9gaQgJCOxIMZMUpeoQ5zhyeYN2TsUHVGD3O/RIn
+gTvuNSz01WZTlOMpCd7+IQo/REERBcW8crtM/UL374shlSNKfNHd+ZIPalV+
+w3YXO+P4Zo5rO54o0K6WAiyW6vxEd6wtg/X9bnmvFbHBURuDV2vIZaV+mIBM
+/UBesk15IYpiL1K2yVba/9p5I3JsNln06gfekXDWFIs/4YbT2/Au07hWpv+I
+gdOIdRCHv3UdLQZrsw4bbAl12GmZE1Ikg7U9vWPdX0CPsIP9ROogB/v1GHWG
+Qg4iSoWDI4w7kAc2e9HS9056WSab2OrTSEDBjItIdXf456k5eaJYF6BeStH3
+1fQHrZ9igvj5J+82CMxAWKWkVfmNOyImbH+u8Bh3ZGQK7xHIXTSAcwxWyURc
+T6crwVlVGzC7AEp+pgbW29LaCXawHCPfrCPZtoJr7ruSiyyZRhgAq/UxaRUs
+yV9sxC7ZJgM5Fl5dSRV/0cIsbubSblZ+dpqEE/cmyXL6LZrQrtLy3BgfYa3T
+KWFLCnAV9QxZWAkFBgxa7SPtIvioNJyk6OPP2kk01SXTT6vmxWlV2S8He4rN
+JvFXICXQB+vMXkx5nLQtYpdFLWXluAHHhrfyW+SBFjyk0HJZgBk1U+ae0BzJ
+oInGO5ZunkJWYjpAiKUGWAL/mIKkl+EYb0liZgc19iyW16K156U+rK13KNci
+HuGlIsRhyldu6/tGRBSDyEgeoQ2sTR8asRIn6bT+/fFfKR4MdKFp8CENshZE
+ypoQ2DI16SCY8DO6vPJGSZR0oH7LPuI261c2e5K/dv41f/ETrlI72av/eoVf
+v9rRvldecOn4NlPfY1DhVfHLjv0VjkIBkMe+GbDyND3CY4A5eFm7xmN7DrXE
+4sc0WFFGGCjfC32/1fV+KpCQO5kWpxJ/vBBfi3amL2e3RQLJr+oBMi830+1R
+g5ayMVRZQbA4BjxP5sk0uYrLZCIE9a349UUdUm7OXr6rwC5/GOy6nXGvQ7/9
+i6P9KP1Dtf6ctDa4roRg1YtG41F8ot8fB315VKPxYWfFxocaMhs3Ugw644FC
+l7xBf8IzPF1mcKwtCjUkm4CsbXkY9FtBMB70W17Qk3Fdte8gWiDRR/CFDKns
+KVjfTdCY2/qtDzmALTRA5JCWIP6rU9sMkQExUtMKoV+zMWLx+vKjM/Xp2kM0
+9dHq4zQTgZqDNfXhJUds6sPLDts0PCqO3SxPNT6As+Cz3lGcBmjlQzn1/fWP
+5yxwGh/UsXdVGI2ktzzNM6RXPqnTxE8/s1t7eL3nZjlG/aGdDR/t+G45TqKb
+fMW2x8Cpgq2mJquHRLXKYwWgngHVfh1fzWu/v07qv1fOgBo8yc+Aap80z4Ca
+2I9yL9/s6WJHbxMH+xnQBlJRoyflyc4G8GsUwQhHa4+QxJnqxcJHxrNmdN38
+3gi068PZ57B8xCWjWZakcZJO+MxpnfvHmXtdnH1jnOqMjzWUvSHR5Wi1OtrS
+uHWzuYqgmB2BZaFnFafaSO290r4m8LgZB5Sgog5KBAdXI6oaPmTf11m+MjLY
+fMVtGA+sfqsqMlj9hh4jVJ9cEi1s8nAjYq3SHFwLI2i7mM0ahWuRha00DReA
+lrcOx4cHnbEXDJVARkV/cBYaq9i2Oi+PMU8ZUPtLuXc1XhoGoTfsKwwa+aE3
+8tWPuvBRT9UJ9o3neaHvdZWnvX4/9PtD7bNh6AcqVD/oht1gqH3WC7s8XFF+
+NoLPAjXY0/fCXn/U6gWeTGHz8tqd6NZWnAeb19bE68qBUlWDRatUNGyy2O13
+x72gC2gHEoNpw0MXRyYJ3tF0/7YIJ1ausntoM6mQRcGPOhjKMyDv+X48/xLA
+fnqC/aOAMO7f9R3ytwLfQavbH457g06rN1AiM47UwvIyjlIe2KTD+JydW/ac
+ZJxHOcWLJaxeqGCAOkXEX52wZoTrh4tiyotXR9UgSDiIUfHg3wskRDG+0nJu
+4q+YPZ9dY6B2Br9qoLDZYPGdSw87x6dfAofTVJ+UENvAb3UDkIHBsNUbeioh
+qABX6hy/cc7f/YXHaS6YNJbVFbtFmKnf7fRbDsut0CgKWt4AVrfts9g9Qgs8
+b2QwYAO8UBXOj16sDMhASp2iAEXEbjbPnnWWJUeGYW84UD8bdMLeqKN9BgZH
+M4t9bxQGPU/9rDsIg0B9t9/rw2ej1qAzamSsRCiizlY1aAW7iaXCd018FKND
+n1j6jxZMovag8zS+CdM78jD0B2qCkfgDC9gETwOLY3QmU4QNXWgsYNMnmneg
+rOECGXZN977QEdCbI1RQB/gGi3R0r1TiY6xDrftEr6RacwSVP+oC2kynuOeD
+cFugMYSP3CM2NKnV0lYfqvcoECyeoU/FBFrqU+XEVFDG9CynbEtcGSkc+URM
+hIaUaSeqnRYlVdj4lrsrhbNie2R2u28D0FBI3vIKMwwXuqJaOBkoD9TCEUgY
+ku/MDzrr2Bd0gnAw8FqDwbCWnWq6Ue3ZiSoYq7SO35S9DfFreMBk9qp8d3bq
+yGAdApvV0Xc0hP0JbDFanjfwayksRqo+ajIarXNYD07fGhQV4pLU6A//0oz8
+B+VrtBV2yjEozw8v3/JHIuRMBgYygeFM85VRShtL2WdAeAZbFI6v2Q3VFXbr
+w2Gns1/Zsb2qUbsKiLdtFxVjmXSZpWypku2e80bMXAVTtll0zuKrWTitCgzU
+m2q5YhHP+lHVXXm96vjMSEHUggn3JJejYX8MuqUkNXDdFZg6BaZqz0sjBGFq
+PK20FXBKvfc6Xj/0/E7Qgn/q7aiA3ih4pmm5vHSKgN096jzMawDz8jyJTBjo
+X2RidEEBvzOGJ3tAAU+NBjnSfCpJLz+jyrglDGdmvQpa7Jubrx126NuE3Dsl
+6LPfP3x690aFBOZjwfpXZ3kUTiT2+12YvK9tkFewDsweVBFnbUCAGMqlj1zx
+g9Xl0hqefXSZ9FEm/VEDmeyiTHZ9mH03UHmDeehhmt4V+YXX8dU1hixxnpVC
+WvvSvUutlRlrS2wXJbY7enoS20WJ7SHPer3VJVY5Hnh0Se2ipPYGTSR1BOzo
+jWDW/a66kn0wFx9cmPiMC1HEeWM5CL43hMlXr3JrQ7x3EVe4t7Zo90ZA9QBt
+XlBv88rUTu71iAEJB2x4PZ3e8cQlXh+kQpzuPRTvdfrgXXT6A5CTQRfmpoW3
+yTXt+gN/3/kAziJlcCOY0zSejeM51qiASR5jkeIZlmKTCxsL/ZfOl8oWOf2y
+YaMhSjjoqO+vM+ivdWNKTSJhzsjPwQDmPOysyU+F/sTc6CsiRfz92wJGj/TQ
+RMHSh/Fivc7AA87yiO02mLpNXgF2sIv1xZma+DTAT8FqdTv1e9vVOFP0+HCL
+Cy2PyxncYHQ9D2bpqexxtsIeLQi5CZt8DxjS64Hp6/X7tQwR9K9IVmUkf/xA
+ThV6ZpTB8uQKwYZzetuht6l4Ia2PNBTBahPVtK/ZYq5CwrsmOT9ODymflxU6
+YzW4MAixo2C6mO9gYHdmLo/sMXGnkdbkaYyelFznTYc3SW5nOyogAh/nxY3L
+KoB1USyv63uh1w9ACfqB7HnXylZdgrMi9uZ62lDGNpMypyGqWhiYxE1/wZIw
+VHPQ8PJ9QsFEdvuVX1p1LsN4ipXx6KyYxp9ocSmDLV1YG/vDYcsLJAu8hC11
+qeRPjC21qNrYYnlhRc58LCEQi2J2qY2aTYWXeHpL+VGcVZOIpw+1dUD63zyB
+qATO0KNjHEwi+jwDzRW3YMr3dn7DGxSIycfI5VNv7+jnTRUBS77s93r+YB/e
+H2PjijvYcpXV5ZAH0pT3nPMoBTtC5wY6LNwl0PlDOAVvfeKcLKZ57IqdnBy/
+pD5Zb09O353tLZHgYTf0gt4Ab9LUHzfrwX1rktdjb/m6Q9i+Bn1ZFyu2fN0h
+uPJBH9bqoK+lT+3sIs/3gC+c3zvFyUPBtfowZsP3t72dq1NWYzNX7N/01VPb
+zHUxvSvAzVywZDO3RDweXTBGPZxIg6hVdxSAYAxgqQ30qPaO4KiojHGEUu9y
+N3BVOVkL3HMQm8Afht6oA+viyKvPuJPPPliSo7ZTUXcZ4gBMqzRWUeWhFCUF
+zBblKsDwZoDRvJHXx+kOVJE5mHFc2WExyFyK9WmiTEkpoKIzuXNwekZXq0WY
+TosPwNC8zijlH6cpyMX0ru1gdc2YNiZYNSLFjIOEyo7CmEjWuwoBXA05cMYx
+G3WsL63SaiYtPjCXPXUyKvoakNVnA1QPkPRgxkd+B0ivxf83X3kF3TdbeM1M
+2/NP7rnztj3sDNue86XX7ji7nf4rv+P19vadIsNA0ntxw8txNbq9g/15mOIW
+J57SjLLFRXH5uwQg9BLEc+zDOC34p4xfqWE3+VrdH+YMbEpce99RPct8/C1t
+PbJ/CEqNkFIBUkpTafOUMuc04LcXVjrlLM7SWazFAFV9zUE7Ah35PupAF7D2
+OoC1113CXzFXNjHiUsXdu2X8t95gfWp8tyMp+O2j9faHSL4+kE83JkUSGntX
+kJ19r3n/avhwMOzvO5+ySMSNYrQmsEZhJ7zyGOb47alo3Is98TQTxNLDHDQs
+y5riri94SKKyRkA5XZvg1bshlMGVF2u4LNDUwgTtOzXsm6el36c5JlSB/asV
+hrjyS7VdjCu/KhzuuBTJvvROFXKsci98qu29GI0kZeuCezjqorT4PZCWrl+v
+bFiLtLG2/QsfUtsjC6kCSXl2sojvfrOJZaU5aWBJWNZi5c1v7UG9/tQDBrf0
++VgDWg2qANTFTeyrEmm0LNz2gJY36qEH1euBQHdRoKXSKFaBxuK5WxPo3wFY
+lUBbhaaKtgZlZdpWk3VZTnKljFOnqBMV6fLNyphQoY1Bt7NfrUBlO3O00tjw
+3YRT3NXyW6LCkt/ut/uCq+Ahj/o+cLXnI1eX+HxqyeOt8feAAwSrO4lThmc4
+ZbJJQ65gwga9gbdP1Fhmeiz94GsECn+K+yhF83mJAxW3APV7Po4jVboaVCSl
+A0d6wJagg2xBB7O/xFVT60tvjS0nHOBTZotVz6XVdLuKvmxJ3FDfV199TUhh
+eQlipQXYkMEAtwsDNA199HelG4ZWGbRULt+aIH5SBfAjH6rswddybq/j8TXr
+BsWOpOmIVPNLTngH8LJ3325hZ/cwvWaR8dza4uvxIgWG5VN9v4/VN8e8jCel
+Nq/iY61n1cXYwqRrnz+4llkXg+3qm8Z4Uq83OGwLG0Rl1NAJ3DTWOjG5NCFY
+m6I318jm9DQBlAQu195e2zMfND+hLPb+oFOsM9sau1LXB7jeDDCgEQxB1wej
+el032w5szxUQzigGHIuBmF7y9nNgHPm4GA1mLSgzfQciN5ULlXS79cRcW1y3
+K+YVC+13IO7+I4q7XynuQ9ycDwMQd/gNPN9+Q3EXfTPuX9yxcd0NX65U2edI
+6NfehSbcg+xzPO5H9jnwH7L/ELKvZ7NZuV7tyt3r6m5z65qxnrpWY81S7vga
+uR42yh/nhrtocRAtXqEJSriJNY7hY0pi/xElsd9IEitvtJZBXP0KnPa6Ebiv
+CAeunhG+tTBf1dnCymE+Y8VZVkN09bigEfSuT3Qr4DU5wc8t+cYGFO0kSkpZ
+0M7xjTcb8HNTji49MdPs5BJ2rh1epBuoa4cb+r1e3T1ZvPezp14KMgFpt4RK
+xR+0hw2XoHsRGYwAVcuMicHjCU11rGpDqVkWQPohPFXCg2cXz8LgSIcs25Ud
+PHA5TBbAyB9SUiUlavjrWchLk4jdpmsVYEj8pr0bl5yH2cIN/W53X4uf5gU6
+FvEzodTegEVwDErknOHFn3HkHtyGqQUbS6GIjCpFZJL4dtteZUTuAQW4CGw9
+IwGuj8VtS4BPYJoPLMTH7ps2dUKZg2zBZtgNp1fJvnNY3Gk/++gewCdpnF/f
+yNU/TVCAIQitiwSZFG1PMln2+o8re5YQw7MQwMahkW1JoS0oUsQsQhaYKNTh
+nVL7ofgxAWCQQuR+4OWWhN8op0pidiHAnxqcnHE4w/hJRtkzmYBm0Y4iaYgX
+BpIaURXBl9QEf2qFtXvyGsyyWfxlHUel3/Ng7eBdE1CCy0v4v3GwoiWbHZu1
+SyqsFxiRktMqj2U0QNXNCB8nBlJ5jHQvcY7NTpZKQDXh9ZrQyFp8LM4bngsf
+9fORh+Vj0yMT2So0ODNRmOpj8Qq/Nxy1/LJ660ZX6qtbrj/mpXq/0++NYYpa
+ZvsTKXfge14n9MFmt/zRqL4IjVonrb7PkUK26rRRwRjupqivPfRFhcrZKDq4
+ShFFCv1KYFkRRYeBra2laLMRJn70MUzJvcSmENW2ompmK9iKU30qqE14NZhq
+VozDBTPAIfrzpQkwzQQOa3gV9Vd6Nw991AQ++g1WnGVsmCUVjRYfgQd4jYx3
+nBZFUXVAwk/kvR0m4km3LOPeZCluQJhJhI1Y4TE3A9MEi8hjEwirHGAJqISu
+tHPkdEiG4jLkWXXNxSz8AjDDi2lVBw2Hb+049Cpw8NFiOhHJdeXbITjs48+3
+YTpxP0bjRZqh82wowO7rj6eHew6WwchyoNWNIfaHR6zw8fg6hnHgz9U1z8MO
+oDZsYE/8mvbEJkoW9RtHkwUrTCoCP1SkP8vLyp5YqR8XKfdNchMaLQKsp6i2
+8JD+nv43nc4GmB+6WWFTs7RpJs78fgcFClMg+xg2X8YwOhxhyX53yZYd4Jt4
+nxBItgUtxBCIJLOProEolrxAi6lIVVw7ztm91Wye8GbIF3HudL3CJfxtGl7B
+SHEEgm5cZ2Y/7z+4pwfnv7t/OTo8//AR2xI89kK0bNJye9I4nIXUmBQ2/PHV
+DEfMXgFr5/pL9GH763V+M/0ZDDBx9gsIE7Azn37ZjlWnvR2KvO3g5DHXPP19
+KhIOSkmZ9mK5u7hTlgExGwdm0+h4fhmJJnSvm32ymFG9E5cqFqFhewr0ciQM
+eSV1w3ByxNEF56X5AYb8HpvOmqrrjR5SdZ+PwX+2NqEIATwF8a4yB+UiKLAF
+6VZcQpJp/c5tU6H2Oz+E+vsRanKbufvEOE2u7wrybdkAbVnYhWvPXSpLYI7j
+va5IP6iL9UOk71ekZceEmbrCP3kKZtviXRixC3iRY7yuQPs/BPr7Eei5f/P4
+GxAQnlP/5BTDm+Pr8CKeasnS+AObD/A7btYV2t6DCm23E2yS/1Of/YOie5rE
+sCLmiUv1neb4133Fe56m3ALQq3Hi3sRX9hZ9jyHDs8R5O00uwJAcJjN+E0OH
+9UE6YXN23x5+wOu+xRwozklnEeuKefCg8Zx+f7Cyba4wzR+jvy3ilF7M+Okb
+l3pJjbD35WI+T9Lcku9kkF6h9bOW8iyZLp6SkB9+cAqUdDAbSW//h/R+T9I7
+/5xhif6Q9S17ArKLj7n/Ht0BHy5YspbJz38/23OcEmtevXldiR48rET7GF/H
+ztHpF1zuz4tTVRCrS8atEH0rs4G0cnJkKsWnDMGFgoDs6EqHcRJhQ/s4Mw7S
+noe4XqTzsQszoD3dWsc99x+uwEAFnhE6hKcOwnayWsWDCoEdPvCB0Pd3Pvo0
+hZtFa59MsIIHj/nJiUHDDSMUD3o0svVTTSNl+HlImOXM7tHFrPkp3boH6A96
+YPFD1MQ6+0SyofTMJB0IRzPOlLX5B9dNrjdImeWzcJM0hiXaFaV1FSBPPVPW
+Non1E2QLxjJoajXvX5erl4ZMOI/tGmVBehVF0rAE6nyJQ+dgjt3bxP76Kg1v
+bsjjJi/tMjTVYffg9HhvtfwSDXOU0Qeaoqmw5FguO6R4bOOwCXUvzAoC90Tc
+10kKSm4pKPD6bR0Jea5/x/O3YI9YT9KKFueqgXn6Gfy1k1nbPp2Bq7O0t/qv
+dWK+lTtxG12Iq1eB5h3DrZpRR/YVNGR5n15AK42usNtgeV9UByMju3vy+nBl
+W7Tp1cUNLy6uyClrl+zH5RLdhQVknGRW1kSn22U6sLoG48C8d+++c+Yp/Z8f
+n2lmC2xzeT85/N41CnsoIYVZF9O6dN0HZU55/ZIhaLCGI1wkLyKrzt+syqvn
+k6myEY+z6zB9Mray5CxDyyADKyywe3K2sj18PuxcaUNUxc8sndrbpD4tfp6x
+jz/G2WdWmPVtmizmwOGzj+/e7iGjz34wupbRGAa1X4t/WpxmeAJD3/8jM7Th
+LlQu5fncImLGBDbbbdr62j3/HSanz3hxs5iGpJ5mic9Siddry3QogDvnR+TR
+fn/eqklHS9XLLRISG6D9o1Cy6irjdihZ1XnreyOoCNSsGkVaj8IHlriQNNx3
+S2YK/oB7BIisEANaj8bvKKLDzoRxLIeNRZuT501gbD6KHUj7467X6be6nmdp
+bLxWK6AXChzWUmjod8Gvi1KqNggU4glC5IKdRdOodDaPvuLRUmy2S/qIDd4n
+dWUxea4brIBydXkBoBbDFYrWW7oeWesSrUW8//d/Vbarf21ISwFmTVIW7+uU
+1IuAbE5Qv98Jwm531G3BP/1anzrik3Sxmzxbyq5wZ4mDqNWvFO+3cbWztatf
+9b1e2O11eq1uz/M1XXacmwVYk5e4VXLjibtIY9YBnf58adaDxJ/aao8kdgdg
+oKKQ4plFhpaoauOcfDo7x/qKc8wynZl+Df58Mz8CgJeOjKcVN3L/Z7f7/EEL
+6Cb4n18rGGNVJT4NZhaLYj11uAPdBxMgeU9VckZ04FMIbLxz8nQRCVkLQNZ6
+ATJq0Ktg1C61VMjnErPKT/aI/y+d/2GfFkxs187ovfvhNGITyg9QvMUOifWj
+5+sHXkYCC3AOu+ctCY5GthrZyffpsTUlh2a4fC71ghOMQHAGQXPBGaCGD30Q
+nGHwHSjOABVnOGw8/6Drhd1+D4x0v/dMjXTQA93vBx5MIajS/SdqpAH3IeI+
+ANwH3vMXv6DvTWAm3ebiNwLeBd6o1Q380T3Y7R9W+zlY7WAEVhssUWOxGXTA
+agddUJug9x2ozXAIRniIWjD0y+nYjLCwuEqtWL4xBiyATsIWK6Z1tfLAa9vi
+4XAwhkkMNE7WlUI3G2w3LhPsjwKQgxHufUedQTPC5YvZLJpSUIfupeTZ41Js
+FMAKMPLAARl5sgPChJhV7Afx1GVYSK94YoWQCBKEvygEtFpXCykdDXzA1Id1
+duR3mxGbJ4MLUnPfgR1zccIrNFy9kvX6hB+AqI582VUCTHO8qpTqzg5H2A2n
+t+GdOL9TJXfZy8VbPjbYhW1xR9ORl4cCQHHWtcMLVjsEaIfn8oFpl0LapvpY
+ABUYMUAynLJgXNfreGGv0++24J96V1Dw9yqCUUBBZWW9wDvIj8tbmMpg3OsE
++oLy8vxIaWjHURWcqyPqeTJ3p9GXaCoxuiAvEhJNvwlboq7nIUp9oK7FP4Jl
+lIGwYliDl/Sq+V7RDh27MoTz+fQOL85QjBWIZi5HEgCzhJitVSRHNuPD0Gmm
+4v7IKNEzJgwQ8SiasPL7ZellzhlygEDuWE8JjItFzZp6CswofQ+sD9a/pZM1
+lpNSgbDFl0JqyTNohrAJSJ6BJBQ9EArrdnW1JVO8Udc2suv5vRb8E8CYwwAE
+kVeuVwd++WmOHVRpQkUmZDSbYLkT+E8T0LbjHDh/j9LkhQWSKLyYscraBBJo
+taABprCk50KFOCX1gC/72ZHmslOrDHb0SzapkGw+ne0zNsUVpmMDUsxwfTTQ
+9GK/IepPgecMeZTC1kCY0ohMU/Q1t3besZBSHM5IEtnFRWA0bPW8TueZLwJ9
+UC7Ph/XMMxxSLivmSlmY8jyOLtIo/AxmY4nANQZj30FUbA5xLuVCI6iWXGTJ
+lDh+ccf2F2IAOyB0I617DxDIPMwXmJwCMkTlUYUMDEdhzwuQcEpQglzSckCr
+S1pIVBpdmtuu0qaVUGzHedqedhJdhotp7rwEZ4p60O7rMFLgf3KjT3OZCyxN
+hXfbCKl7CK2U1NHKif62CKfw12X4JcE8qSwyilbwlRcWWyzGSRdjAMg8Hn8m
+Bl1ERv4Bn163C45grxt4rV7PL7zBb/T//3beJ+Ch307xyhIsUGh4YZzLeBpp
+kqjoiUU5I35Y6QKF3IzOifAv4lVN1O4BUpAaodgwG+mQZRaXm7yEN8ciXN6d
+nYpBTM9HjMj6G6usIpEX764n8EJqp9ncFZOlj5bJfc2ptjwnS7rVsqPs7qhX
+1TxCzLuOF6vPvoQ2DueszFy8KQVU3m2TBA2zAXFYkDScJSyDLo8lPRXNYljR
+4lxg1lChDmDERUb3QQW0S+rGAP4fh6lHP9sW1akIXKjkWtFsq+E2RpJJ1HYO
+We+5NOLhUtYZ7/jUWPuABfBEhuHgSZLjc2DlJ/LHIbl4nz4eV+WIiglWakY0
+W9xE9up4Dn3pxJamvUtDji+PTwWiYqZsFIkY9YFXI2RM6OSmfDTDCCTCzpKm
+I1tls9nYwKJtkWEF03OODE4ujfC/ikm17Ihf4ZcXP/38s3Majj9jc6sjB0Fn
+zn+CmXHexJeXGT4gG4I57lWj0h6A8oO/Av5B/BWE/xKLgM8XF8XN7ja+Tr5k
+0TOIdxFg29cJjABv5bfoWuIHNC63SfFMahNKVWf/+OOfsL3uYBB8+ybafRav
+RFNhxfDVP/6Yf87duxDNPXz57RtHJaJty6zklDyBmCp7XIZjXBwwK+4yGS+y
+ImkdwUe3BX+lcW3DFUU/sSbWVZRRlQjKdBftg3QA5dxKqhGBhPNNdo82LSVS
+l8kUTD3+9en98V/pilPIK5TwIQ3CFmTKmpDYNrd9xO//wM+LnwhBahUL6jsn
+KWLL7Z/9jt9xO4Hrddr4qvUh9g0TRpBGIoaLINv5V/BzMSVpJ3v1X6/w61c7
+2vfKC24GcAGg8l4h7q/ELzv2V8Qiy75lW0MOjM2TiU6yyOeL3Nk1HttD0QHt
+w6JTEwcr6BONEKjnjW1pcUjifYf7jUzdwjzk6ocrnSXhqS5V7K/wsy48zw+9
+bstTGtipi/98CqRycAwmv+E4x8ao+BC7yqG6GLOJYiCkoLc/9m1JNfjBTRhP
+82Q/z8Jw8uf/XsziOVjNWZT/Wr/5VV/EF/58hZ+0Qfz5q3hOhyHvVm8kjz1B
+AtFaSb56zLInizAJatDJ6bszMIptFvpgunq5mGp5hbBNxjw6UeeXtzl2TsJZ
+eMVyLJEXWY7G0awZzaHsvj95c7DXtk52OaaFAZeZPCMmK4sHZsypcQDlD22W
+K81MASTPUp3Zr+aIn6M7B8CC0drB8OVOi/2PXi7+/vHof306/nj0Bn8/+/3g
+3TvxiwKJP332+4dP796Uv5VQDj+cnBy9f8MAYUxX+UiBtXNy8J/wFMrxzofT
+8+MP7w/e7QifeQKLAs09ZDXnLiIlFBaqRabYOn7BfO7Xh6eO13N2UXF8zxvt
+sV+H3qC359xeRzM2aDID4tOfCihgwR0tVmFK7UGnUwe2MrBSTWHzD4tEdo1V
+t9D6cGL3vHFfsT2Hyfwuja+uwYaN9xw00c7x0Tkml2KmQ7GkguJltDwUnkU5
+KU0wDXi9FeH1gnFfiT6z4NU4mtHWDWWviEIhAVv0/Vl8M58yOK/P3jjv+OMi
+NqIh2QTkR1wTq+D1vVbfHwdea6jEq2mFxri+7EsoHkzmwAJMcbjC5P+CranL
+2CiHhN/GeRZNL8lUo/KBd38FFhZMZ4yLVIXpXxUFtOCqQZCLPaWXYzcim08l
+n7Cx+yv4DF/aE4hLyCqQliCOTwn/DAXF7fiuFzTdD9JExfuwAck072cGnll5
+vW1fc5nd8n6DCx4oxrGs3dBddn7Bg8hgCMM790uYxuTM1j88TTI9mABPyDHp
+peDkhxFcRX/ERrQods0WUpROGA0oKGMiVD5JMxVP6qHkOvyEww9WCnxrQI2J
+WAxCwp3jFW7qbeLmKDufdZycFj80wPU4UgDFtE6y/V+19xN445HX8kalwXv1
+pz+Zev3qT9LE/+QcC6mWP37VLD6k3ha1K8GzuzNaMY3GN0eLm06n7G0mPc2v
+ZN5El7CrcS9u7RfeGlmaut39ydFvjtdxDDybRxcZhHZ33zkC0lLf6jMsCo0d
+xg9ysC8XCzxFPL1GfLurXKLCJcIPRoP7mz25RjDCJvMHGAgCiwufgQEAFn9E
+tT2/TmENO0ymYCdOwvRzlK4x9eG9T324+dSHOPXz22Rb8+55Xv9+540jbDhv
+BIHzxrgVPpXHFCvhko/kcJEcLUYPl9FDB8TowxaAo0s6LgdP/3dAbMqv3MUz
+VxgOttg0oKbNNgsK1/gcGgw1rt/U6G5mdp1GiFolozx5kl5cUTiQUp9m8SRO
+WaQKVuQ3OLTzFzE0uwLW0l+9icJskTICYdpChty7icdpkkXjRE5raiRea93F
+M5Aq4m29dtfu3dFuYL2bb3WDbVNG0TeVRNGQ0UeWTELvAcWRMtDf4aCrCGKn
+3cGf7j8/rhT2HlIKe5tKYc126mlZyhpE60WzInWuqWjSDd7HsY9Dv9u9v7Zn
+cm8HtqC7B7cYgKMbyDos64XklnTY4bWX14BdQRafoEU00Lt3sZNN4FZt3jOT
+rOVrbbHD94adsOsFra43Mr7ju/+3RRynZvPfG/hh4PmtYOjZxm2eTFIRGHpC
+6SR2/Bru/EleyreokyLBazuW1BFzWzMLb+y5FlmO62G1zjgv3+OroAHGDmdp
+gkeTYEfjZKhGW7XqRIQy82D1eYxje8LmIp7lQU9DgVmMlxfw7yu2GOkGw3ov
+r4m5QmMQU9LNsRS0o33y7uHxx8oC8+VELgxb+sgTeb1Is9w5i/+OU3htlEA0
+pxBtlxd1WB59HWOqkEnroya0jtah9V2uZ1E2QlGm4lETKs4fjoqnUfjZQsPT
+JjScPwQNCUGZgqe1FPzuFiT1fKTpgkQ7x9dNFyQ+VMUo9yd8B6IZHhsaRv4S
+ThfM5L/46Y995+eE3sxYOhn1rgQZxdZrsCShE4gzo7MTpBpPMNpKZhldORlH
+KbWFuAaZYOfxhC38ys9rkK1F/lFeJrhx4SCo2XU00fOwKAqYLHKHdnAsrztx
+bhZjlsA1x64llLDJi3uFlO7wH29FhkDGscTw6xy84xjR4rQqz1Hkc3FM/+fZ
+lTm/goGzIzgfZsXLPFHtcxTNceRMzQuJjVw6vG8WsUywOzYuPUw3CwgDlqw+
+2XcSPC9QX8XLe1keT6dOfEPtS+GRmzbp5yQNby9AKuVMujQJgT4xv/mGZbXB
+tWeMR6xIcqRi3MpQ0/izzqgsxsYd/GF5lreIEV5qm6cRJs+mdOHqhhpiT8v7
+XMoARMYDh6mASssyXf+GcivoENXE0dmN2lftloqkG33N91agCKEO80pJ4NV6
+uAo92NkpkS6e3XFpFtufSonm04TxU2OWX8ByzmF64nyWC2+1eqASxHQZhSuG
+exFnTWfL9YQWWDQCHAHWT/QivpJhOv+NSSMsy1uaL0M9oR4HbecE7ADYh5Ql
+vCyurqIMXaDJgiJSlHzieV3MVAL0SRfjbLzIcKotztWqqcuZiTIFilusMT/D
+5spiWIuLBZP3JKIFA8ZiCn3B159o0qLPMv5haXdo4pixSefhdPxaNq2Bz2Ui
+7WIexh9//Ct8Nup6vW/f9ji7L5NFCqaZ8btFZRy59eUGwe10kCA8XQRmFSIm
+lKjoijSlgt2UnlskOlE+En7SVAKR52DwimtiUtLUL2w4kH66WI5Qbq+TaSTu
+40lpsRIq1ErgIpnc8ffBSDpZcsNW66wlyIxrx8SyXLQKYJZhMOUX83yVJN8Z
+u6y8nUkTh1iJPX4j9BLkADUHtCJNbgq57SnSmsvJPSKSCWsDbBQos45L1xjp
+oKonm+6KFHogOrxhqsrzCbmWZlHGsllyQQtMhQOFy2H5YzVgCzsiSAGuTgoj
+jmHhQsBFKhNmS+YpKnPaRiQpmekminANegWAX8FCjXftpuAMTTE1xYUP3Rnh
+4oZ40Xgej90bzHGku0fXkRt94Q3PsWgoTZzSobmdBsVqzyeXiMNvC/IBClIV
+dlFo0jhZTGGxmsZXszITXNCrMJ9t7lexZSGa/M+Xl4Bt9JL7VwdjbFo5jSYs
+BzMrXKFwAe5KCksjDUKLKfEqpBpAHxOAlTv/gcmywO13ycJ5HaVXaEpPQnAi
+rp1/i/BZ3I/OYvJ9/y26vHR+DzFZj18shS0PruDkX8UzTIbm0lAK7oufwHle
+qKafRAvTk+hqIssIMta0UBGicIrr+p1kJdmlGJDyNs+tPldIi+YMfAGWZc8S
+5D+n4c2Etff8/1BAStOZ9wMA
 
 -->
 

--- a/ietf-te-packet-types.yang
+++ b/ietf-te-packet-types.yang
@@ -134,8 +134,8 @@ module ietf-te-packet-types {
         Marker with Efficient Handling of in-Profile Traffic";
     }
 
-    // CHANGE NOTE: The identity link-metric-delay-variation below has 
-    // been added in this module revision
+    // CHANGE NOTE: The identity link-metric-delay-variation
+    // below has been added in this module revision
     // RFC Editor: remove the note above and this note
     identity link-metric-delay-variation {
       base te-types:link-metric-type;
@@ -154,7 +154,7 @@ module ietf-te-packet-types {
     // been added in this module revision
     // RFC Editor: remove the note above and this note
     identity link-metric-loss {
-      base te-types:path-metric-type;
+      base te-types:link-metric-type;
       description
         "The Unidirectional Link Loss Metric,
         measured in units of 0.000003%.";
@@ -166,8 +166,8 @@ module ietf-te-packet-types {
         section 4.4";
     }
 
-    // CHANGE NOTE: The identity path-metric-delay-variation below has 
-    // been added in this module revision
+    // CHANGE NOTE: The identity path-metric-delay-variation
+    // below has been added in this module revision
     // RFC Editor: remove the note above and this note
     identity path-metric-delay-variation {
       base te-types:path-metric-type;

--- a/ietf-te-packet-types.yang
+++ b/ietf-te-packet-types.yang
@@ -61,12 +61,14 @@ module ietf-te-packet-types {
      This version of this YANG module is part of RFC XXXX
      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
      for full legal notices.";
-  revision 2024-01-25 {
+  revision 2024-02-09 {
     description
       "Added common TE packet identities:
        - bandwidth-profile-type;
-       - path-metric-loss;
-       - path-metric-delay-variation.
+       - link-metric-delay-variation;
+       - link-metric-loss;
+       - path-metric-delay-variation;
+       - path-metric-loss.
 
        Added common TE packet groupings:
        - te-packet-path-bandwidth;
@@ -132,57 +134,64 @@ module ietf-te-packet-types {
         Marker with Efficient Handling of in-Profile Traffic";
     }
 
-  // CHANGE NOTE: The identity path-metric-loss below has 
-  // been added in this module revision
-  // RFC Editor: remove the note above and this note
-  identity path-metric-loss {
-    base te-types:path-metric-type;
-    description
-      "The path loss (as a packet percentage) metric type
-      encodes a function of the unidirectional loss metrics of all
-      links traversed by a P2P path.
-       
-      The basic unit is 0.000003%,
-      where (2^24 - 2) or 50.331642% is the maximum value of the
-      path loss percentage that can be expressed.
-      
-      Values that are larger than the maximum value SHOULD be
-      encoded as the maximum value.";
-    reference
-      "RFC8233: Extensions to the Path Computation Element
-      Communication Protocol (PCEP) to Compute Service-Aware Label
-      Switched Paths (LSPs);
+    // CHANGE NOTE: The identity link-metric-delay-variation below has 
+    // been added in this module revision
+    // RFC Editor: remove the note above and this note
+    identity link-metric-delay-variation {
+      base te-types:link-metric-type;
+      description
+        "The Unidirectional Delay Variation Metric,
+        measured in units of microseconds.";
+      reference
+        "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+        section 4.3
 
-      RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
+        RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+        section 4.3";
+    }
 
-      RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
-  }
+    // CHANGE NOTE: The identity link-metric-loss below has 
+    // been added in this module revision
+    // RFC Editor: remove the note above and this note
+    identity link-metric-loss {
+      base te-types:path-metric-type;
+      description
+        "The Unidirectional Link Loss Metric,
+        measured in units of 0.000003%.";
+      reference
+        "RFC7471: OSPF Traffic Engineering (TE) Metric Extensions,
+        section 4.4
 
-  // CHANGE NOTE: The identity path-metric-delay-variation below has 
-  // been added in this module revision
-  // RFC Editor: remove the note above and this note
-  identity path-metric-delay-variation {
-    base te-types:path-metric-type;
-    description
-      "The path delay variation encodes the sum of the unidirectional
-      delay variation metrics of all links traversed by a P2P path.
-      
-      The path delay variation metric unit is in microseconds, where
-      (2^24 - 1) or 16,777,215 microseconds (16.777215 sec) is the
-      maximum value of the path delay variation that can be
-      expressed.
-      
-      Values that are larger than the maximum value SHOULD be
-      encoded as the maximum value.";
-    reference
-      "RFC8233: Extensions to the Path Computation Element
-      Communication Protocol (PCEP) to Compute Service-Aware Label
-      Switched Paths (LSPs);
+        RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions,
+        section 4.4";
+    }
 
-      RFC7471: OSPF Traffic Engineering (TE) Metric Extensions;
+    // CHANGE NOTE: The identity path-metric-delay-variation below has 
+    // been added in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-delay-variation {
+      base te-types:path-metric-type;
+      description
+        "The Path Delay Variation Metric,
+        measured in units of microseconds.";
+      reference
+        "RFC8233: Extensions to the Path Computation Element
+        Communication Protocol (PCEP) to Compute Service-Aware Label
+        Switched Paths (LSPs), section 3.1.2";
+    }
 
-      RFC8570: IS-IS Traffic Engineering (TE) Metric Extensions.";
-  }
+    // CHANGE NOTE: The identity path-metric-loss below has 
+    // been added in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-loss {
+      base te-types:path-metric-type;
+      description
+        "The Path Loss Metric, measured in units of 0.000003%.";
+      reference
+        "RFC8233: Extensions to the Path Computation Element
+        Communication Protocol (PCEP) to Compute Service-Aware Label
+        Switched Paths (LSPs), section 3.1.3";
+    }
 
   /*
    * Typedefs

--- a/ietf-te-packet-types.yang
+++ b/ietf-te-packet-types.yang
@@ -61,20 +61,20 @@ module ietf-te-packet-types {
      This version of this YANG module is part of RFC XXXX
      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
      for full legal notices.";
-  revision 2024-02-09 {
+  revision 2024-02-16 {
     description
-      "Added common TE packet identities:
+      "This revision adds the following new identities:
        - bandwidth-profile-type;
        - link-metric-delay-variation;
        - link-metric-loss;
        - path-metric-delay-variation;
        - path-metric-loss.
 
-       Added common TE packet groupings:
+      This revision adds the following new groupings:
        - te-packet-path-bandwidth;
        - te-packet-link-bandwidth.
        
-       Updated module description.";
+      This revision provides also few editorial changes.";
     reference
       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
   }

--- a/ietf-te-types.yang
+++ b/ietf-te-types.yang
@@ -90,12 +90,12 @@ module ietf-te-types {
       - base identity svec-objective-function-type and its derived
         identities;
       - base identity svec-metric-type and its derived identities;
+      - base identity path-metric-optimization-type;
       - base identity link-path-metric-type;
       - base identity link-metric-type and its derived identities;
-      - identity path-metric-delay;
       - typedef te-gen-node-id;
       - grouping encoding-and-switching-type;
-      - grouping te-generic-node-id;.
+      - grouping te-generic-node-id.
       
       Updated:
       - description of the base identity objective-function-type;
@@ -108,6 +108,10 @@ module ietf-te-types {
         identity;
       - description and reference of path-metric-delay-minimum
         identity;
+      - base of the path-metric-optimize-includes identity;
+      - base of the identity path-metric-optimize-excludes;
+      - description and the reference of the identity
+        path-metric-residual-bandwidth;
       - description of path-metric-bounds container in
         generic-path-metric-bounds grouping;
       - description of path-metric-bound list in
@@ -118,8 +122,13 @@ module ietf-te-types {
         explicit-route-hop;
       - description of the upper-bound leaf in
         generic-path-metric-bounds grouping;
-      - typedef te-node-id to support also 16 octects TE identifiers.
+      - typedef te-node-id to support also 16 octects TE identifiers;
+      - type of the leaf metric-type in grouping
+        optimization-metric-entry.
       
+      Deprecated:
+      - container tiebreakers in grouping generic-path-optimization.
+
       Obsoleted:
       - identity of-minimize-agg-bandwidth-consumption;
       - identity of-minimize-load-most-loaded-link;
@@ -2292,7 +2301,6 @@ module ietf-te-types {
       // RFC Editor: remove the note above and this note
       identity path-metric-hop {
         base path-metric-type;
-        status deprecated;
         description
           "Hop Count Path Metric.";
         reference

--- a/ietf-te-types.yang
+++ b/ietf-te-types.yang
@@ -1197,8 +1197,8 @@ module ietf-te-types {
       "Indicates a constrained-path LSP in which the
        path is computed by the local LER.";
     reference
-      "RFC 3272: Overview and Principles of Internet Traffic
-       Engineering, Section 5.4";
+      "RFC 9522: Overview and Principles of Internet Traffic
+      Engineering, Section 4.4";
   }
 
   identity path-externally-queried {
@@ -1212,8 +1212,9 @@ module ietf-te-types {
        returned by the external source may require further local
        computation on the device.";
     reference
-      "RFC 3272: Overview and Principles of Internet Traffic
+      "RFC 9522: Overview and Principles of Internet Traffic
        Engineering
+
        RFC 4657: Path Computation Element (PCE) Communication
        Protocol Generic Requirements";
   }
@@ -1226,7 +1227,8 @@ module ietf-te-types {
        hops.";
     reference
       "RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels
-       RFC 3272: Overview and Principles of Internet Traffic
+
+       RFC 9522: Overview and Principles of Internet Traffic
        Engineering";
   }
 
@@ -2265,7 +2267,7 @@ module ietf-te-types {
     description
       "Base identity for the TE optimization criteria.";
     reference
-      "RFC 3272: Overview and Principles of Internet Traffic
+      "RFC 9522: Overview and Principles of Internet Traffic
        Engineering";
   }
 

--- a/ietf-te-types.yang
+++ b/ietf-te-types.yang
@@ -77,67 +77,86 @@ module ietf-te-types {
      for full legal notices.";
   revision 2024-02-16 {
     description
-      "Added:
-      - base identity lsp-provisioning-error-reason;
-      - identity association-type-diversity;
-      - identity tunnel-admin-state-auto;
-      - identity lsp-restoration-restore-none;
-      - identity restoration-scheme-rerouting;
-      - base identity path-computation-error-reason and
-        its derived identities;
-      - base identity protocol-origin-type and
-        its derived identities;
-      - base identity svec-objective-function-type and its derived
-        identities;
-      - base identity svec-metric-type and its derived identities;
-      - base identity path-metric-optimization-type;
-      - base identity link-path-metric-type;
-      - base identity link-metric-type and its derived identities;
-      - typedef te-gen-node-id;
-      - grouping encoding-and-switching-type;
-      - grouping te-generic-node-id.
-      
-      Updated:
-      - description of the base identity objective-function-type;
-      - description and reference of identity action-exercise;
-      - description of identity path-metric-te;
-      - description of identity path-metric-igp;
-      - description of identity path-metric-hop;
-      - base identity and description of path-metric-type identity;
-      - description and reference of path-metric-delay-average
-        identity;
-      - description and reference of path-metric-delay-minimum
-        identity;
-      - base of the path-metric-optimize-includes identity;
-      - base of the identity path-metric-optimize-excludes;
-      - description and the reference of the identity
-        path-metric-residual-bandwidth;
-      - description of path-metric-bounds container in
-        generic-path-metric-bounds grouping;
-      - description of path-metric-bound list in
-        generic-path-metric-bounds grouping;
-      - type of metric-type leaf in
-        generic-path-metric-bounds grouping;
-      - node and termination points identifiers in grouping
-        explicit-route-hop;
-      - description of the upper-bound leaf in
-        generic-path-metric-bounds grouping;
-      - typedef te-node-id to support also 16 octects TE identifiers;
-      - type of the leaf metric-type in grouping
-        optimization-metric-entry.
-      
-      Deprecated:
-      - container tiebreakers in grouping generic-path-optimization.
+      "This revision adds the following new identities:
+      - lsp-provisioning-error-reason;
+      - association-type-diversity;
+      - tunnel-admin-state-auto;
+      - lsp-restoration-restore-none;
+      - restoration-scheme-rerouting;
+      - path-metric-optimization-type;
+      - link-path-metric-type;
+      - link-metric-type and its derived identities;
+      - path-computation-error-reason and its derived identities;
+      - protocol-origin-type and its derived identities;
+      - svec-objective-function-type and its derived identities;
+      - svec-metric-type and its derived identities.
 
-      Obsoleted:
-      - identity of-minimize-agg-bandwidth-consumption;
-      - identity of-minimize-load-most-loaded-link;
-      - identity of-minimize-cost-path-set;
-      - identity lsp-protection-reroute-extra;
-      - identity lsp-protection-reroute.
+      This revision adds the following new data types:
+      - path-type;
+      - te-gen-node-id.
 
-      Container explicit-route-objects-always renamed as
-      explicit-route-objects.";
+      This revision adds the following new groupings:
+      - encoding-and-switching-type;
+      - te-generic-node-id.
+
+      This revision updates the following identities:
+      - objective-function-type;
+      - action-exercise;
+      - path-metric-type;
+      - path-metric-te;
+      - path-metric-igp;
+      - path-metric-hop;
+      - path-metric-delay-average;
+      - path-metric-delay-minimum;
+      - path-metric-residual-bandwidth;
+      - path-metric-optimize-includes;
+      - path-metric-optimize-excludes;
+      - te-optimization-criterion.
+
+      This revision updates the following data types:
+      - te-node-id.
+
+      This revision updates the following groupings:
+      - explicit-route-hop:
+        - adds the following leaves:
+          - node-id-uri;
+          - link-tp-id-uri;
+        - updates the following leaves:
+          - node-id;
+          - link-tp-id;
+      - record-route-state:
+        - adds the following leaves:
+          - node-id-uri;
+          - link-tp-id-uri;
+        - updates the following leaves:
+          - node-id;
+          - link-tp-id;
+      - optimization-metric-entry:
+        - updates the following leaves:
+          - metric-type;
+      - tunnel-constraints;
+        - adds the following leaves:
+          - network-id;
+      - path-constraints-route-objects:
+        - updates the following containers:
+          - explicit-route-objects-always;
+      - generic-path-metric-bounds:
+        - updates the following leaves:
+          - metric-type;
+      - generic-path-optimization
+        - adds the following leaves:
+          - tiebreaker;
+        - deprecate the following containers:
+          - tiebreakers.
+
+      This revision obsoletes the following identities:
+      - of-minimize-agg-bandwidth-consumption;
+      - of-minimize-load-most-loaded-link;
+      - of-minimize-cost-path-set;
+      - lsp-protection-reroute-extra;
+      - lsp-protection-reroute.
+
+      This revision provides also few editorial changes.";
     reference
       "RFC XXXX: Common YANG Data Types for Traffic Engineering";
   }
@@ -146,7 +165,7 @@ module ietf-te-types {
 
   revision 2020-06-10 {
     description
-      "Latest revision of TE types.";
+      "Initial Version of TE types.";
     reference
       "RFC 8776: Common YANG Data Types for Traffic Engineering";
   }
@@ -1153,7 +1172,7 @@ module ietf-te-types {
   // RFC Editor: remove the note above and this note
   identity objective-function-type {
     description
-      "Base identity for path objective function type.";
+      "Base identity for path objective function types.";
   }
 
   identity of-minimize-cost-path {
@@ -1192,7 +1211,11 @@ module ietf-te-types {
     status obsolete;
     description
       "Objective function for minimizing aggregate bandwidth
-      consumption.";
+      consumption.
+      
+      This identity has been obsoleted: the
+      'svec-of-minimize-agg-bandwidth-consumption' identity SHOULD
+      be used instead.";
     reference
       "RFC 5541: Encoding of Objective Functions in the Path
       Computation Element Communication Protocol (PCEP)";
@@ -1206,7 +1229,11 @@ module ietf-te-types {
     status obsolete;
     description
       "Objective function for minimizing the load on the link that
-      is carrying the highest load.";
+      is carrying the highest load.
+      
+      This identity has been obsoleted: the
+      'svec-of-minimize-load-most-loaded-link' identity SHOULD
+      be used instead.";
     reference
       "RFC 5541: Encoding of Objective Functions in the Path
       Computation Element Communication Protocol (PCEP)";
@@ -1219,7 +1246,11 @@ module ietf-te-types {
     base objective-function-type;
     status obsolete;
     description
-      "Objective function for minimizing the cost on a path set.";
+      "Objective function for minimizing the cost on a path set.
+      
+      This identity has been obsoleted: the
+      'svec-of-minimize-cost-path-set' identity SHOULD
+      be used instead.";
     reference
       "RFC 5541: Encoding of Objective Functions in the Path
        Computation Element Communication Protocol (PCEP)";
@@ -1230,6 +1261,9 @@ module ietf-te-types {
       "Base identity for supported path computation mechanisms.";
   }
 
+  // CHANGE NOTE: The reference of the identity path-locally-computed
+  // below has been updated in this module revision
+  // RFC Editor: remove the note above and this note
   identity path-locally-computed {
     base path-computation-method;
     description
@@ -1240,6 +1274,10 @@ module ietf-te-types {
       Engineering, Section 4.4";
   }
 
+  // CHANGE NOTE: The reference of the identity 
+  // path-externally-queried below has been updated
+  // in this module revision
+  // RFC Editor: remove the note above and this note
   identity path-externally-queried {
     base path-computation-method;
     description
@@ -1258,6 +1296,10 @@ module ietf-te-types {
        Protocol Generic Requirements";
   }
 
+  // CHANGE NOTE: The reference of the identity 
+  // path-explicitly-defined below has been updated
+  // in this module revision
+  // RFC Editor: remove the note above and this note
   identity path-explicitly-defined {
     base path-computation-method;
     description
@@ -2444,6 +2486,10 @@ module ietf-te-types {
        RFC 3209: RSVP-TE: Extensions to RSVP for LSP Tunnels";
   }
 
+  // CHANGE NOTE: The reference of the identity 
+  // te-optimization-criterion below has been updated
+  // in this module revision
+  // RFC Editor: remove the note above and this note
   identity te-optimization-criterion {
     description
       "Base identity for the TE optimization criteria.";
@@ -3494,6 +3540,9 @@ module ietf-te-types {
     }
   }
 
+  // CHANGE NOTE: The explicit-route-hop grouping below has been
+  // updated in this module revision
+  // RFC Editor: remove the note above and this note
   grouping record-route-state {
     description
       "The Record Route grouping.";
@@ -3767,16 +3816,15 @@ module ietf-te-types {
     }
   }
 
+  // CHANGE NOTE: The grouping optimization-metric-entry below has
+  // been updated in this module revision
+  // RFC Editor: remove the note above and this note
   grouping optimization-metric-entry {
     description
       "Optimization metrics configuration grouping.";
-    // CHANGE NOTE: The type of the metric-type leaf in
-    // optimization-metric-entry grouping has been updated
-    // in this module revision
-    // RFC Editor: remove the note above and this note
     leaf metric-type {
       type identityref {
-        base path-metric-type;
+        base path-metric-optimization-type;
       }
       description
         "Identifies the 'metric-type' that the path computation
@@ -3854,6 +3902,9 @@ module ietf-te-types {
     }
   }
 
+  // CHANGE NOTE: The grouping tunnel-constraints below has
+  // been updated in this module revision
+  // RFC Editor: remove the note above and this note
   grouping tunnel-constraints {
     description
       "Tunnel constraints grouping that can be set on
@@ -3867,13 +3918,13 @@ module ietf-te-types {
     uses common-constraints;
   }
 
+  // CHANGE NOTE: The grouping path-constraints-route-objects below
+  // has been updated in this module revision
+  // RFC Editor: remove the note above and this note
   grouping path-constraints-route-objects {
     description
       "List of route entries to be included or excluded when
        performing the path computation.";
-    // CHANGE NOTE: The explicit-route-objects container below has
-    // been updated in this module revision
-    // RFC Editor: remove the note above and this note
     container explicit-route-objects {
       description
         "Container for the explicit route object lists.";
@@ -3999,18 +4050,15 @@ module ietf-te-types {
     }
   }
 
+  // CHANGE NOTE: The grouping generic-path-metric-bounds below
+  // has been updated in this module revision
+  // RFC Editor: remove the note above and this note
   grouping generic-path-metric-bounds {
     description
       "TE path metric bounds grouping.";
-    // CHANGE NOTE: The descriptions for the path-metric-bounds
-    // container has been updated in this module revision
-    // RFC Editor: remove the note above and this note
     container path-metric-bounds {
       description
         "Top-level container for the list of path metric bounds.";
-      // CHANGE NOTE: The descriptions for the path-metric-bound
-      // list has been updated in this module revision
-      // RFC Editor: remove the note above and this note
       list path-metric-bound {
         key "metric-type";
         description
@@ -4023,9 +4071,6 @@ module ietf-te-types {
           TE paths that traverse TE links which have at least one
           link metric which exceeds the specified bounds MUST NOT
           be selected.";
-        // CHANGE NOTE: The type of the metric-type leaf has been
-        // updated in this module revision
-        // RFC Editor: remove the note above and this note
         leaf metric-type {
           type identityref {
             base link-path-metric-type;
@@ -4034,9 +4079,6 @@ module ietf-te-types {
             "Identifies an entry in the list of 'metric-type' items
              bound for the TE path.";
         }
-        // CHANGE NOTE: The description of the upper-bound leaf has
-        // been updated in this module revision
-        // RFC Editor: remove the note above and this note
         leaf upper-bound {
           type uint64;
           default "0";
@@ -4053,6 +4095,9 @@ module ietf-te-types {
     }
   }
 
+  // CHANGE NOTE: The grouping generic-path-metric-bounds below
+  // has been updated in this module revision
+  // RFC Editor: remove the note above and this note
   grouping generic-path-optimization {
     description
       "TE generic path optimization grouping.";
@@ -4073,9 +4118,6 @@ module ietf-te-types {
             uses optimization-metric-entry;
           }
           /* Tiebreakers */
-          // CHANGE NOTE: The tiebreakers container below has been
-          // deprecated in this module revision
-          // RFC Editor: remove the note above and this note
           container tiebreakers {
             description
               "Container for the list of tiebreakers.

--- a/ietf-te-types.yang
+++ b/ietf-te-types.yang
@@ -75,7 +75,7 @@ module ietf-te-types {
      This version of this YANG module is part of RFC XXXX
      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
      for full legal notices.";
-  revision 2024-01-29 {
+  revision 2024-02-09 {
     description
       "Added:
       - base identity lsp-provisioning-error-reason;
@@ -2121,180 +2121,203 @@ module ietf-te-types {
        Protocol-Traffic Engineering (RSVP-TE)";
   }
 
-  // CHANGE NOTE: The link-metric-type base identity
+  // CHANGE NOTE: The link-path-metric-type base identity
   // and its derived identities
   // have been added in this module revision
   // RFC Editor: remove the note above and this note
-  identity link-metric-type {
-    base metric-type;
+  identity link-path-metric-type {
     description
-      "Base identity for the link metric types.";
+      "Base identity used to define the link and the path metric
+      types.
+      
+      The unit of the path metric value is interpreted in the
+      context of the path metric type and the derived identities
+      SHOULD describe the unit of the path metric types they
+      define.";
   }
 
-    identity link-metric-te {
-      base link-metric-type;
+    // CHANGE NOTE: The link-metric-type base identity
+    // and its derived identities
+    // have been added in this module revision
+    // RFC Editor: remove the note above and this note
+    identity link-metric-type {
+      base link-path-metric-type;
       description
-        "Traffic Engineering (TE) Link Metric.";
-      reference
-        "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
-        Version 2, section 2.5.5
-
-        RFC 5305: IS-IS Extensions for Traffic Engineering,
-        section 3.7
-
-        RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
-        second MPLS Traffic Engineering (TE) Metric";
+        "Base identity for the link metric types.";
     }
 
-    identity link-metric-igp {
-      base link-metric-type;
-      description
-        "Interior Gateway Protocol (IGP) Link Metric.";
-      reference
-        "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
-        second MPLS Traffic Engineering (TE) Metric";
-    }
+      identity link-metric-te {
+        base link-metric-type;
+        description
+          "Traffic Engineering (TE) Link Metric.";
+        reference
+          "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+          Version 2, section 2.5.5
 
-    identity link-metric-delay {
-      base link-metric-type;
-      description
-        "Unidirectional Link Delay, measured in units of
-        microseconds.";
-      reference
-        "RFC 7471: OSPF Traffic Engineering (TE) Metric
-        Extensions, section 4.1
-        
-        RFC 8570: IS-IS Traffic Engineering (TE) Metric
-        Extensions, section 4.1";
-    }
+          RFC 5305: IS-IS Extensions for Traffic Engineering,
+          section 3.7
 
-    identity link-metric-delay-minimum {
-      base link-metric-type;
-      description
-        "Minimum unidirectional Link Delay, measured in units of
-        microseconds.";
-      reference
-        "RFC 7471: OSPF Traffic Engineering (TE) Metric
-        Extensions, section 4.2
-        
-        RFC 8570: IS-IS Traffic Engineering (TE) Metric
-        Extensions, section 4.2";
-    }
+          RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+          second MPLS Traffic Engineering (TE) Metric";
+      }
 
-    identity link-metric-residual-bandwidth {
-      base link-metric-type;
-      description
-        "Unidirectional Residual Bandwidth, measured in units of
-        bytes per second.
-        
-        It is defined to be Maximum Bandwidth minus the bandwidth
-        currently allocated to LSPs.";
-      reference
-        "RFC 7471: OSPF Traffic Engineering (TE) Metric
-        Extensions, section 4.5
-        
-        RFC 8570: IS-IS Traffic Engineering (TE) Metric
-        Extensions, section 4.5";
-    }
+      identity link-metric-igp {
+        base link-metric-type;
+        description
+          "Interior Gateway Protocol (IGP) Link Metric.";
+        reference
+          "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+          second MPLS Traffic Engineering (TE) Metric";
+      }
 
-  // CHANGE NOTE: The base and the description of the
-  // path-metric-type identity
-  // has been updated in this module revision
-  // RFC Editor: remove the note above and this note
-  identity path-metric-type {
-    base metric-type;
-    description
-      "Base identity for the path metric types.";
-  }
+      identity link-metric-delay-average {
+        base link-metric-type;
+        description
+          "Unidirectional Link Delay, measured in units of
+          microseconds.";
+        reference
+          "RFC 7471: OSPF Traffic Engineering (TE) Metric
+          Extensions, section 4.1
+          
+          RFC 8570: IS-IS Traffic Engineering (TE) Metric
+          Extensions, section 4.1";
+      }
 
-    // CHANGE NOTE: The description of the path-metric-te identity
+      identity link-metric-delay-minimum {
+        base link-metric-type;
+        description
+          "Minimum unidirectional Link Delay, measured in units of
+          microseconds.";
+        reference
+          "RFC 7471: OSPF Traffic Engineering (TE) Metric
+          Extensions, section 4.2
+          
+          RFC 8570: IS-IS Traffic Engineering (TE) Metric
+          Extensions, section 4.2";
+      }
+
+      identity link-metric-delay-maximum {
+        base link-metric-type;
+        description
+          "Maximum unidirectional Link Delay, measured in units of
+          microseconds.";
+        reference
+          "RFC 7471: OSPF Traffic Engineering (TE) Metric
+          Extensions, section 4.2
+          
+          RFC 8570: IS-IS Traffic Engineering (TE) Metric
+          Extensions, section 4.2";
+      }
+
+      identity link-metric-residual-bandwidth {
+        base link-metric-type;
+        description
+          "Unidirectional Residual Bandwidth, measured in units of
+          bytes per second.
+          
+          It is defined to be Maximum Bandwidth minus the bandwidth
+          currently allocated to LSPs.";
+        reference
+          "RFC 7471: OSPF Traffic Engineering (TE) Metric
+          Extensions, section 4.5
+          
+          RFC 8570: IS-IS Traffic Engineering (TE) Metric
+          Extensions, section 4.5";
+      }
+
+    // CHANGE NOTE: The base and the description of the
+    // path-metric-type identity
     // has been updated in this module revision
     // RFC Editor: remove the note above and this note
-    identity path-metric-te {
-      base path-metric-type;
+    identity path-metric-type {
+      base link-path-metric-type;
       description
-        "Traffic Engineering (TE) Path Metric.";
-      reference
-        "RFC 5440: Path Computation Element (PCE) Communication
-        Protocol (PCEP), section 7.8";
+        "Base identity for the path metric types.";
     }
 
-    // CHANGE NOTE: The description of the path-metric-igp identity
-    // has been updated in this module revision
-    // RFC Editor: remove the note above and this note
-    identity path-metric-igp {
-      base path-metric-type;
-      description
-        "Interior Gateway Protocol (IGP) Path Metric.";
-      reference
-        "RFC 5440: Path Computation Element (PCE) Communication
-        Protocol (PCEP), section 7.8";
-    }
+      // CHANGE NOTE: The description and the reference of the
+      // path-metric-te identity have been updated
+      // in this module revision
+      // RFC Editor: remove the note above and this note
+      identity path-metric-te {
+        base path-metric-type;
+        description
+          "Traffic Engineering (TE) Path Metric.";
+        reference
+          "RFC 5440: Path Computation Element (PCE) Communication
+          Protocol (PCEP), section 7.8";
+      }
 
-    // CHANGE NOTE: The description of the path-metric-hop identity
-    // has been updated in this module revision
-    // RFC Editor: remove the note above and this note
-    identity path-metric-hop {
-      base path-metric-type;
-      status deprecated;
-      description
-        "Hop Count Path Metric.";
-      reference
-        "RFC 5440: Path Computation Element (PCE) Communication
-        Protocol (PCEP), section 7.8";
-    }
+      // CHANGE NOTE: The description and the reference of the
+      // path-metric-igp identity have been updated 
+      // in this module revision
+      // RFC Editor: remove the note above and this note
+      identity path-metric-igp {
+        base path-metric-type;
+        description
+          "Interior Gateway Protocol (IGP) Path Metric.";
+        reference
+          "RFC 5440: Path Computation Element (PCE) Communication
+          Protocol (PCEP), section 7.8";
+      }
 
-    // CHANGE NOTE: The path-metric-delay-average identity
-    // has been obsoleted in this module revision
-    // RFC Editor: remove the note above and this note
-    identity path-metric-delay-average {
-      base path-metric-type;
-      status obsolete;
-      description
-        "Average unidirectional link delay.";
-      reference
-        "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-    }
+      // CHANGE NOTE: The description and the reference of the
+      // path-metric-hop identity have been updated
+      // in this module revision
+      // RFC Editor: remove the note above and this note
+      identity path-metric-hop {
+        base path-metric-type;
+        status deprecated;
+        description
+          "Hop Count Path Metric.";
+        reference
+          "RFC 5440: Path Computation Element (PCE) Communication
+          Protocol (PCEP), section 7.8";
+      }
 
-    // CHANGE NOTE: The path-metric-delay identity
-    // has been added in this module revision
-    // RFC Editor: remove the note above and this note
-    identity path-metric-delay {
-      base path-metric-type;
-      description
-        "The Path Delay Metric measured in units of microseconds.";
-      reference
-        "RFC8233: Extensions to the Path Computation Element
-        Communication Protocol (PCEP) to Compute Service-Aware
-        Label Switched Paths (LSPs), section 3.1.1";
-    }
+      // CHANGE NOTE: The description and the reference of the
+      // path-metric-delay-average identity have been updated
+      // in this module revision
+      // RFC Editor: remove the note above and this note
+      identity path-metric-delay-average {
+        base path-metric-type;
+        description
+          "The Path Delay Metric, measured in units of
+          microseconds.";
+        reference
+          "RFC8233: Extensions to the Path Computation Element
+          Communication Protocol (PCEP) to Compute Service-Aware
+          Label Switched Paths (LSPs), section 3.1.1";
+      }
 
-    // CHANGE NOTE: The path-metric-delay-minimum identity
-    // has been obsoleted in this module revision
-    // RFC Editor: remove the note above and this note
-    identity path-metric-delay-minimum {
-      base path-metric-type;
-      status obsolete;
-      description
-        "Minimum unidirectional link delay.";
-      reference
-        "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-    }
+      // CHANGE NOTE: The description and the reference of the
+      // path-metric-delay-minimum identity have been updated
+      // in this module revision
+      // RFC Editor: remove the note above and this note
+      identity path-metric-delay-minimum {
+        base path-metric-type;
+        description
+          "The Path Min Delay Metric, measured in units of
+          microseconds.";
+        reference
+          "I-D.ietf-pce-sid-algo: Carrying SR-Algorithm information
+          in PCE-based Networks, section 3.5.1";
+      }
 
-    // CHANGE NOTE: The path-metric-delay-minimum identity
-    // has been obsoleted in this module revision
-    // RFC Editor: remove the note above and this note
-    identity path-metric-residual-bandwidth {
-      base path-metric-type;
-      description
-        "Unidirectional Residual Bandwidth, which is defined to be
-        Maximum Bandwidth (RFC 3630) minus the bandwidth currently
-        allocated to LSPs.";
-      reference
-        "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
-        Version 2
-        RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-    }
+      // CHANGE NOTE: The path-metric-delay-minimum identity
+      // has been obsoleted in this module revision
+      // RFC Editor: remove the note above and this note
+      identity path-metric-residual-bandwidth {
+        base path-metric-type;
+        description
+          "Unidirectional Residual Bandwidth, which is defined to be
+          Maximum Bandwidth (RFC 3630) minus the bandwidth currently
+          allocated to LSPs.";
+        reference
+          "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+          Version 2
+          RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+      }
 
   identity path-metric-optimize-includes {
     base path-metric-type;
@@ -3889,72 +3912,52 @@ module ietf-te-types {
   grouping generic-path-metric-bounds {
     description
       "TE path metric bounds grouping.";
-    // NOTE: The descriptions for the path-metric-bounds contianer
-    // and the path-metric-bound listhas been updated in this module
-    // revision
+    // CHANGE NOTE: The descriptions for the path-metric-bounds
+    // container has been updated in this module revision
     // RFC Editor: remove the note above and this note
     container path-metric-bounds {
       description
-        "Top-level container for the list of end-to-end TE path
-        metric bounds.";
+        "Top-level container for the list of path metric bounds.";
+      // CHANGE NOTE: The descriptions for the path-metric-bound
+      // list has been updated in this module revision
+      // RFC Editor: remove the note above and this note
       list path-metric-bound {
         key "metric-type";
         description
-          "List of end-to-end TE path metric bounds.";
-        leaf metric-type {
-          type identityref {
-            base path-metric-type;
-          }
-          description
-            "Identifies an entry in the list of 'metric-type' items
-             bound for the TE path.";
-        }
-        leaf upper-bound {
-          type uint64;
-          default "0";
-          description
-            "Upper bound on the end-to-end TE path metric.
-            
-            A zero indicates an unbounded upper limit for the
-            specific 'metric-type'.
-            
-            The unit of is interpreted in the context of the
-            path-metric-type.";
-        }
-      }
-    }
-    // NOTE: The contianer link-metric-bounds has been
-    // added in this module revision
-    // RFC Editor: remove the note above and this note
-    container link-metric-bounds {
-      description
-        "Top-level container for the list of TE link metric bounds.";
-      list path-metric-bound {
-        key "metric-type";
-        description
-          "List of of TE link metric bounds.
+          "List of path metric bounds, which can apply to link and
+          path metrics.
           
-          The TE links whose TE link metric exceeds the upper-bound
-          are not considered as candidate link for the TE path.";
+          TE paths which have at least one path metric which
+          exceeds the specified bounds MUST NOT be selected.
+          
+          TE paths that traverse TE links which have at least one
+          link metric which exceeds the specified bounds MUST NOT
+          be selected.";
+        // CHANGE NOTE: The type of the metric-type leaf has been
+        // updated in this module revision
+        // RFC Editor: remove the note above and this note
         leaf metric-type {
           type identityref {
-            base link-metric-type;
+            base link-path-metric-type;
           }
           description
             "Identifies an entry in the list of 'metric-type' items
              bound for the TE path.";
         }
+        // CHANGE NOTE: The description of the upper-boudn leaf has
+        // been updated in this module revision
+        // RFC Editor: remove the note above and this note
         leaf upper-bound {
           type uint64;
           default "0";
           description
-            "Upper bound on the TE link metric.
+            "Upper bound on the specified 'metric-type'.
             
             A zero indicates an unbounded upper limit for the
-            specific 'metric-type'.
+            specificied 'metric-type'.
             
             The unit of is interpreted in the context of the
-            path-metric-type.";
+            'metric-type' identity.";
         }
       }
     }

--- a/ietf-te-types.yang
+++ b/ietf-te-types.yang
@@ -2155,10 +2155,7 @@ module ietf-te-types {
           Version 2, section 2.5.5
 
           RFC 5305: IS-IS Extensions for Traffic Engineering,
-          section 3.7
-
-          RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
-          second MPLS Traffic Engineering (TE) Metric";
+          section 3.7";
       }
 
       identity link-metric-igp {
@@ -2166,8 +2163,8 @@ module ietf-te-types {
         description
           "Interior Gateway Protocol (IGP) Link Metric.";
         reference
-          "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
-          second MPLS Traffic Engineering (TE) Metric";
+          "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric
+          as a second MPLS Traffic Engineering (TE) Metric";
       }
 
       identity link-metric-delay-average {

--- a/ietf-te-types.yang
+++ b/ietf-te-types.yang
@@ -125,8 +125,7 @@ module ietf-te-types {
       - identity of-minimize-load-most-loaded-link;
       - identity of-minimize-cost-path-set;
       - identity lsp-protection-reroute-extra;
-      - identity lsp-protection-reroute;
-      - identity path-metric-residual-bandwidth.
+      - identity lsp-protection-reroute.
 
       Container explicit-route-objects-always renamed as
       explicit-route-objects.";
@@ -2330,19 +2329,22 @@ module ietf-te-types {
           in PCE-based Networks, section 3.5.1";
       }
 
-      // CHANGE NOTE: The path-metric-delay-minimum identity
-      // has been obsoleted in this module revision
+      // CHANGE NOTE: The description and the reference of the
+      // path-metric-residual-bandwidth identity have been updated
+      // in this module revision
       // RFC Editor: remove the note above and this note
       identity path-metric-residual-bandwidth {
         base path-metric-type;
         description
-          "Unidirectional Residual Bandwidth, which is defined to be
-          Maximum Bandwidth (RFC 3630) minus the bandwidth currently
-          allocated to LSPs.";
+          "The Path Residual Bandwidth, defined as the minimum Link
+          Residual Bandwidth all the links along the path.
+
+          The Path Residual Bandwidth can be seen as the path
+          metric associated with the Maximum residual Bandwidth Path
+          (MBP) objective function.";
         reference
-          "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
-          Version 2
-          RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+          "RFC 5541: Encoding of Objective Functions in the Path
+          Computation Element Communication Protocol (PCEP)";
       }
 
     // CHANGE NOTE: The base of the path-metric-optimize-includes
@@ -2524,7 +2526,13 @@ module ietf-te-types {
         a Backward-Recursive Path Computation (BRPC) downstream
         PCE or a child PCE.";
       reference
-        "RFC 5441, RFC 8685";
+        "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+        Procedure to Compute Shortest Constrained Inter-Domain
+        Traffic Engineering Label Switched Paths
+        
+        RFC 8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture";
     }
 
     identity path-computation-error-pce-unavailable {
@@ -2557,7 +2565,9 @@ module ietf-te-types {
         It corresponds to bit 19 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC 8685;
+        "RFC 8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
     }
@@ -2571,7 +2581,9 @@ module ietf-te-types {
         It corresponds to bit 20 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC 8685;
+        "RFC 8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
     }
@@ -2585,7 +2597,9 @@ module ietf-te-types {
         It corresponds to bit 21 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC 8685;
+        "RFC 8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
     }
@@ -2599,7 +2613,9 @@ module ietf-te-types {
         It corresponds to bit 22 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC 8685;
+        "RFC 8685: Path Computation Element Communication Protocol 
+        (PCEP) Extensions for the Hierarchical Path Computation 
+        Element (H-PCE) Architecture
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
     }
@@ -2669,7 +2685,9 @@ module ietf-te-types {
         It corresponds to bit 28 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC 5441;
+        "RFC 5441: A Backward-Recursive PCE-Based Computation (BRPC)
+        Procedure to Compute Shortest Constrained Inter-Domain
+        Traffic Engineering Label Switched Paths
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
     }
@@ -2799,7 +2817,7 @@ module ietf-te-types {
       reference
         "RFC 8685: Path Computation Element Communication Protocol 
         (PCEP) Extensions for the Hierarchical Path Computation 
-        Element (H-PCE) Architecture.";
+        Element (H-PCE) Architecture";
     }
 
     identity svec-of-minimize-shared-link {

--- a/ietf-te-types.yang
+++ b/ietf-te-types.yang
@@ -2141,9 +2141,17 @@ module ietf-te-types {
        Protocol-Traffic Engineering (RSVP-TE)";
   }
 
+  // CHANGE NOTE: The path-metric-optimization-type base identity
+  // has been added in this module revision
+  // RFC Editor: remove the note above and this note
+  identity path-metric-optimization-type {
+    description
+      "Base identity used to define the path metric optimization
+      types.";
+  }
+
   // CHANGE NOTE: The link-path-metric-type base identity
-  // and its derived identities
-  // have been added in this module revision
+  // has been added in this module revision
   // RFC Editor: remove the note above and this note
   identity link-path-metric-type {
     description
@@ -2248,6 +2256,7 @@ module ietf-te-types {
     // RFC Editor: remove the note above and this note
     identity path-metric-type {
       base link-path-metric-type;
+      base path-metric-optimization-type;
       description
         "Base identity for the path metric types.";
     }
@@ -2336,19 +2345,25 @@ module ietf-te-types {
           RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
       }
 
-  identity path-metric-optimize-includes {
-    base path-metric-type;
-    description
-      "A metric that optimizes the number of included resources
-       specified in a set.";
-  }
+    // CHANGE NOTE: The base of the path-metric-optimize-includes
+    // identity has been updated in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-optimize-includes {
+      base path-metric-optimization-type;
+      description
+        "A metric that optimizes the number of included resources
+        specified in a set.";
+    }
 
-  identity path-metric-optimize-excludes {
-    base path-metric-type;
-    description
-      "A metric that optimizes to a maximum the number of excluded
-       resources specified in a set.";
-  }
+    // CHANGE NOTE: The base of the path-metric-optimize-excludes
+    // identity has been updated in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-optimize-excludes {
+      base path-metric-optimization-type;
+      description
+        "A metric that optimizes to a maximum the number of excluded
+        resources specified in a set.";
+    }
 
   identity path-tiebreaker-type {
     description
@@ -3701,6 +3716,10 @@ module ietf-te-types {
   grouping optimization-metric-entry {
     description
       "Optimization metrics configuration grouping.";
+    // CHANGE NOTE: The type of the metric-type leaf in
+    // optimization-metric-entry grouping has been updated
+    // in this module revision
+    // RFC Editor: remove the note above and this note
     leaf metric-type {
       type identityref {
         base path-metric-type;

--- a/ietf-te-types.yang
+++ b/ietf-te-types.yang
@@ -163,6 +163,7 @@ module ietf-te-types {
     description
       "Administrative group / resource class / color representation
        in 'hex-string' type.
+
        The most significant byte in the hex-string is the farthest
        to the left in the byte sequence.  Leading zero bytes in the
        configured value may be omitted for brevity.";
@@ -190,6 +191,7 @@ module ietf-te-types {
     description
       "Extended administrative group / resource class / color
        representation in 'hex-string' type.
+
        The most significant byte in the hex-string is the farthest
        to the left in the byte sequence.  Leading zero bytes in the
        configured value may be omitted for brevity.";
@@ -344,12 +346,15 @@ module ietf-te-types {
     description
       "An identifier to uniquely identify an operator, which can be
        either a provider or a client.
+
        The definition of this type is taken from RFCs 6370 and 5003.
+
        This attribute type is used solely to provide a globally
        unique context for TE topologies.";
     reference
       "RFC 5003: Attachment Individual Identifier (AII) Types for
        Aggregation
+
        RFC 6370: MPLS Transport Profile (MPLS-TP) Identifiers";
   }
 
@@ -614,6 +619,7 @@ module ietf-te-types {
     }
     description
       "An identifier for a topology.
+
        It is optional to have one or more prefixes at the beginning,
        separated by colons.  The prefixes can be 'network-types' as
        defined in the 'ietf-network' module in RFC 8345, to help the
@@ -632,6 +638,7 @@ module ietf-te-types {
     }
     description
       "An identifier for a TE link endpoint on a node.
+
        This attribute is mapped to a local or remote link identifier
        as defined in RFCs 3630 and 5305.";
     reference
@@ -2552,9 +2559,10 @@ module ietf-te-types {
         NO-PATH-VECTOR TLV.";
       reference
         "RFC 5440: Path Computation Element (PCE) Communication
-        Protocol (PCEP);
+        Protocol (PCEP)
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-no-inclusion-hop {
@@ -2577,7 +2585,8 @@ module ietf-te-types {
         (PCEP) Extensions for the Hierarchical Path Computation 
         Element (H-PCE) Architecture
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-no-resource {
@@ -2593,7 +2602,8 @@ module ietf-te-types {
         (PCEP) Extensions for the Hierarchical Path Computation 
         Element (H-PCE) Architecture
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-child-pce-unresponsive {
@@ -2609,7 +2619,8 @@ module ietf-te-types {
         (PCEP) Extensions for the Hierarchical Path Computation 
         Element (H-PCE) Architecture
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-destination-domain-unknown {
@@ -2625,7 +2636,8 @@ module ietf-te-types {
         (PCEP) Extensions for the Hierarchical Path Computation 
         Element (H-PCE) Architecture
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-p2mp {
@@ -2637,9 +2649,12 @@ module ietf-te-types {
         It corresponds to bit 24 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC 8306;
+        "RFC 8306: Extensions to the Path Computation Element
+        Communication Protocol (PCEP) for Point-to-Multipoint
+        Traffic Engineering Label Switched Paths
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-no-gco-migration {
@@ -2651,9 +2666,12 @@ module ietf-te-types {
         It corresponds to bit 26 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC 5557;
+        "RFC 5557: Path Computation Element Communication Protocol
+        (PCEP) Requirements and Protocol Extensions in Support of
+        Global Concurrent Optimization
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-no-gco-solution {
@@ -2665,9 +2683,12 @@ module ietf-te-types {
         It corresponds to bit 25 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC 5557;
+        "RFC 5557: Path Computation Element Communication Protocol
+        (PCEP) Requirements and Protocol Extensions in Support of
+        Global Concurrent Optimization
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-pks-expansion {
@@ -2679,9 +2700,12 @@ module ietf-te-types {
         It corresponds to bit 27 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC 5520;
+        "RFC 5520: Preserving Topology Confidentiality in
+        Inter-Domain Path Computation Using a Path-Key-Based
+        Mechanism
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-brpc-chain-unavailable {
@@ -2697,7 +2721,8 @@ module ietf-te-types {
         Procedure to Compute Shortest Constrained Inter-Domain
         Traffic Engineering Label Switched Paths
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-source-unknown {
@@ -2712,7 +2737,8 @@ module ietf-te-types {
         "RFC 5440: Path Computation Element (PCE) Communication
         Protocol (PCEP);
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-destination-unknown {
@@ -2727,7 +2753,8 @@ module ietf-te-types {
         "RFC 5440: Path Computation Element (PCE) Communication
         Protocol (PCEP);
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
     identity path-computation-error-no-server {
@@ -2739,7 +2766,8 @@ module ietf-te-types {
         "RFC 5440: Path Computation Element (PCE) Communication
         Protocol (PCEP);
         
-        https://www.iana.org/assignments/pcep/pcep.xhtml";
+        https://www.iana.org/assignments/pcep
+        /pcep.xhtml#no-path-vector-tlv";
     }
 
   // CHANGE NOTE: The base identity protocol-origin-type and 
@@ -2784,7 +2812,7 @@ module ietf-te-types {
       "Base identity for SVEC objective function type.";
     reference
       "RFC 5541: Encoding of Objective Functions in the Path
-       Computation Element Communication Protocol (PCEP).";
+       Computation Element Communication Protocol (PCEP)";
   }
 
     identity svec-of-minimize-agg-bandwidth-consumption {
@@ -2794,7 +2822,7 @@ module ietf-te-types {
         consumption (MBC).";
       reference
         "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        Computation Element Communication Protocol (PCEP)";
     }
 
     identity svec-of-minimize-load-most-loaded-link {
@@ -2804,7 +2832,7 @@ module ietf-te-types {
         is carrying the highest load (MLL).";
       reference
         "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        Computation Element Communication Protocol (PCEP)";
     }
 
     identity svec-of-minimize-cost-path-set {
@@ -2814,7 +2842,7 @@ module ietf-te-types {
         (MCC).";
       reference
         "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        Computation Element Communication Protocol (PCEP)";
     }
 
     identity svec-of-minimize-common-transit-domain {
@@ -2870,7 +2898,7 @@ module ietf-te-types {
       "Base identity for SVEC metric type.";
     reference
       "RFC 5541: Encoding of Objective Functions in the Path
-       Computation Element Communication Protocol (PCEP).";
+       Computation Element Communication Protocol (PCEP)";
   }
 
     identity svec-metric-cumulative-te {
@@ -2879,7 +2907,7 @@ module ietf-te-types {
         "Cumulative TE cost.";
       reference
         "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        Computation Element Communication Protocol (PCEP)";
     }
 
     identity svec-metric-cumulative-igp {
@@ -2888,7 +2916,7 @@ module ietf-te-types {
         "Cumulative IGP cost.";
       reference
         "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        Computation Element Communication Protocol (PCEP)";
     }
 
     identity svec-metric-cumulative-hop {
@@ -2897,7 +2925,7 @@ module ietf-te-types {
         "Cumulative Hop path metric.";
       reference
         "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        Computation Element Communication Protocol (PCEP)";
     }
 
     identity svec-metric-aggregate-bandwidth-consumption {
@@ -2906,7 +2934,7 @@ module ietf-te-types {
         "Aggregate bandwidth consumption.";
       reference
         "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        Computation Element Communication Protocol (PCEP)";
     }
 
     identity svec-metric-load-of-the-most-loaded-link {
@@ -2915,7 +2943,7 @@ module ietf-te-types {
         "Load of the most loaded link.";
       reference
         "RFC 5541: Encoding of Objective Functions in the Path
-        Computation Element Communication Protocol (PCEP).";
+        Computation Element Communication Protocol (PCEP)";
     }
 
   /**

--- a/ietf-te-types.yang
+++ b/ietf-te-types.yang
@@ -75,7 +75,7 @@ module ietf-te-types {
      This version of this YANG module is part of RFC XXXX
      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
      for full legal notices.";
-  revision 2024-02-09 {
+  revision 2024-02-16 {
     description
       "Added:
       - base identity lsp-provisioning-error-reason;
@@ -90,15 +90,36 @@ module ietf-te-types {
       - base identity svec-objective-function-type and its derived
         identities;
       - base identity svec-metric-type and its derived identities;
+      - base identity link-path-metric-type;
+      - base identity link-metric-type and its derived identities;
+      - identity path-metric-delay;
       - typedef te-gen-node-id;
-      - grouping encoding-and-switching-type
-      - grouping te-generic-node-id.
+      - ordered-by statement to tiebreaker list in
+        generic-path-optimization grouping;
+      - grouping encoding-and-switching-type;
+      - grouping te-generic-node-id;.
       
       Updated:
       - description of the base identity objective-function-type;
       - description and reference of identity action-exercise;
+      - description of identity path-metric-te;
+      - description of identity path-metric-igp;
+      - description of identity path-metric-hop;
+      - base identity and description of path-metric-type identity;
+      - description and reference of path-metric-delay-average
+        identity;
+      - description and reference of path-metric-delay-minimum
+        identity;
+      - description of path-metric-bounds container in
+        generic-path-metric-bounds grouping;
+      - description of path-metric-bound list in
+        generic-path-metric-bounds grouping;
+      - type of metric-type leaf in
+        generic-path-metric-bounds grouping;
       - node and termination points identifiers in grouping
         explicit-route-hop;
+      - description of the upper-bound leaf in
+        generic-path-metric-bounds grouping;
       - typedef te-node-id to support also 16 octects TE identifiers.
       
       Obsoleted:
@@ -106,7 +127,8 @@ module ietf-te-types {
       - identity of-minimize-load-most-loaded-link;
       - identity of-minimize-cost-path-set;
       - identity lsp-protection-reroute-extra;
-      - identity lsp-protection-reroute.
+      - identity lsp-protection-reroute;
+      - identity path-metric-residual-bandwidth.
 
       Container explicit-route-objects-always renamed as
       explicit-route-objects.";
@@ -3941,7 +3963,7 @@ module ietf-te-types {
             "Identifies an entry in the list of 'metric-type' items
              bound for the TE path.";
         }
-        // CHANGE NOTE: The description of the upper-boudn leaf has
+        // CHANGE NOTE: The description of the upper-bound leaf has
         // been updated in this module revision
         // RFC Editor: remove the note above and this note
         leaf upper-bound {
@@ -3985,6 +4007,10 @@ module ietf-te-types {
               "Container for the list of tiebreakers.";
             list tiebreaker {
               key "tiebreaker-type";
+              // CHANGE NOTE: The ordered-by statement below has been
+              // added in this module revision
+              // RFC Editor: remove the note above and this note
+              ordered-by user;
               description
                 "The list of tiebreaker criteria to apply on an
                  equally favored set of paths, in order to pick

--- a/ietf-te-types.yang
+++ b/ietf-te-types.yang
@@ -141,7 +141,9 @@ module ietf-te-types {
     reference
       "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
        Version 2
+
        RFC 5305: IS-IS Extensions for Traffic Engineering
+       
        RFC 7308: Extended Administrative Groups in MPLS Traffic
        Engineering (MPLS-TE)";
   }
@@ -204,9 +206,11 @@ module ietf-te-types {
        bit not set), abnormal (anomalous bit set), or unknown.";
     reference
       "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions
+
        RFC 7823: Performance-Based Path Selection for Explicitly
        Routed Label Switched Paths (LSPs) Using TE Metric
        Extensions
+
        RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
   }
 
@@ -1103,7 +1107,7 @@ module ietf-te-types {
       "Association Type diversity used to associate LSPs whose 
       paths are to be diverse from each other.";
     reference
-      "RFC8800: Path Computation Element Communication Protocol 
+      "RFC 8800: Path Computation Element Communication Protocol 
       (PCEP) Extension for Label Switched Path (LSP) Diversity 
       Constraint Signaling";
   }
@@ -2117,75 +2121,180 @@ module ietf-te-types {
        Protocol-Traffic Engineering (RSVP-TE)";
   }
 
-  // CHANGE NOTE: The description of the identity path-metric-type
+  // CHANGE NOTE: The link-metric-type base identity
+  // and its derived identities
+  // have been added in this module revision
+  // RFC Editor: remove the note above and this note
+  identity link-metric-type {
+    base metric-type;
+    description
+      "Base identity for the link metric types.";
+  }
+
+    identity link-metric-te {
+      base link-metric-type;
+      description
+        "Traffic Engineering (TE) Link Metric.";
+      reference
+        "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+        Version 2, section 2.5.5
+
+        RFC 5305: IS-IS Extensions for Traffic Engineering,
+        section 3.7
+
+        RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+        second MPLS Traffic Engineering (TE) Metric";
+    }
+
+    identity link-metric-igp {
+      base link-metric-type;
+      description
+        "Interior Gateway Protocol (IGP) Link Metric.";
+      reference
+        "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
+        second MPLS Traffic Engineering (TE) Metric";
+    }
+
+    identity link-metric-delay {
+      base link-metric-type;
+      description
+        "Unidirectional Link Delay, measured in units of
+        microseconds.";
+      reference
+        "RFC 7471: OSPF Traffic Engineering (TE) Metric
+        Extensions, section 4.1
+        
+        RFC 8570: IS-IS Traffic Engineering (TE) Metric
+        Extensions, section 4.1";
+    }
+
+    identity link-metric-delay-minimum {
+      base link-metric-type;
+      description
+        "Minimum unidirectional Link Delay, measured in units of
+        microseconds.";
+      reference
+        "RFC 7471: OSPF Traffic Engineering (TE) Metric
+        Extensions, section 4.2
+        
+        RFC 8570: IS-IS Traffic Engineering (TE) Metric
+        Extensions, section 4.2";
+    }
+
+    identity link-metric-residual-bandwidth {
+      base link-metric-type;
+      description
+        "Unidirectional Residual Bandwidth, measured in units of
+        bytes per second.
+        
+        It is defined to be Maximum Bandwidth minus the bandwidth
+        currently allocated to LSPs.";
+      reference
+        "RFC 7471: OSPF Traffic Engineering (TE) Metric
+        Extensions, section 4.5
+        
+        RFC 8570: IS-IS Traffic Engineering (TE) Metric
+        Extensions, section 4.5";
+    }
+
+  // CHANGE NOTE: The base and the description of the
+  // path-metric-type identity
   // has been updated in this module revision
   // RFC Editor: remove the note above and this note
   identity path-metric-type {
+    base metric-type;
     description
-      "Base identity for the path metric type.
-      
-      Derived identities SHOULD describe the unit and maximum value
-      of the path metric types they define.";
+      "Base identity for the path metric types.";
   }
 
-  identity path-metric-te {
-    base path-metric-type;
-    description
-      "TE path metric.";
-    reference
-      "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
-       second MPLS Traffic Engineering (TE) Metric";
-  }
+    // CHANGE NOTE: The description of the path-metric-te identity
+    // has been updated in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-te {
+      base path-metric-type;
+      description
+        "Traffic Engineering (TE) Path Metric.";
+      reference
+        "RFC 5440: Path Computation Element (PCE) Communication
+        Protocol (PCEP), section 7.8";
+    }
 
-  identity path-metric-igp {
-    base path-metric-type;
-    description
-      "IGP path metric.";
-    reference
-      "RFC 3785: Use of Interior Gateway Protocol (IGP) Metric as a
-       second MPLS Traffic Engineering (TE) Metric";
-  }
+    // CHANGE NOTE: The description of the path-metric-igp identity
+    // has been updated in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-igp {
+      base path-metric-type;
+      description
+        "Interior Gateway Protocol (IGP) Path Metric.";
+      reference
+        "RFC 5440: Path Computation Element (PCE) Communication
+        Protocol (PCEP), section 7.8";
+    }
 
-  // CHANGE NOTE: The reference for the identity path-metric-hop
-  // has been added in this module revision
-  // RFC Editor: remove the note above and this note
-  identity path-metric-hop {
-    base path-metric-type;
-    description
-      "Hop path metric.";
-    reference
-      "RFC5440: Path Computation Element (PCE) Communication
-      Protocol (PCEP)";
-  }
+    // CHANGE NOTE: The description of the path-metric-hop identity
+    // has been updated in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-hop {
+      base path-metric-type;
+      status deprecated;
+      description
+        "Hop Count Path Metric.";
+      reference
+        "RFC 5440: Path Computation Element (PCE) Communication
+        Protocol (PCEP), section 7.8";
+    }
 
+    // CHANGE NOTE: The path-metric-delay-average identity
+    // has been obsoleted in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-delay-average {
+      base path-metric-type;
+      status obsolete;
+      description
+        "Average unidirectional link delay.";
+      reference
+        "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+    }
 
-  identity path-metric-delay-average {
-    base path-metric-type;
-    description
-      "Average unidirectional link delay.";
-    reference
-      "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-  }
+    // CHANGE NOTE: The path-metric-delay identity
+    // has been added in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-delay {
+      base path-metric-type;
+      description
+        "The Path Delay Metric measured in units of microseconds.";
+      reference
+        "RFC8233: Extensions to the Path Computation Element
+        Communication Protocol (PCEP) to Compute Service-Aware
+        Label Switched Paths (LSPs), section 3.1.1";
+    }
 
-  identity path-metric-delay-minimum {
-    base path-metric-type;
-    description
-      "Minimum unidirectional link delay.";
-    reference
-      "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-  }
+    // CHANGE NOTE: The path-metric-delay-minimum identity
+    // has been obsoleted in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-delay-minimum {
+      base path-metric-type;
+      status obsolete;
+      description
+        "Minimum unidirectional link delay.";
+      reference
+        "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+    }
 
-  identity path-metric-residual-bandwidth {
-    base path-metric-type;
-    description
-      "Unidirectional Residual Bandwidth, which is defined to be
-       Maximum Bandwidth (RFC 3630) minus the bandwidth currently
-       allocated to LSPs.";
-    reference
-      "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
-       Version 2
-       RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
-  }
+    // CHANGE NOTE: The path-metric-delay-minimum identity
+    // has been obsoleted in this module revision
+    // RFC Editor: remove the note above and this note
+    identity path-metric-residual-bandwidth {
+      base path-metric-type;
+      description
+        "Unidirectional Residual Bandwidth, which is defined to be
+        Maximum Bandwidth (RFC 3630) minus the bandwidth currently
+        allocated to LSPs.";
+      reference
+        "RFC 3630: Traffic Engineering (TE) Extensions to OSPF
+        Version 2
+        RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions";
+    }
 
   identity path-metric-optimize-includes {
     base path-metric-type;
@@ -2339,8 +2448,8 @@ module ietf-te-types {
         "Path computation has failed because of an unspecified 
         reason.";
       reference
-        "Section 7.5 of RFC5440: Path Computation Element (PCE)
-        Communication Protocol (PCEP)";
+        "RFC 5440: Path Computation Element (PCE) Communication
+        Protocol (PCEP), section 7.5";
     }
 
     identity path-computation-error-no-topology {
@@ -2360,7 +2469,7 @@ module ietf-te-types {
         a Backward-Recursive Path Computation (BRPC) downstream
         PCE or a child PCE.";
       reference
-        "RFC5441, RFC8685";
+        "RFC 5441, RFC 8685";
     }
 
     identity path-computation-error-pce-unavailable {
@@ -2371,7 +2480,7 @@ module ietf-te-types {
         It corresponds to bit 31 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC5440: Path Computation Element (PCE) Communication
+        "RFC 5440: Path Computation Element (PCE) Communication
         Protocol (PCEP);
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
@@ -2393,7 +2502,7 @@ module ietf-te-types {
         It corresponds to bit 19 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC8685;
+        "RFC 8685;
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
     }
@@ -2407,7 +2516,7 @@ module ietf-te-types {
         It corresponds to bit 20 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC8685;
+        "RFC 8685;
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
     }
@@ -2421,7 +2530,7 @@ module ietf-te-types {
         It corresponds to bit 21 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC8685;
+        "RFC 8685;
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
     }
@@ -2435,7 +2544,7 @@ module ietf-te-types {
         It corresponds to bit 22 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC8685;
+        "RFC 8685;
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
     }
@@ -2449,7 +2558,7 @@ module ietf-te-types {
         It corresponds to bit 24 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC8306;
+        "RFC 8306;
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
     }
@@ -2463,7 +2572,7 @@ module ietf-te-types {
         It corresponds to bit 26 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC5557;
+        "RFC 5557;
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
     }
@@ -2477,7 +2586,7 @@ module ietf-te-types {
         It corresponds to bit 25 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC5557;
+        "RFC 5557;
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
     }
@@ -2491,7 +2600,7 @@ module ietf-te-types {
         It corresponds to bit 27 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC5520;
+        "RFC 5520;
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
     }
@@ -2505,7 +2614,7 @@ module ietf-te-types {
         It corresponds to bit 28 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC5441;
+        "RFC 5441;
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
     }
@@ -2519,7 +2628,7 @@ module ietf-te-types {
         It corresponds to bit 29 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC5440: Path Computation Element (PCE) Communication
+        "RFC 5440: Path Computation Element (PCE) Communication
         Protocol (PCEP);
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
@@ -2534,7 +2643,7 @@ module ietf-te-types {
         It corresponds to bit 30 of the Flags field of the 
         NO-PATH-VECTOR TLV.";
       reference
-        "RFC5440: Path Computation Element (PCE) Communication
+        "RFC 5440: Path Computation Element (PCE) Communication
         Protocol (PCEP);
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
@@ -2546,7 +2655,7 @@ module ietf-te-types {
         "Path computation has failed because path computation
         server is unavailable.";
       reference
-        "RFC5440: Path Computation Element (PCE) Communication
+        "RFC 5440: Path Computation Element (PCE) Communication
         Protocol (PCEP);
         
         https://www.iana.org/assignments/pcep/pcep.xhtml";
@@ -2574,7 +2683,7 @@ module ietf-te-types {
         "Protocol origin is Path Computation Engine Protocol 
         (PCEP).";
       reference
-        "RFC5440: Path Computation Element (PCE) Communication
+        "RFC 5440: Path Computation Element (PCE) Communication
         Protocol (PCEP)";
     }
 
@@ -2582,7 +2691,7 @@ module ietf-te-types {
       base protocol-origin-type;
       description
         "Protocol origin is Border Gateway Protocol (BGP).";
-      reference "RFC9012";
+      reference "RFC 9012";
     }
 
   // CHANGE NOTE: The base identity svec-objective-function-type 
@@ -2593,7 +2702,7 @@ module ietf-te-types {
     description
       "Base identity for SVEC objective function type.";
     reference
-      "RFC5541: Encoding of Objective Functions in the Path
+      "RFC 5541: Encoding of Objective Functions in the Path
        Computation Element Communication Protocol (PCEP).";
   }
 
@@ -2603,7 +2712,7 @@ module ietf-te-types {
         "Objective function for minimizing aggregate bandwidth 
         consumption (MBC).";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
+        "RFC 5541: Encoding of Objective Functions in the Path
         Computation Element Communication Protocol (PCEP).";
     }
 
@@ -2613,7 +2722,7 @@ module ietf-te-types {
         "Objective function for minimizing the load on the link that 
         is carrying the highest load (MLL).";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
+        "RFC 5541: Encoding of Objective Functions in the Path
         Computation Element Communication Protocol (PCEP).";
     }
 
@@ -2623,7 +2732,7 @@ module ietf-te-types {
         "Objective function for minimizing the cost on a path set 
         (MCC).";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
+        "RFC 5541: Encoding of Objective Functions in the Path
         Computation Element Communication Protocol (PCEP).";
     }
 
@@ -2633,7 +2742,7 @@ module ietf-te-types {
         "Objective function for minimizing the number of common 
         transit domains (MCTD).";
       reference
-        "RFC8685: Path Computation Element Communication Protocol 
+        "RFC 8685: Path Computation Element Communication Protocol 
         (PCEP) Extensions for the Hierarchical Path Computation 
         Element (H-PCE) Architecture.";
     }
@@ -2644,7 +2753,7 @@ module ietf-te-types {
         "Objective function for minimizing the number of shared 
         links (MSL).";
       reference
-        "RFC8685: Path Computation Element Communication Protocol 
+        "RFC 8685: Path Computation Element Communication Protocol 
         (PCEP) Extensions for the Hierarchical Path Computation 
         Element (H-PCE) Architecture.";
     }
@@ -2655,7 +2764,7 @@ module ietf-te-types {
         "Objective function for minimizing the number of shared 
         Shared Risk Link Groups (SRLG) (MSS).";
       reference
-        "RFC8685: Path Computation Element Communication Protocol 
+        "RFC 8685: Path Computation Element Communication Protocol 
         (PCEP) Extensions for the Hierarchical Path Computation 
         Element (H-PCE) Architecture.";
     }
@@ -2666,7 +2775,7 @@ module ietf-te-types {
         "Objective function for minimizing the number of shared 
         nodes (MSN).";
       reference
-        "RFC8685: Path Computation Element Communication Protocol 
+        "RFC 8685: Path Computation Element Communication Protocol 
         (PCEP) Extensions for the Hierarchical Path Computation 
         Element (H-PCE) Architecture.";
     }
@@ -2679,34 +2788,34 @@ module ietf-te-types {
     description
       "Base identity for SVEC metric type.";
     reference
-      "RFC5541: Encoding of Objective Functions in the Path
+      "RFC 5541: Encoding of Objective Functions in the Path
        Computation Element Communication Protocol (PCEP).";
   }
 
-    identity svec-metric-cumul-te {
+    identity svec-metric-cumulative-te {
       base svec-metric-type;
       description
         "Cumulative TE cost.";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
+        "RFC 5541: Encoding of Objective Functions in the Path
         Computation Element Communication Protocol (PCEP).";
     }
 
-    identity svec-metric-cumul-igp {
+    identity svec-metric-cumulative-igp {
       base svec-metric-type;
       description
         "Cumulative IGP cost.";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
+        "RFC 5541: Encoding of Objective Functions in the Path
         Computation Element Communication Protocol (PCEP).";
     }
 
-    identity svec-metric-cumul-hop {
+    identity svec-metric-cumulative-hop {
       base svec-metric-type;
       description
         "Cumulative Hop path metric.";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
+        "RFC 5541: Encoding of Objective Functions in the Path
         Computation Element Communication Protocol (PCEP).";
     }
 
@@ -2715,7 +2824,7 @@ module ietf-te-types {
       description
         "Aggregate bandwidth consumption.";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
+        "RFC 5541: Encoding of Objective Functions in the Path
         Computation Element Communication Protocol (PCEP).";
     }
 
@@ -2724,7 +2833,7 @@ module ietf-te-types {
       description
         "Load of the most loaded link.";
       reference
-        "RFC5541: Encoding of Objective Functions in the Path
+        "RFC 5541: Encoding of Objective Functions in the Path
         Computation Element Communication Protocol (PCEP).";
     }
 
@@ -2838,11 +2947,13 @@ module ietf-te-types {
        grouping are applicable to generic TE PM as well as packet TE
        PM.";
     reference
-      "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensions
-       RFC 7823: Performance-Based Path Selection for Explicitly
-       Routed Label Switched Paths (LSPs) Using TE Metric
-       Extensions
-       RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
+      "RFC 7471: OSPF Traffic Engineering (TE) Metric Extensionsù
+      
+      RFC 7823: Performance-Based Path Selection for Explicitly
+      Routed Label Switched Paths (LSPs) Using TE Metric
+      Extensions
+
+      RFC 8570: IS-IS Traffic Engineering (TE) Metric Extensions";
     leaf one-way-delay {
       type uint32 {
         range "0..16777215";
@@ -3778,13 +3889,18 @@ module ietf-te-types {
   grouping generic-path-metric-bounds {
     description
       "TE path metric bounds grouping.";
+    // NOTE: The descriptions for the path-metric-bounds contianer
+    // and the path-metric-bound listhas been updated in this module
+    // revision
+    // RFC Editor: remove the note above and this note
     container path-metric-bounds {
       description
-        "TE path metric bounds container.";
+        "Top-level container for the list of end-to-end TE path
+        metric bounds.";
       list path-metric-bound {
         key "metric-type";
         description
-          "List of TE path metric bounds.";
+          "List of end-to-end TE path metric bounds.";
         leaf metric-type {
           type identityref {
             base path-metric-type;
@@ -3798,6 +3914,41 @@ module ietf-te-types {
           default "0";
           description
             "Upper bound on the end-to-end TE path metric.
+            
+            A zero indicates an unbounded upper limit for the
+            specific 'metric-type'.
+            
+            The unit of is interpreted in the context of the
+            path-metric-type.";
+        }
+      }
+    }
+    // NOTE: The contianer link-metric-bounds has been
+    // added in this module revision
+    // RFC Editor: remove the note above and this note
+    container link-metric-bounds {
+      description
+        "Top-level container for the list of TE link metric bounds.";
+      list path-metric-bound {
+        key "metric-type";
+        description
+          "List of of TE link metric bounds.
+          
+          The TE links whose TE link metric exceeds the upper-bound
+          are not considered as candidate link for the TE path.";
+        leaf metric-type {
+          type identityref {
+            base link-metric-type;
+          }
+          description
+            "Identifies an entry in the list of 'metric-type' items
+             bound for the TE path.";
+        }
+        leaf upper-bound {
+          type uint64;
+          default "0";
+          description
+            "Upper bound on the TE link metric.
             
             A zero indicates an unbounded upper limit for the
             specific 'metric-type'.
@@ -4071,7 +4222,7 @@ module ietf-te-types {
       description
         "LSP encoding type.";
       reference
-        "RFC3945";
+        "RFC 3945";
     }
     leaf switching-type {
       type identityref {
@@ -4080,7 +4231,7 @@ module ietf-te-types {
       description
         "LSP switching type.";
       reference
-        "RFC3945";
+        "RFC 3945";
     }
   }
 

--- a/ietf-te-types.yang
+++ b/ietf-te-types.yang
@@ -94,8 +94,6 @@ module ietf-te-types {
       - base identity link-metric-type and its derived identities;
       - identity path-metric-delay;
       - typedef te-gen-node-id;
-      - ordered-by statement to tiebreaker list in
-        generic-path-optimization grouping;
       - grouping encoding-and-switching-type;
       - grouping te-generic-node-id;.
       
@@ -4002,15 +4000,18 @@ module ietf-te-types {
             uses optimization-metric-entry;
           }
           /* Tiebreakers */
+          // CHANGE NOTE: The tiebreakers container below has been
+          // deprecated in this module revision
+          // RFC Editor: remove the note above and this note
           container tiebreakers {
             description
-              "Container for the list of tiebreakers.";
+              "Container for the list of tiebreakers.
+              
+              This container has been obsoleted by the tiebreaker
+              leaf.";
+            status deprecated;
             list tiebreaker {
               key "tiebreaker-type";
-              // CHANGE NOTE: The ordered-by statement below has been
-              // added in this module revision
-              // RFC Editor: remove the note above and this note
-              ordered-by user;
               description
                 "The list of tiebreaker criteria to apply on an
                  equally favored set of paths, in order to pick
@@ -4043,6 +4044,15 @@ module ietf-te-types {
           }
         }
       }
+    }
+    leaf tiebreaker {
+      type identityref {
+        base path-tiebreaker-type;
+      }
+      default "te-types:path-tiebreaker-random";
+      description
+        "The tiebreaker criteria to apply on an equally favored set
+        of paths, in order to pick the best.";
     }
   }
 

--- a/ietf-te-types.yang
+++ b/ietf-te-types.yang
@@ -90,11 +90,15 @@ module ietf-te-types {
       - base identity svec-objective-function-type and its derived
         identities;
       - base identity svec-metric-type and its derived identities;
-      - grouping encoding-and-switching-type.
+      - typedef te-gen-node-id;
+      - grouping encoding-and-switching-type
+      - grouping te-generic-node-id.
       
       Updated:
       - description of the base identity objective-function-type;
       - description and reference of identity action-exercise;
+      - node and termination points identifiers in grouping
+        explicit-route-hop;
       - typedef te-node-id to support also 16 octects TE identifiers.
       
       Obsoleted:


### PR DESCRIPTION
- Added description of the YANG model changes in [draft-ietf-teas-rfc8776-update-09](https://datatracker.ietf.org/doc/html/draft-ietf-teas-rfc8776-update-09)
- Replaced references to RFC3272 with references to RFC9522: fix #261 
- Updated tiebreaker definition: fix #263 
- Updated optimization metrics: fix #264 
- Clean-up link and path metrics for generic and packet TE types: fix #103 
- Added description of the changes from RFC8776: fix #220 