### PR TITLE
Updated JSON examples

### DIFF
--- a/te-json-examples/basic-tunnel-example.json
+++ b/te-json-examples/basic-tunnel-example.json
@@ -1,0 +1,17 @@
+{
+  "ietf-te:tunnel": [
+    {
+      "name": "Example_LSP_Tunnel_A_2",
+      "admin-state": "ietf-te-types:tunnel-admin-state-up",
+      "encoding": "ietf-te-types:lsp-encoding-packet",
+      "source": {
+        "te-node-id": "192.0.2.1"
+      },
+      "destination": {
+        "te-node-id": "192.0.2.4"
+      },
+      "bidirectional": false,
+      "signaling-type": "ietf-te-types:path-setup-rsvp"
+    }
+  ]
+}

--- a/te-json-examples/individual-path-constraints-tunnel-example.json
+++ b/te-json-examples/individual-path-constraints-tunnel-example.json
@@ -1,0 +1,33 @@
+{
+  "ietf-te:tunnel": [
+    {
+      "name": "Example_LSP_Tunnel_A_4_2",
+      "admin-state": "ietf-te-types:tunnel-admin-state-up",
+      "encoding": "ietf-te-types:lsp-encoding-packet",
+      "source": {
+        "te-node-id": "192.0.2.1"
+      },
+      "destination": {
+        "te-node-id": "192.0.2.4"
+      },
+      "bidirectional": false,
+      "signaling-type": "ietf-te-types:path-setup-rsvp",
+      "primary-paths": {
+        "primary-path": [
+          {
+            "name": "path1",
+            "path-scope": "ietf-te-types:path-scope-end-to-end",
+            "path-metric-bounds": {
+              "path-metric-bound": [
+                {
+                  "metric-type": "ietf-te-types:path-metric-hop",
+                  "upper-bound": "3"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/te-json-examples/ipv6-tunnel-example.json
+++ b/te-json-examples/ipv6-tunnel-example.json
@@ -1,0 +1,17 @@
+{
+  "ietf-te:tunnel": [
+    {
+      "name": "Example_LSP_Tunnel_A_2 (IPv6)",
+      "admin-state": "ietf-te-types:tunnel-admin-state-up",
+      "encoding": "ietf-te-types:lsp-encoding-packet",
+      "source": {
+        "te-node-id": "2001:db8::1"
+      },
+      "destination": {
+        "te-node-id": "2001:db8::4"
+      },
+      "bidirectional": false,
+      "signaling-type": "ietf-te-types:path-setup-rsvp"
+    }
+  ]
+}

--- a/te-json-examples/json/basic-tunnel.json
+++ b/te-json-examples/json/basic-tunnel.json
@@ -1,0 +1,21 @@
+{
+  "ietf-te:te": {
+    "tunnels": {
+      "tunnel": [
+        {
+          "name": "Example_LSP_Tunnel_A_2",
+          "encoding": "ietf-te-types:lsp-encoding-packet",
+          "admin-state": "ietf-te-types:tunnel-admin-state-up",
+          "source": {
+            "te-node-id": "192.0.2.1"
+          },
+          "destination": {
+            "te-node-id": "192.0.2.4"
+          },
+          "bidirectional": false,
+          "signaling-type": "ietf-te-types:path-setup-rsvp"
+        }
+      ]
+    }
+  }
+}

--- a/te-json-examples/json/ipv6-tunnel.json
+++ b/te-json-examples/json/ipv6-tunnel.json
@@ -1,0 +1,21 @@
+{
+  "ietf-te:te": {
+    "tunnels": {
+      "tunnel": [
+        {
+          "name": "Example_LSP_Tunnel_A_2 (IPv6)",
+          "encoding": "ietf-te-types:lsp-encoding-packet",
+          "admin-state": "ietf-te-types:tunnel-admin-state-up",
+          "source": {
+            "te-node-id": "2001:db8::1"
+          },
+          "destination": {
+            "te-node-id": "2001:db8::4"
+          },
+          "bidirectional": false,
+          "signaling-type": "ietf-te-types:path-setup-rsvp"
+        }
+      ]
+    }
+  }
+}

--- a/te-json-examples/json/multi-domain-tunnel.json
+++ b/te-json-examples/json/multi-domain-tunnel.json
@@ -1,0 +1,196 @@
+{
+  "ietf-te:te": {
+    "tunnels": {
+      "tunnel": [
+        {
+          "name": "Example_Head_End_Tunnel_Segment",
+          "encoding": "ietf-te-types:lsp-encoding-packet",
+          "admin-state": "ietf-te-types:tunnel-admin-state-up",
+          "source": {
+            "te-node-id": "192.0.2.100"
+          },
+          "bidirectional": true,
+          "signaling-type": "ietf-te-types:path-setup-rsvp",
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "primary-path-1",
+                "co-routed": true,
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.1"
+                      }
+                    }
+                  ]
+                },
+                "candidate-secondary-paths": {
+                  "candidate-secondary-path": [
+                    {
+                      "secondary-path": "secondary-path-1"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-paths": {
+            "secondary-path": [
+              {
+                "name": "secondary-path-1",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.5"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "Example_Primary_Transit_Tunnel_Segment",
+          "encoding": "ietf-te-types:lsp-encoding-packet",
+          "admin-state": "ietf-te-types:tunnel-admin-state-up",
+          "bidirectional": true,
+          "signaling-type": "ietf-te-types:path-setup-rsvp",
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "primary-path-2",
+                "co-routed": true,
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.2"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.3"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "Example_Tail_End_Tunnel_Segment",
+          "encoding": "ietf-te-types:lsp-encoding-packet",
+          "admin-state": "ietf-te-types:tunnel-admin-state-up",
+          "destination": {
+            "te-node-id": "192.0.2.200"
+          },
+          "bidirectional": true,
+          "signaling-type": "ietf-te-types:path-setup-rsvp",
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "primary-path-3",
+                "co-routed": true,
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.4"
+                      }
+                    }
+                  ]
+                },
+                "candidate-secondary-paths": {
+                  "candidate-secondary-path": [
+                    {
+                      "secondary-path": "secondary-path-3"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-paths": {
+            "secondary-path": [
+              {
+                "name": "secondary-path-3",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.8"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "Example_Secondary_Transit_Tunnel_Segment",
+          "encoding": "ietf-te-types:lsp-encoding-packet",
+          "admin-state": "ietf-te-types:tunnel-admin-state-up",
+          "bidirectional": true,
+          "signaling-type": "ietf-te-types:path-setup-rsvp",
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "primary-path-4",
+                "co-routed": true,
+                "candidate-secondary-paths": {
+                  "candidate-secondary-path": [
+                    {
+                      "secondary-path": "secondary-path-4"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-paths": {
+            "secondary-path": [
+              {
+                "name": "secondary-path-4",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.6"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.7"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/te-json-examples/json/multi-paths-tunnel.json
+++ b/te-json-examples/json/multi-paths-tunnel.json
@@ -1,0 +1,387 @@
+{
+  "ietf-te:te": {
+    "tunnels": {
+      "tunnel": [
+        {
+          "name": "example-1",
+          "description": "Example in slide 1",
+          "source": {
+            "te-node-id": "192.0.2.1"
+          },
+          "destination": {
+            "te-node-id": "192.0.2.5"
+          },
+          "bidirectional": true,
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "primary-1 (fwd)",
+                "co-routed": false,
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage" : "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                },
+                "primary-reverse-path": {
+                  "name": "primary-2 (rev)",
+                  "explicit-route-objects": {
+                    "route-object-include-exclude": [
+                      {
+                        "index": 1,
+                        "explicit-route-usage" : "ietf-te-types:route-include-object",
+                        "numbered-node-hop": {
+                          "node-id": "192.0.2.3",
+                          "hop-type": "loose"
+                        }
+                      }
+                    ]
+                  },
+                  "candidate-secondary-reverse-paths": {
+                    "candidate-secondary-reverse-path": [
+                      {
+                        "secondary-reverse-path": "secondary-3 (rev)"
+                      },
+                      {
+                        "secondary-reverse-path": "secondary-4 (rev)"
+                      },
+                      {
+                        "secondary-reverse-path": "secondary-5 (rev)"
+                      }
+                    ]
+                  }
+                },
+                "candidate-secondary-paths": {
+                  "candidate-secondary-path": [
+                    {
+                      "secondary-path": "secondary-1 (fwd)"
+                    },
+                    {
+                      "secondary-path": "secondary-2 (fwd)"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-paths": {
+            "secondary-path": [
+              {
+                "name": "secondary-1 (fwd)",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage" : "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.1"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "secondary-2 (fwd)",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage" : "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.5",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-reverse-paths": {
+            "secondary-reverse-path": [
+              {
+                "name": "secondary-3 (rev)",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage" : "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.5"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.4",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "secondary-4 (rev)",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage" : "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.4"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.3",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "secondary-5 (rev)",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage" : "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.3"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.1",
+                        "hop-type":"loose"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "example-3",
+          "description": "Example in slide 3",
+          "source": {
+            "te-node-id": "192.0.2.1"
+          },
+          "destination": {
+            "te-node-id": "192.0.2.5"
+          },
+          "bidirectional": true,
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "primary-1 (bidir)",
+                "co-routed": true,
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage" : "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                },
+                "candidate-secondary-paths": {
+                  "candidate-secondary-path": [
+                    {
+                      "secondary-path": "secondary-1 (bidir)"
+                    },
+                    {
+                      "secondary-path": "secondary-2 (bidir)"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-paths": {
+            "secondary-path": [
+              {
+                "name": "secondary-1 (bidir)",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage" : "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.1"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "secondary-2 (bidir)",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage" : "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.5",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "example-4",
+          "description": "Example in slide 4",
+          "source": {
+            "te-node-id": "192.0.2.1"
+          },
+          "destination": {
+            "te-node-id": "192.0.2.5"
+          },
+          "bidirectional": true,
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "primary-1 (fwd)",
+                "co-routed": true,
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage" : "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                },
+                "primary-reverse-path": {
+                  "name": "primary-2 (rev)",
+                  "candidate-secondary-reverse-paths": {
+                    "candidate-secondary-reverse-path": [
+                      {
+                        "secondary-reverse-path": "secondary-3 (rev)"
+                      },
+                      {
+                        "secondary-reverse-path": "secondary-4 (rev)"
+                      }
+                    ]
+                  }
+                },
+                "candidate-secondary-paths": {
+                  "candidate-secondary-path": [
+                    {
+                      "secondary-path": "secondary-1 (fwd)"
+                    },
+                    {
+                      "secondary-path": "secondary-2 (fwd)"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-paths": {
+            "secondary-path": [
+              {
+                "name": "secondary-1 (fwd)",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage" : "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.1"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "secondary-2 (fwd)",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage" : "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.5",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-reverse-paths": {
+            "secondary-reverse-path": [
+              {
+                "name": "secondary-3 (rev)"
+              },
+              {
+                "name": "secondary-4 (rev)"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/te-json-examples/json/named-path-constraints.json
+++ b/te-json-examples/json/named-path-constraints.json
@@ -1,0 +1,47 @@
+{
+	"ietf-te:te": {
+    "globals": {
+      "named-path-constraints": {
+        "named-path-constraint": [
+          {
+            "name": "max-hop-3",
+            "path-metric-bounds": {
+              "path-metric-bound": [
+                {
+                  "metric-type": "ietf-te-types:path-metric-hop",
+                  "upper-bound": "3"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+		"tunnels": {
+			"tunnel": [
+				{
+					"name": "Example_LSP_Tunnel_A_4_1",
+					"encoding": "ietf-te-types:lsp-encoding-packet",
+					"description": "Simple_LSP_with_named_path",
+          "admin-state": "ietf-te-types:tunnel-admin-state-up",
+          "source": {
+            "te-node-id": "192.0.2.1"
+          },
+          "destination": {
+            "te-node-id": "192.0.2.4"
+          },
+          "signaling-type": "ietf-te-types:path-setup-rsvp",
+					"primary-paths": {
+						"primary-path": [
+							{
+								"name": "Simple_LSP_1",
+								"use-path-computation": true,
+								"named-path-constraint": "max-hop-3"
+							}
+						]
+					}
+				}
+			]
+		}
+	}
+}

--- a/te-json-examples/json/path-constraints-tunnel.json
+++ b/te-json-examples/json/path-constraints-tunnel.json
@@ -1,0 +1,36 @@
+{
+  "ietf-te:te": {
+    "tunnels": {
+      "tunnel": [
+        {
+          "name": "Example_LSP_Tunnel_A_4_2",
+          "encoding": "ietf-te-types:lsp-encoding-packet",
+          "admin-state": "ietf-te-types:tunnel-admin-state-up",
+          "source": {
+            "te-node-id": "192.0.2.1"
+          },
+          "destination": {
+            "te-node-id": "192.0.2.4"
+          },
+          "bidirectional": false,
+          "signaling-type": "ietf-te-types:path-setup-rsvp",
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "path1",
+                "path-metric-bounds": {
+                  "path-metric-bound": [
+                    {
+                      "metric-type": "ietf-te-types:path-metric-hop",
+                      "upper-bound": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/te-json-examples/json/prova.json
+++ b/te-json-examples/json/prova.json
@@ -1,0 +1,62 @@
+{
+  "tunnel": [
+    {
+      "name": "Example_LSP_Tunnel_A_2",
+      "admin-state": "ietf-te-types:tunnel-admin-state-up",
+      "encoding": "ietf-te-types:lsp-encoding-packet",
+      "source": {
+        "te-node-id": "192.0.2.1"
+      },
+      "destination": {
+        "te-node-id": "192.0.2.4"
+      },
+      "bidirectional": false,
+      "signaling-type": "ietf-te-types:path-setup-rsvp",
+      "primary-paths": {
+        "primary-path": [
+          {
+            "name": "path1",
+            "path-computation-method": "ietf-te-types:path-locally-computed",
+            "path-scope": "ietf-te-types:path-scope-end-to-end",
+            "computed-paths-properties": {
+              "computed-path-properties": [
+                {
+                  "k-index": 1,
+                  "path-properties": {
+                    "path-route-objects": {
+                      "path-route-object": [
+                        {
+                          "index": 1,
+                          "numbered-node-hop": {
+                            "node-id": "192.0.2.2",
+                            "hop-type": "strict"
+                          }
+                        },
+                        {
+                          "index": 2,
+                          "numbered-node-hop": {
+                            "node-id": "192.0.2.4",
+                            "hop-type": "strict"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            "lsps": {
+              "lsp": [
+                {
+                  "node": "192.0.2.1",
+                  "lsp-id": 25356,
+                  "tunnel-name": "Example_LSP_Tunnel_A_4_1"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/te-json-examples/json/tunnel-state.json
+++ b/te-json-examples/json/tunnel-state.json
@@ -1,0 +1,72 @@
+{
+  "ietf-te:te": {
+    "tunnels": {
+      "tunnel": [
+        {
+          "name": "Example_LSP_Tunnel_A_2",
+          "encoding": "ietf-te-types:lsp-encoding-packet",
+          "admin-state": "ietf-te-types:tunnel-admin-state-up",
+          "source": {
+            "te-node-id": "192.0.2.1"
+          },
+          "destination": {
+            "te-node-id": "192.0.2.4"
+          },
+          "bidirectional": false,
+          "signaling-type": "ietf-te-types:path-setup-rsvp",
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "path1",
+                "path-computation-method": "ietf-te-types:path-locally-computed",
+                "computed-paths-properties": {
+                  "computed-path-properties": [
+                    {
+                      "k-index": 1,
+                      "path-properties": {
+                        "path-route-objects": {
+                          "path-route-object": [
+                            {
+                              "index": 1,
+                              "numbered-node-hop": {
+                                "node-id": "192.0.2.2"
+                              }
+                            },
+                            {
+                              "index": 2,
+                              "numbered-node-hop": {
+                                "node-id": "192.0.2.4"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                "lsps": {
+                  "lsp": [
+                    {
+                      "tunnel-name": "Example_LSP_Tunnel_A_4_1",
+                      "node": "192.0.2.1",
+                      "lsp-id": 25356
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "lsps": {
+      "lsp": [
+        {
+          "tunnel-name": "Example_LSP_Tunnel_A_4_1",
+          "node": "192.0.2.1",
+          "lsp-id": 25356
+        }
+      ]
+    }
+  }
+}

--- a/te-json-examples/multi-domain-tunnel-example.json
+++ b/te-json-examples/multi-domain-tunnel-example.json
@@ -1,0 +1,215 @@
+{
+  "ietf-te:te": {
+    "tunnels": {
+      "tunnel": [
+        {
+          "name": "Example_Head_End_Tunnel_Segment",
+          "admin-state": "ietf-te-types:tunnel-admin-state-up",
+          "encoding": "ietf-te-types:lsp-encoding-packet",
+          "source": {
+            "te-node-id": "192.0.2.100"
+          },
+          "bidirectional": true,
+          "signaling-type": "ietf-te-types:path-setup-rsvp",
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "primary-path-1",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "co-routed": true,
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.1"
+                      }
+                    }
+                  ]
+                },
+                "primary-reverse-path": {
+                  "path-scope": "ietf-te-types:path-scope-end-to-end"
+                },
+                "candidate-secondary-paths": {
+                  "candidate-secondary-path": [
+                    {
+                      "secondary-path": "secondary-path-1"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-paths": {
+            "secondary-path": [
+              {
+                "name": "secondary-path-1",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.5"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "Example_Primary_Transit_Tunnel_Segment",
+          "admin-state": "ietf-te-types:tunnel-admin-state-up",
+          "encoding": "ietf-te-types:lsp-encoding-packet",
+          "bidirectional": true,
+          "signaling-type": "ietf-te-types:path-setup-rsvp",
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "primary-path-2",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "co-routed": true,
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.2"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.3"
+                      }
+                    }
+                  ]
+                },
+                "primary-reverse-path": {
+                  "path-scope": "ietf-te-types:path-scope-end-to-end"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "Example_Secondary_Transit_Tunnel_Segment",
+          "admin-state": "ietf-te-types:tunnel-admin-state-up",
+          "encoding": "ietf-te-types:lsp-encoding-packet",
+          "bidirectional": true,
+          "signaling-type": "ietf-te-types:path-setup-rsvp",
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "primary-path-4",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "co-routed": true,
+                "primary-reverse-path": {
+                  "path-scope": "ietf-te-types:path-scope-end-to-end"
+                },
+                "candidate-secondary-paths": {
+                  "candidate-secondary-path": [
+                    {
+                      "secondary-path": "secondary-path-4"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-paths": {
+            "secondary-path": [
+              {
+                "name": "secondary-path-4",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.6"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.7"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "Example_Tail_End_Tunnel_Segment",
+          "admin-state": "ietf-te-types:tunnel-admin-state-up",
+          "encoding": "ietf-te-types:lsp-encoding-packet",
+          "destination": {
+            "te-node-id": "192.0.2.200"
+          },
+          "bidirectional": true,
+          "signaling-type": "ietf-te-types:path-setup-rsvp",
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "primary-path-3",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "co-routed": true,
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.4"
+                      }
+                    }
+                  ]
+                },
+                "primary-reverse-path": {
+                  "path-scope": "ietf-te-types:path-scope-end-to-end"
+                },
+                "candidate-secondary-paths": {
+                  "candidate-secondary-path": [
+                    {
+                      "secondary-path": "secondary-path-3"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-paths": {
+            "secondary-path": [
+              {
+                "name": "secondary-path-3",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-link-hop": {
+                        "link-tp-id": "192.0.2.8"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/te-json-examples/multi-paths-tunnel-example.json
+++ b/te-json-examples/multi-paths-tunnel-example.json
@@ -1,0 +1,406 @@
+{
+  "ietf-te:te": {
+    "tunnels": {
+      "tunnel": [
+        {
+          "name": "example-1",
+          "description": "Example in slide 1",
+          "source": {
+            "te-node-id": "192.0.2.1"
+          },
+          "destination": {
+            "te-node-id": "192.0.2.5"
+          },
+          "bidirectional": true,
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "primary-1 (fwd)",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "co-routed": false,
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                },
+                "primary-reverse-path": {
+                  "name": "primary-2 (rev)",
+                  "path-scope": "ietf-te-types:path-scope-end-to-end",
+                  "explicit-route-objects": {
+                    "route-object-include-exclude": [
+                      {
+                        "index": 1,
+                        "explicit-route-usage": "ietf-te-types:route-include-object",
+                        "numbered-node-hop": {
+                          "node-id": "192.0.2.3",
+                          "hop-type": "loose"
+                        }
+                      }
+                    ]
+                  },
+                  "candidate-secondary-reverse-paths": {
+                    "candidate-secondary-reverse-path": [
+                      {
+                        "secondary-reverse-path": "secondary-3 (rev)"
+                      },
+                      {
+                        "secondary-reverse-path": "secondary-4 (rev)"
+                      },
+                      {
+                        "secondary-reverse-path": "secondary-5 (rev)"
+                      }
+                    ]
+                  }
+                },
+                "candidate-secondary-paths": {
+                  "candidate-secondary-path": [
+                    {
+                      "secondary-path": "secondary-1 (fwd)"
+                    },
+                    {
+                      "secondary-path": "secondary-2 (fwd)"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-paths": {
+            "secondary-path": [
+              {
+                "name": "secondary-1 (fwd)",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.1"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "secondary-2 (fwd)",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.5",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-reverse-paths": {
+            "secondary-reverse-path": [
+              {
+                "name": "secondary-3 (rev)",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.5"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.4",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "secondary-4 (rev)",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.4"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.3",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "secondary-5 (rev)",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.3"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.1",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "example-3",
+          "description": "Example in slide 3",
+          "source": {
+            "te-node-id": "192.0.2.1"
+          },
+          "destination": {
+            "te-node-id": "192.0.2.5"
+          },
+          "bidirectional": true,
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "primary-1 (bidir)",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "co-routed": true,
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                },
+                "primary-reverse-path": {
+                  "path-scope": "ietf-te-types:path-scope-end-to-end"
+                },
+                "candidate-secondary-paths": {
+                  "candidate-secondary-path": [
+                    {
+                      "secondary-path": "secondary-1 (bidir)"
+                    },
+                    {
+                      "secondary-path": "secondary-2 (bidir)"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-paths": {
+            "secondary-path": [
+              {
+                "name": "secondary-1 (bidir)",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.1"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "secondary-2 (bidir)",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.5",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "example-4",
+          "description": "Example in slide 4",
+          "source": {
+            "te-node-id": "192.0.2.1"
+          },
+          "destination": {
+            "te-node-id": "192.0.2.5"
+          },
+          "bidirectional": true,
+          "primary-paths": {
+            "primary-path": [
+              {
+                "name": "primary-1 (fwd)",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "co-routed": true,
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                },
+                "primary-reverse-path": {
+                  "name": "primary-2 (rev)",
+                  "path-scope": "ietf-te-types:path-scope-end-to-end",
+                  "candidate-secondary-reverse-paths": {
+                    "candidate-secondary-reverse-path": [
+                      {
+                        "secondary-reverse-path": "secondary-3 (rev)"
+                      },
+                      {
+                        "secondary-reverse-path": "secondary-4 (rev)"
+                      }
+                    ]
+                  }
+                },
+                "candidate-secondary-paths": {
+                  "candidate-secondary-path": [
+                    {
+                      "secondary-path": "secondary-1 (fwd)"
+                    },
+                    {
+                      "secondary-path": "secondary-2 (fwd)"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-paths": {
+            "secondary-path": [
+              {
+                "name": "secondary-1 (fwd)",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.1"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "secondary-2 (fwd)",
+                "path-scope": "ietf-te-types:path-scope-end-to-end",
+                "explicit-route-objects": {
+                  "route-object-include-exclude": [
+                    {
+                      "index": 1,
+                      "explicit-route-usage": "ietf-te-types:route-include-object",
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.2"
+                      }
+                    },
+                    {
+                      "index": 2,
+                      "numbered-node-hop": {
+                        "node-id": "192.0.2.5",
+                        "hop-type": "loose"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "secondary-reverse-paths": {
+            "secondary-reverse-path": [
+              {
+                "name": "secondary-3 (rev)",
+                "path-scope": "ietf-te-types:path-scope-end-to-end"
+              },
+              {
+                "name": "secondary-4 (rev)",
+                "path-scope": "ietf-te-types:path-scope-end-to-end"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/te-json-examples/named-path-constraints-global-example.json
+++ b/te-json-examples/named-path-constraints-global-example.json
@@ -1,0 +1,15 @@
+{
+  "ietf-te:named-path-constraint": [
+    {
+      "name": "max-hop-3",
+      "path-metric-bounds": {
+        "path-metric-bound": [
+          {
+            "metric-type": "ietf-te-types:path-metric-hop",
+            "upper-bound": "3"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/te-json-examples/named-path-constraints-tunnel-example.json
+++ b/te-json-examples/named-path-constraints-tunnel-example.json
@@ -1,0 +1,27 @@
+{
+  "ietf-te:tunnel": [
+    {
+      "name": "Example_LSP_Tunnel_A_4_1",
+      "description": "Simple_LSP_with_named_path",
+      "admin-state": "ietf-te-types:tunnel-admin-state-up",
+      "encoding": "ietf-te-types:lsp-encoding-packet",
+      "source": {
+        "te-node-id": "192.0.2.1"
+      },
+      "destination": {
+        "te-node-id": "192.0.2.4"
+      },
+      "signaling-type": "ietf-te-types:path-setup-rsvp",
+      "primary-paths": {
+        "primary-path": [
+          {
+            "name": "Simple_LSP_1",
+            "use-path-computation": true,
+            "path-scope": "ietf-te-types:path-scope-end-to-end",
+            "named-path-constraint": "max-hop-3"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/te-json-examples/tunnel-state-example.json
+++ b/te-json-examples/tunnel-state-example.json
@@ -1,0 +1,45 @@
+{
+  "ietf-te:primary-path": [
+    {
+      "name": "path1",
+      "path-computation-method": "ietf-te-types:path-locally-computed",
+      "path-scope": "ietf-te-types:path-scope-end-to-end",
+      "computed-paths-properties": {
+        "computed-path-properties": [
+          {
+            "k-index": 1,
+            "path-properties": {
+              "path-route-objects": {
+                "path-route-object": [
+                  {
+                    "index": 1,
+                    "numbered-node-hop": {
+                      "node-id": "192.0.2.2",
+                      "hop-type": "strict"
+                    }
+                  },
+                  {
+                    "index": 2,
+                    "numbered-node-hop": {
+                      "node-id": "192.0.2.4",
+                      "hop-type": "strict"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "lsps": {
+        "lsp": [
+          {
+            "node": "192.0.2.1",
+            "lsp-id": 25356,
+            "tunnel-name": "Example_LSP_Tunnel_A_4_1"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Updated and compiled the JSON examples in the draft
Added a new JSON example for a tunnel segment with no primary path

Note: it seems that yanglint can only validate JSON representing data stores and not input/output to RESTCONF operations. The JSON data stores validate with yanglint are provided in the te-json-examples/json folder while the JSON examples to be included into the draft are extracted through an automatic tool from the validate JSON datastore and provided into the te-json-examples

